### PR TITLE
補充分紅計算中對於董事持股數量的描述

### DIFF
--- a/client/layout/tutorial.html
+++ b/client/layout/tutorial.html
@@ -124,8 +124,8 @@
               <li>除此之外，公司的經理人隨時可以辭職不幹。</li>
               <li>一週為一個商業季度。每個商業季度結束時，上個商業季度推出的產品將會進入投票榜，所有通過驗證的使用者將會得到與當季公司數量成正比的推薦票張數，可以向自己喜愛公司的產品投票推薦，每張推薦票都可以令產品公司獲得<span class="text-info">$3000</span>的營利額。</li>
               <li>經理人可以在商業季度結束前<span class="text-info">72</span>小時調整下個商業季度的員工薪資，調整範圍為<span class="text-info">$500~$2000</span>，以及在商業季度結束前<span class="text-info">24</span>小時調整本商業季度的員工分紅，調整範圍為總盈利額的<span class="text-info">1%~5%</span>。</li>
-              <li>商業季度結束後，公司的收益金額將分出<span class="text-info">百分之五</span>作為經理人的薪水、<span class="text-info">百分之十五</span>作為營運成本，剩餘的收益金額扣除員工分紅後依照持股比例由董事會成員均分。</li>
-              <li>商業季度中<span class="text-danger">未曾上線</span>、<span class="text-danger">被禁止交易權限</span>的使用者將<span class="text-danger">無法</span>得到公司的季度分紅。</li>
+              <li>商業季度結束後，公司的收益金額將分出<span class="text-info">5%</span>作為經理人的薪水、<span class="text-info">15%</span>作為營運成本、<span class="text-info">1%~5%</span>作為員工分紅。剩餘的收益金額作為董事會分紅，依照董事會成員個人之持股數量對所有董事的總持股數量之比例來分配。</li>
+              <li>商業季度中<span class="text-danger">未曾上線</span>、<span class="text-danger">被禁止交易權限</span>的使用者將<span class="text-danger">無法</span>得到公司的季度分紅；計算董事會分紅時，持數數量也將以<span class="text-danger">0%</span>計算。</li>
               <li>商業季度中，若是未登入天數達到<span class="text-danger">四天</span>，則在計算董事會分紅時，該董事的持股數量將以<span class="text-danger">50%</span>計算，因此會拿到與比原本少的董事會分紅。</li>
               <li>商業季度中，若是未登入天數達到<span class="text-danger">五天以上</span>，則在計算董事會分紅時，該董事的持股數量將以<span class="text-danger">0%</span>計算，也就是說，拿不到董事會分紅！</li>
               <li>除了產品收益，別忘了還有三種釋股機制也會為公司產生營利額。</li>


### PR DESCRIPTION
董事會分紅計算原本描述是依照持股比例均分，然而在遇到殭屍或是當季未上線到一定程度時，並不能只看對公司總釋股數的比例
因此強調董事會分紅計算為以「個人之持股數量對所有董事的總持股數量之比例」分配
並補充在當季未上線時，個人持股會以 0% 計算