### PR TITLE
修正 cancelAllOrder 在無買賣單或只有系統買賣單時會出錯的問題

### DIFF
--- a/server/intervalCheck.js
+++ b/server/intervalCheck.js
@@ -498,8 +498,15 @@ function cancelAllOrder() {
         companiesBulk.execute = Meteor.wrapAsync(companiesBulk.execute);
         companiesBulk.execute();
       }
-      directorsBulk.execute = Meteor.wrapAsync(directorsBulk.execute);
-      directorsBulk.execute();
+
+      const nonSystemIncreaseStocksDirectorList = Object.keys(increaseStocksHash).filter((k) => {
+        return k !== '!system';
+      });
+
+      if (nonSystemIncreaseStocksDirectorList.length > 0) {
+        directorsBulk.execute = Meteor.wrapAsync(directorsBulk.execute);
+        directorsBulk.execute();
+      }
     }
     logBulk.execute = Meteor.wrapAsync(logBulk.execute);
     logBulk.execute();


### PR DESCRIPTION
在換季時，若是場上完全無任何買賣單，或是只有 ``!system`` 的買賣單，將會導致 ``directorsBulk`` 為空
需要針對上述狀況判斷，以避免 ``execute()`` 丟出 error