### PR TITLE
移除 dev-utils/createSeedData 對 xolvio:cleaner 的引用

### DIFF
--- a/client/companyArchive/companyArchiveDetail.js
+++ b/client/companyArchive/companyArchiveDetail.js
@@ -53,7 +53,7 @@ Template.companyArchiveDetail.helpers({
   }
 });
 Template.companyArchiveDetail.events({
-  'click [data-action="invest"]'(event, templaceInstance) {
+  'click [data-action="invest"]'(event) {
     event.preventDefault();
     investArchiveCompany(this);
   },

--- a/dev-utils/createSeedData.js
+++ b/dev-utils/createSeedData.js
@@ -1,10 +1,52 @@
 import { Meteor } from 'meteor/meteor';
 import { Accounts } from 'meteor/accounts-base';
-import { resetDatabase } from 'meteor/xolvio:cleaner';
 
 import { pttUserFactory, companyFactory } from './factories';
+import { dbAdvertising } from '/db/dbAdvertising';
 import { dbCompanies } from '/db/dbCompanies';
 import { dbCompanyArchive } from '/db/dbCompanyArchive';
+import { dbDirectors } from '/db/dbDirectors';
+import { dbFoundations } from '/db/dbFoundations';
+import { dbLog } from '/db/dbLog';
+import { dbOrders } from '/db/dbOrders';
+import { dbPrice } from '/db/dbPrice';
+import { dbProducts } from '/db/dbProducts';
+import { dbProductLike } from '/db/dbProductLike';
+import { dbRankCompanyPrice } from '/db/dbRankCompanyPrice';
+import { dbRankCompanyProfit } from '/db/dbRankCompanyProfit';
+import { dbRankCompanyValue } from '/db/dbRankCompanyValue';
+import { dbRankUserWealth } from '/db/dbRankUserWealth';
+import { dbRound } from '/db/dbRound';
+import { dbRuleAgendas } from '/db/dbRuleAgendas';
+import { dbSeason } from '/db/dbSeason';
+import { dbTaxes } from '/db/dbTaxes';
+import { dbUserArchive } from '/db/dbUserArchive';
+import { dbValidatingUsers } from '/db/dbValidatingUsers';
+import { dbVoteRecord } from '/db/dbVoteRecord';
+
+function resetDatabase() {
+  dbAdvertising.remove({});
+  dbCompanies.remove({});
+  dbCompanyArchive.remove({});
+  dbDirectors.remove({});
+  dbFoundations.remove({});
+  dbLog.remove({});
+  dbOrders.remove({});
+  dbPrice.remove({});
+  dbProducts.remove({});
+  dbProductLike.remove({});
+  dbRankCompanyPrice.remove({});
+  dbRankCompanyProfit.remove({});
+  dbRankCompanyValue.remove({});
+  dbRankUserWealth.remove({});
+  dbRound.remove({});
+  dbRuleAgendas.remove({});
+  dbSeason.remove({});
+  dbTaxes.remove({});
+  dbUserArchive.remove({});
+  dbValidatingUsers.remove({});
+  dbVoteRecord.remove({});
+}
 
 if (Meteor.isServer && Meteor.isDevelopment) {
   module.exports.createSeedData = function({ reset } = {}) {


### PR DESCRIPTION
在 ``meteor build`` 時 xolvio:cleaner 這個 package 會找不到，估計可能是 dev-only 的 package
目前以手動清除所有 collections 的方式代替 xolvio:cleaner 的 resetDatabase