### PR TITLE
修正聖晶石的圖片路徑。

### DIFF
--- a/client/layout/nav.html
+++ b/client/layout/nav.html
@@ -20,7 +20,7 @@
             {{currentUser.profile.vote}}
           </li>
           <li title="現有聖晶石：{{currentUser.profile.stone}}顆">
-            <img class="float-left" style="margin-top: 5px; width: 1rem; height: 1rem;" src="stone.jpeg" title="聖晶石" />
+            <img class="float-left" style="margin-top: 5px; width: 1rem; height: 1rem;" src="/stone.jpeg" title="聖晶石" />
             {{currentUser.profile.stone}}
           </li>
           <a class="d-block" href="#" title="登出" data-action="logout">


### PR DESCRIPTION
原本聖晶石的圖片路徑是相對路徑，在非 root 的頁面顯示會不正常，因此改為絕對路徑