### PR TITLE
增加產品描述欄位 & 產品介面修正、調整

### DIFF
--- a/client/company/companyDetail.html
+++ b/client/company/companyDetail.html
@@ -20,7 +20,7 @@
             {{> companyLogList}}
           </div>
         </div>
-      {{else}}       
+      {{else}}
         <div class="card-block">
           <h1 class="card-title text-truncate">
             {{this.companyName}}
@@ -395,9 +395,10 @@
       <div class="col-3 text-center">投票</div>
     </div>
     {{#each product in productList}}
-      <div class="row mb-1">
-        <div class="col-9 text-truncate">
-          {{>productLink product._id}}
+      <div class="row mb-1 align-items-center">
+        <div class="col-9">
+          <div class="text-truncate">{{>productLink product._id}}</div>
+          <div class="small text-truncate" title="{{product.description}}">{{product.description}}</div>
         </div>
         <div class="col-3 text-center">
           <button class="btn btn-primary btn-sm" type="button" data-vote-product="{{product._id}}">
@@ -424,9 +425,10 @@
       <div class="col-3 text-center">投票</div>
     </div>
     {{#each product in productList}}
-      <div class="row mb-1">
-        <div class="col-9 text-truncate">
-          {{>productLink product._id}}
+      <div class="row mb-1 align-items-center">
+        <div class="col-9">
+          <div class="text-truncate">{{>productLink product._id}}</div>
+          <div class="small text-truncate">{{product.description}}</div>
         </div>
         <div class="col-3 text-center">
           <button class="btn btn-primary btn-sm" type="button" data-like-product="{{product._id}}">

--- a/client/company/editCompany.html
+++ b/client/company/editCompany.html
@@ -137,10 +137,10 @@
       {{/with}}
       <hr />
     {{/if}}
-    <table class="table-bordered" style="width: 100%; table-layout: fixed;">
+    <table class="table table-sm table-bordered">
       <thead>
         <tr>
-          <th class="text-center text-truncate" title="產品名稱">產品名稱</th>
+          <th class="text-center text-truncate" title="產品">產品</th>
           <th class="text-center text-truncate" style="max-width: 60px;" title="類別">類別</th>
           <th class="text-center text-truncate" style="max-width: 60px;" title="刪除">刪除</th>
         </tr>
@@ -148,15 +148,20 @@
       <tbody>
         {{#each product in productList}}
           <tr>
-            <td class="text-left text-truncate px-2">
-              <a href="{{product.url}}" title="{{product.productName}}" target="_blank">
-                {{product.productName}}
-              </a>
+            <td class="text-left px-2">
+              <div>
+                <a href="{{product.url}}" title="{{product.productName}}" target="_blank">
+                  {{product.productName}}
+                </a>
+              </div>
+              <div class="small">
+                {{product.description}}
+              </div>
             </td>
-            <td class="text-center text-truncate">
+            <td class="text-center text-truncate align-middle">
               {{product.type}}
             </td>
-            <td class="text-center text-truncate px-2">
+            <td class="text-center text-truncate px-2 align-middle">
               <button class="btn btn-danger btn-sm" type="button" data-retrieve="{{product._id}}">
                 <i class="fa fa-trash" aria-hidden="true"></i>
                 刪除
@@ -201,6 +206,17 @@
         placeholder="http://"
       />
       {{{errorHtmlOf 'url'}}}
+    </div>
+    <div class="form-group">
+      <label for="url">產品描述：</label>
+      <input
+        class="form-control"
+        type="text"
+        name="description"
+        value="{{valueOf 'description'}}"
+        placeholder="請輸入產品描述"
+      />
+      {{{errorHtmlOf 'description'}}}
     </div>
     <div class="text-right">
       <button class="btn btn-primary" type="submit">送出</button>

--- a/client/company/editCompany.js
+++ b/client/company/editCompany.js
@@ -215,13 +215,16 @@ Template.companyProductEditForm.events({
 function validateProductModel(model) {
   const error = {};
   if (model.productName.length < 4) {
-    error.productName = '產品名稱字數過短！';
+    error.productName = '產品名稱字數過短，至少需要 4 個字！';
   }
   else if (model.productName.length > 255) {
-    error.productName = '產品名稱字數過長！';
+    error.productName = '產品名稱字數過長，最多不超過 255 字！';
   }
   if (! SimpleSchema.RegEx.Url.test(model.url)) {
     error.url = '連結格式錯誤！';
+  }
+  if (model.description.length > 500) {
+    error.productName = '產品描述字數過長，最多不超過 500 字！';
   }
 
   if (_.size(error) > 0) {

--- a/client/productCenter/productCenterByCompany.html
+++ b/client/productCenter/productCenterByCompany.html
@@ -2,7 +2,7 @@
   <div class="card">
     <div class="card-block">
       <h1 class="card-title mb-1">
-        產品中心 - 
+        產品中心 -
         {{#with companyId}}
           {{>companyLink}}
         {{/with}}
@@ -26,13 +26,19 @@
           股東評價
           {{{getSortIcon 'likeCount'}}}
         </th>
+        {{#if currentUser.profile.isAdmin}}
+          <th class="text-center" style="width: 70px;" title="下架">
+            下架
+          </th>
+        {{/if}}
       </tr>
     </thead>
     <tbody>
       {{#each product in productList}}
         <tr>
-          <td class="text-left text-truncate px-2">
-            {{>productLink product._id}}
+          <td class="text-left px-2">
+            <div>{{>productLink product._id}}</div>
+            <div class="small">{{product.description}}</div>
           </td>
           <td class="text-center text-truncate">
             {{product.type}}
@@ -47,6 +53,17 @@
               <i class="fa fa-thumbs-o-up" aria-hidden="true"></i>
             </button>
           </td>
+          {{#if currentUser.profile.isAdmin}}
+            <td class="text-center px-2">
+              <button
+                class="btn btn-danger btn-sm"
+                type="button"
+                data-take-down="{{product._id}}"
+              >
+                下架
+              </button>
+            </td>
+          {{/if}}
         </tr>
       {{else}}
         <tr>

--- a/client/productCenter/productCenterByCompany.js
+++ b/client/productCenter/productCenterByCompany.js
@@ -4,10 +4,12 @@ import { Meteor } from 'meteor/meteor';
 import { Template } from 'meteor/templating';
 import { ReactiveVar } from 'meteor/reactive-var';
 import { FlowRouter } from 'meteor/kadira:flow-router';
+
 import { dbProducts } from '/db/dbProducts';
 import { inheritedShowLoadingOnSubscribing } from '../layout/loading';
 import { likeProduct } from '../utils/methods';
 import { shouldStopSubscribe } from '../utils/idle';
+import { alertDialog } from '../layout/alertDialog';
 
 inheritedShowLoadingOnSubscribing(Template.productCenterByCompany);
 const rProductSortBy = new ReactiveVar('likeCount');
@@ -97,5 +99,19 @@ Template.productListByCompanyTable.events({
     event.preventDefault();
     const productId = $(event.currentTarget).attr('data-like-product');
     likeProduct(productId);
+  },
+  'click [data-take-down]'(event) {
+    event.preventDefault();
+    const productId = $(event.currentTarget).attr('data-take-down');
+    alertDialog.dialog({
+      type: 'prompt',
+      title: '違規處理 - 產品下架',
+      message: `請輸入處理事由：`,
+      callback: function(message) {
+        if (message) {
+          Meteor.customCall('takeDownProduct', { productId, message });
+        }
+      }
+    });
   }
 });

--- a/client/productCenter/productCenterBySeason.html
+++ b/client/productCenter/productCenterBySeason.html
@@ -29,7 +29,7 @@
   <table class="table-bordered" style="width: 100%; table-layout: fixed;">
     <thead>
       <tr>
-        <th class="text-center text-truncate">產品名稱</th>
+        <th class="text-center text-truncate">產品</th>
         <th class="text-center text-truncate" title="公司名稱">
           公司名稱
         </th>
@@ -43,7 +43,7 @@
         </th>
         {{#if currentUser.profile.isAdmin}}
           <th class="text-center" style="width: 70px;" title="下架">
-            得票數
+            下架
           </th>
         {{/if}}
       </tr>
@@ -69,8 +69,9 @@
 
 <template name="productInfoBySeasonTable">
   <tr>
-    <td class="text-left text-truncate px-2">
-      {{>productLink this._id}}
+    <td class="text-left px-2">
+      <div>{{>productLink this._id}}</div>
+      <div class="small">{{this.description}}</div>
     </td>
     <td class="text-left text-truncate px-2">
       {{>companyLink this.companyId}}

--- a/client/utils/displayLink.js
+++ b/client/utils/displayLink.js
@@ -94,10 +94,11 @@ Template.productLink.onRendered(function() {
         id: productId
       },
       dataType: 'json',
-      success: (productData) => {
+      success: ({ productName, url }) => {
         $link
-          .attr('href', productData.url)
-          .text(productData.productName || '???');
+          .attr('href', url)
+          .attr('title', productName || '???')
+          .text(productName || '???');
       },
       error: () => {
         $link.text('???');

--- a/db/dbProducts.js
+++ b/db/dbProducts.js
@@ -49,6 +49,12 @@ const schema = new SimpleSchema({
     type: String,
     regEx: SimpleSchema.RegEx.Url
   },
+  // 產品描述
+  description: {
+    type: String,
+    max: 500,
+    optional: true
+  },
   //總票數
   votes: {
     type: SimpleSchema.Integer,
@@ -65,4 +71,3 @@ const schema = new SimpleSchema({
   }
 });
 dbProducts.attachSchema(schema);
-

--- a/dev-utils/factories.js
+++ b/dev-utils/factories.js
@@ -72,6 +72,9 @@ export const productFactory = new Factory()
     url() {
       return faker.internet.url();
     },
+    description() {
+      return faker.lorem.sentence(20);
+    },
     createdAt() {
       return new Date();
     }

--- a/server/methods/product/createProduct.js
+++ b/server/methods/product/createProduct.js
@@ -13,7 +13,8 @@ Meteor.methods({
       productName: String,
       companyId: String,
       type: String,
-      url: String
+      url: String,
+      description: String
     });
     createProduct(Meteor.user(), productData);
 


### PR DESCRIPTION
增加選擇性的「產品描述」欄位，上限 500 字
方便經理人簡介產品內容與解釋產品意涵，而不必全寫在產品名稱的 255 字裡面
一般大眾也能更快速地分別產品標題與介紹

其他修正：
* ``productLink`` template 補上連結的 title，方便當產品名稱過長被 truncate 掉時，滑鼠指上去仍能看得到完整名稱
* 公司的產品中心頁面補上金管會的「下架」按鍵，原本只有在當季的產品中心才有
* 在公司產品中心頁、當季產品中心頁、公司管理頁等等較大空間的頁面，移除產品名稱欄的 ``text-truncate`` 樣式，以讓人能完整閱讀名稱與描述
* 修正一些文字上與排版上的錯誤