### PR TITLE
增加開發時用的 users 與 companies 資料產生機制

### DIFF
--- a/dev-utils/.eslintrc
+++ b/dev-utils/.eslintrc
@@ -1,0 +1,9 @@
+{
+  "env": {
+    "es6": true,
+    "node": true
+  },
+  "rules": {
+     "no-console": "off"
+  }
+}

--- a/dev-utils/createSeedData.js
+++ b/dev-utils/createSeedData.js
@@ -1,0 +1,50 @@
+import { Meteor } from 'meteor/meteor';
+import { Accounts } from 'meteor/accounts-base';
+import { resetDatabase } from 'meteor/xolvio:cleaner';
+
+import { pttUserFactory, companyFactory } from './factories';
+import { dbCompanies } from '/db/dbCompanies';
+import { dbCompanyArchive } from '/db/dbCompanyArchive';
+
+if (Meteor.isServer && Meteor.isDevelopment) {
+  module.exports.createSeedData = function({ reset } = {}) {
+    console.log('createSeedData');
+
+    if (reset) {
+      console.log('reset database...');
+      resetDatabase();
+    }
+
+    console.log('create users...');
+    pttUserFactory.buildList(100).forEach((u) => {
+      Accounts.createUser(u);
+    });
+
+    console.log('make user1 be admin...');
+    Meteor.users.update({ username: 'user1' }, { $set: { 'profile.isAdmin': true } });
+
+    console.log('create companies...');
+    companyFactory.buildList(100).forEach((c) => {
+      dbCompanies.insert(c);
+    });
+
+    console.log('add companies to archive...');
+    const companyArchiveBulk = dbCompanyArchive.rawCollection().initializeUnorderedBulkOp();
+    dbCompanies
+      .find({ isSeal: false })
+      .forEach((companyData) => {
+        companyArchiveBulk.insert({
+          _id: companyData._id,
+          status: 'market',
+          name: companyData.companyName,
+          tags: companyData.tags,
+          pictureSmall: companyData.pictureSmall,
+          pictureBig: companyData.pictureSmall,
+          description: companyData.description
+        });
+      });
+    companyArchiveBulk.execute();
+
+    console.log('done');
+  };
+}

--- a/dev-utils/factories.js
+++ b/dev-utils/factories.js
@@ -1,0 +1,93 @@
+import { Factory } from 'rosie';
+import faker from 'faker';
+
+import { productTypeList } from '/db/dbProducts';
+
+export const pttUserFactory = new Factory()
+  .sequence('username', (n) => {
+    return `user${n}`;
+  })
+  .attr('password', ['username'], (username) => {
+    return username;
+  })
+  .attr('profile', ['username'], (username) => {
+    return {
+      validateType: 'PTT',
+      name: username
+    };
+  });
+
+export const companyFactory = new Factory()
+  .attrs({
+    companyName() {
+      return faker.company.companyName();
+    },
+    manager: '!none',
+    chairman: '!none',
+    description() {
+      return faker.lorem.paragraph();
+    },
+    tags() {
+      return faker.lorem.words(10).split(' ');
+    },
+    totalRelease: 1000,
+    lastPrice: 128,
+    listPrice: 128,
+    profit: 0,
+    candidateList: [],
+    voteList: [],
+    createdAt() {
+      return new Date();
+    }
+  })
+  .attr('totalValue', ['totalRelease', 'listPrice'], (totalRelease, listPrice) => {
+    return totalRelease * listPrice;
+  });
+
+export const foundationFactory = new Factory()
+  .attrs({
+    companyName() {
+      return faker.company.companyName();
+    },
+    manager: '!none',
+    description() {
+      return faker.lorem.paragraph();
+    },
+    tags() {
+      return faker.lorem.words(10).split(' ');
+    },
+    createdAt() {
+      return new Date();
+    }
+  });
+
+export const productFactory = new Factory()
+  .attrs({
+    productName() {
+      return faker.lorem.sentence();
+    },
+    type() {
+      return faker.random.arrayElement(productTypeList);
+    },
+    url() {
+      return faker.internet.url();
+    },
+    createdAt() {
+      return new Date();
+    }
+  });
+
+export const taxFactory = new Factory()
+  .attrs({
+    tax() {
+      return faker.random.number({ min: 1 });
+    },
+    zombie() {
+      return faker.random.number({ min: 1 });
+    },
+    fine: 0,
+    paid: 0,
+    expireDate() {
+      return faker.date.future(0.1);
+    }
+  });

--- a/package.json
+++ b/package.json
@@ -31,9 +31,11 @@
     "babel-runtime": "6.26.0",
     "bcrypt": "^1.0.3",
     "cheerio": "1.0.0-rc.2",
+    "faker": "^4.1.0",
     "image-type": "3.0.0",
     "meteor-node-stubs": "0.2.11",
     "opencollective": "^1.0.3",
+    "rosie": "^1.6.0",
     "simpl-schema": "0.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
在開發時會需要建立一些初始資料來幫助測試
若是直接進入 mongo 的 shell 操作，會有點繁複，尤其是當需要將整個資料庫清空重建的時候

``createSeedData`` 可以清空目前資料庫，再依照裡面寫的方式塞進資料
在開發模式進入 ``meteor shell`` 後 import 進來，即可使用 ``createSeedData({ reset: true})`` 來將原來的資料庫清空並建立新的資料

目前只有建立 100 個 users 與 100 個 companies，並指定 user1 為 admin
日後可以依需求再擴增
