### PR TITLE
修正換季時雇用員工條件錯誤。

### DIFF
--- a/server/intervalCheck.js
+++ b/server/intervalCheck.js
@@ -442,7 +442,7 @@ function generateNewSeason() {
     {
       resigned: false,
       registerAt: {
-        $lt: endDate.getTime() - config.seasonTime
+        $lt: new Date(endDate.getTime() - config.seasonTime)
       }
     },
     {


### PR DESCRIPTION
@mrbigmouth 
對不起我當時沒有進到這個修正orz
又要再麻煩您把registerAt早於2017/11/5 10:00:00且resigned=false的資料改為employed=true