### PR TITLE
修改分頁條顯示條件與總數量的發佈 bug

### DIFF
--- a/client/utils/pagination.html
+++ b/client/utils/pagination.html
@@ -36,7 +36,7 @@
         <div class="form-group">
           <div class="input-group input-group-sm">
             <span class="input-group-addon">跳至頁數</span>
-            <input type="number" name="page" min="1" max="{{totalPages}}" value="{{currentPage}}" />
+            <input class="form-control" type="number" name="page" min="1" max="{{totalPages}}" value="{{currentPage}}" />
             <span class="input-group-btn">
               <button class="btn btn-primary">走！</button>
             </span>

--- a/client/utils/pagination.js
+++ b/client/utils/pagination.js
@@ -8,9 +8,8 @@ import { dbVariables } from '../../db/dbVariables';
 Template.pagination.helpers({
   haveData() {
     const totalCount = dbVariables.get(this.useVariableForTotalCount);
-    const totalPages = Math.ceil(totalCount / this.dataNumberPerPage);
 
-    return totalPages > 0;
+    return totalCount > 0;
   },
   pages() {
     const totalCount = dbVariables.get(this.useVariableForTotalCount);

--- a/client/utils/pagination.js
+++ b/client/utils/pagination.js
@@ -8,8 +8,9 @@ import { dbVariables } from '../../db/dbVariables';
 Template.pagination.helpers({
   haveData() {
     const totalCount = dbVariables.get(this.useVariableForTotalCount);
+    const totalPages = Math.ceil(totalCount / this.dataNumberPerPage);
 
-    return totalCount > this.dataNumberPerPage;
+    return totalPages > 0;
   },
   pages() {
     const totalCount = dbVariables.get(this.useVariableForTotalCount);
@@ -38,8 +39,9 @@ Template.pagination.helpers({
   },
   totalPages() {
     const totalCount = dbVariables.get(this.useVariableForTotalCount);
+    const totalPages = Math.ceil(totalCount / this.dataNumberPerPage);
 
-    return Math.ceil(totalCount / this.dataNumberPerPage);
+    return totalPages;
   },
   pageItemClass(page) {
     const offset = this.offset.get();

--- a/server/methods/accuse.js
+++ b/server/methods/accuse.js
@@ -13,6 +13,7 @@ import { dbSeason } from '../../db/dbSeason';
 import { banTypeList } from '../../db/users';
 import { limitSubscription } from './rateLimit';
 import { debug } from '../debug';
+import { publishTotalCount } from './utils';
 
 Meteor.methods({
   accuseSomething(message) {
@@ -532,58 +533,33 @@ Meteor.publish('accuseRecord', function(offset) {
   debug.log('publish accuseRecord', offset);
   check(offset, Match.Integer);
 
-  let initialized = false;
-  let total = dbLog
-    .find({
-      logType: {
-        $in: accuseLogTypeList
-      }
-    })
-    .count();
-  this.added('variables', 'totalCountOfAccuseRecord', {
-    value: total
-  });
+  const filter = {
+    logType: { $in: accuseLogTypeList }
+  };
 
-  const observer = dbLog
-    .find(
-      {
-        logType: {
-          $in: accuseLogTypeList
-        }
+  const totalCountObserver = publishTotalCount('totalCountOfAccuseRecord', dbLog.find(filter), this);
+
+  const pageObserver = dbLog
+    .find(filter, {
+      sort: {
+        createdAt: -1
       },
-      {
-        sort: {
-          createdAt: -1
-        },
-        skip: offset,
-        limit: 30,
-        disableOplog: true
-      }
-    )
+      skip: offset,
+      limit: 30,
+      disableOplog: true
+    })
     .observeChanges({
       added: (id, fields) => {
         this.added('log', id, fields);
-        if (initialized) {
-          total += 1;
-          this.changed('variables', 'totalCountOfAccuseRecord', {
-            value: total
-          });
-        }
       },
       removed: (id) => {
         this.removed('log', id);
-        if (initialized) {
-          total -= 1;
-          this.changed('variables', 'totalCountOfAccuseRecord', {
-            value: total
-          });
-        }
       }
     });
-  initialized = true;
   this.ready();
   this.onStop(() => {
-    observer.stop();
+    totalCountObserver.stop();
+    pageObserver.stop();
   });
 });
 //一分鐘最多重複訂閱10次

--- a/server/methods/order.js
+++ b/server/methods/order.js
@@ -11,6 +11,7 @@ import { dbVariables } from '../../db/dbVariables';
 import { limitMethod, limitSubscription } from './rateLimit';
 import { createOrder } from '../transaction';
 import { debug } from '../debug';
+import { publishTotalCount } from './utils';
 
 Meteor.methods({
   createBuyOrder(orderData) {
@@ -370,17 +371,12 @@ Meteor.publish('companyOrderExcludeMe', function(companyId, type, offset) {
   }
 
   const variableId = 'totalCountOfCompanyOrder' + type;
-  let initialized = false;
-  let total = dbOrders.find(filter).count();
-  this.added('variables', variableId, {
-    value: total
-  });
 
-  const observer = dbOrders
+  const totalCountObserver = publishTotalCount(variableId, dbOrders.find(filter), this);
+
+  const pageObserver = dbOrders
     .find(filter, {
-      sort: {
-        unitPrice: type === '賣出' ? 1 : -1
-      },
+      sort: { unitPrice: type === '賣出' ? 1 : -1 },
       skip: offset,
       limit: 10,
       disableOplog: true
@@ -388,30 +384,19 @@ Meteor.publish('companyOrderExcludeMe', function(companyId, type, offset) {
     .observeChanges({
       added: (id, fields) => {
         this.added('orders', id, fields);
-        if (initialized) {
-          total += 1;
-          this.changed('variables', variableId, {
-            value: total
-          });
-        }
       },
       changed: (id, fields) => {
         this.changed('orders', id, fields);
       },
       removed: (id) => {
         this.removed('orders', id);
-        if (initialized) {
-          total -= 1;
-          this.changed('variables', variableId, {
-            value: total
-          });
-        }
       }
     });
-  initialized = true;
+
   this.ready();
   this.onStop(() => {
-    observer.stop();
+    totalCountObserver.stop();
+    pageObserver.stop();
   });
 });
 //一分鐘最多20次

--- a/server/methods/product.js
+++ b/server/methods/product.js
@@ -323,7 +323,7 @@ Meteor.publish('productListByCompany', function({companyId, sortBy, sortDir, off
       },
       sort: { [sortBy]: sortDir },
       skip: offset,
-      limit: 10,
+      limit: 30,
       disableOplog: true
     })
     .observeChanges({

--- a/server/methods/product.js
+++ b/server/methods/product.js
@@ -11,6 +11,7 @@ import { dbLog } from '../../db/dbLog';
 import { dbVoteRecord } from '../../db/dbVoteRecord';
 import { limitMethod, limitSubscription } from './rateLimit';
 import { debug } from '../debug';
+import { publishTotalCount } from './utils';
 
 Meteor.methods({
   createProduct(productData) {
@@ -257,67 +258,42 @@ Meteor.publish('productListBySeasonId', function({seasonId, sortBy, sortDir, off
   check(sortDir, new Match.OneOf(1, -1));
   check(offset, Match.Integer);
 
-  let initialized = false;
-  let total = dbProducts
-    .find({
-      seasonId: seasonId,
-      overdue: {
-        $gt: 0
-      }
-    })
-    .count();
-  this.added('variables', 'totalCountOfProductList', {
-    value: total
-  });
+  const filter = {
+    seasonId: seasonId,
+    overdue: {
+      $gt: 0
+    }
+  };
 
-  const observer = dbProducts
-    .find(
-      {
-        seasonId: seasonId,
-        overdue: {
-          $gt: 0
-        }
+  const totalCountObserver = publishTotalCount('totalCountOfProductList', dbProducts.find(filter), this);
+
+  const pageObserver = dbProducts
+    .find(filter, {
+      fields: {
+        productName: 0,
+        url: 0
       },
-      {
-        fields: {
-          productName: 0,
-          url: 0
-        },
-        sort: {
-          [sortBy]: sortDir
-        },
-        skip: offset,
-        limit: 30,
-        disableOplog: true
-      }
-    )
+      sort: { [sortBy]: sortDir },
+      skip: offset,
+      limit: 30,
+      disableOplog: true
+    })
     .observeChanges({
       added: (id, fields) => {
         this.added('products', id, fields);
-        if (initialized) {
-          total += 1;
-          this.changed('variables', 'totalCountOfProductList', {
-            value: total
-          });
-        }
       },
       changed: (id, fields) => {
         this.changed('products', id, fields);
       },
       removed: (id) => {
         this.removed('products', id);
-        if (initialized) {
-          total -= 1;
-          this.changed('variables', 'totalCountOfProductList', {
-            value: total
-          });
-        }
       }
     });
-  initialized = true;
+
   this.ready();
   this.onStop(() => {
-    observer.stop();
+    totalCountObserver.stop();
+    pageObserver.stop();
   });
 });
 //一分鐘最多重複訂閱10次
@@ -330,67 +306,42 @@ Meteor.publish('productListByCompany', function({companyId, sortBy, sortDir, off
   check(sortDir, new Match.OneOf(1, -1));
   check(offset, Match.Integer);
 
-  let initialized = false;
-  let total = dbProducts
-    .find({
-      companyId: companyId,
-      overdue: {
-        $gt: 0
-      }
-    })
-    .count();
-  this.added('variables', 'totalCountOfProductList', {
-    value: total
-  });
+  const filter = {
+    companyId: companyId,
+    overdue: {
+      $gt: 0
+    }
+  };
 
-  const observer = dbProducts
-    .find(
-      {
-        companyId: companyId,
-        overdue: {
-          $gt: 0
-        }
+  const totalCountObserver = publishTotalCount('totalCountOfProductList', dbProducts.find(filter), this);
+
+  const pageObserver = dbProducts
+    .find(filter, {
+      fields: {
+        productName: 0,
+        url: 0
       },
-      {
-        fields: {
-          productName: 0,
-          url: 0
-        },
-        sort: {
-          [sortBy]: sortDir
-        },
-        skip: offset,
-        limit: 10,
-        disableOplog: true
-      }
-    )
+      sort: { [sortBy]: sortDir },
+      skip: offset,
+      limit: 10,
+      disableOplog: true
+    })
     .observeChanges({
       added: (id, fields) => {
         this.added('products', id, fields);
-        if (initialized) {
-          total += 1;
-          this.changed('variables', 'totalCountOfProductList', {
-            value: total
-          });
-        }
       },
       changed: (id, fields) => {
         this.changed('products', id, fields);
       },
       removed: (id) => {
         this.removed('products', id);
-        if (initialized) {
-          total -= 1;
-          this.changed('variables', 'totalCountOfProductList', {
-            value: total
-          });
-        }
       }
     });
-  initialized = true;
+
   this.ready();
   this.onStop(() => {
-    observer.stop();
+    totalCountObserver.stop();
+    pageObserver.stop();
   });
 });
 //一分鐘最多20次

--- a/server/methods/utils.js
+++ b/server/methods/utils.js
@@ -1,0 +1,23 @@
+export function publishTotalCount(variableId, cursor, publish) {
+  let initialized = false;
+  let totalCount = cursor.count();
+  publish.added('variables', variableId, { value: totalCount });
+
+  const observer = cursor.observeChanges({
+    added: () => {
+      if (initialized) {
+        totalCount += 1;
+        publish.changed('variables', variableId, { value: totalCount });
+      }
+    },
+    removed: () => {
+      if (initialized) {
+        totalCount -= 1;
+        publish.changed('variables', variableId, { value: totalCount });
+      }
+    }
+  });
+  initialized = true;
+
+  return observer;
+}


### PR DESCRIPTION
試圖解決以下問題：

1. 訂單總量有兩頁，分頁條顯示有兩頁，使用者目前在第一頁
2. 有人撤單使訂單總量下降到不滿一頁，此時分頁條未即時更新，仍然顯示有兩頁
3. 使用者按下分頁條連結進入第二頁
4. 此時分頁條更新，因總量不滿一頁，分頁條會消失不見，因此使用者無法回到第一頁

以下是針對問題進行的更動：

- 分頁條顯示的條件由原來的「超過一頁才顯示」改成「有資料就顯示」
  現在只有完全沒資料才會隱藏分頁條，避免有人跳到空頁面之後回不來
- 原本的 ``variables.totalCountOf*`` 在訂閱後會有無法反映全部數量的問題，導致分頁條的總頁數無法即時更新
  現在把總量與分頁內容以兩個 cursor 來 observeChanges 分別處理

其他顯示上的更動：
- 補上跳頁表單 input 欄位的 css class
- 公司產品中心的發佈每頁限制 server 端是 10 個，但 client 端是 30 個，以 client 端的 30 為準修改