### PR TITLE
修正儲備員工列表的排版問題

### DIFF
--- a/client/company/companyDetail.html
+++ b/client/company/companyDetail.html
@@ -616,20 +616,20 @@
       <div class="col-2 text-center">使用者帳號</div>
       <div class="col-3 text-center">報名時間</div>
     </div>
-    <div class="row mb-1" style="overflow-y: auto; max-height: 240px;">
-      {{#each employee in nextSeasonEmployeeList}}
+    {{#each employee in nextSeasonEmployeeList}}
+      <div class="row mb-1" style="overflow-y: auto; max-height: 240px;">
         <div class="col-2 text-truncate">
           {{>userLink employee.userId}}
         </div>
         <div class="col-3 text-center">
           {{formatDateText employee.registerAt}}
         </div>
-      {{else}}
-        <div class="col text-center">
-          沒有儲備員工！
-        </div>
-      {{/each}}
-    </div>
+      </div>
+    {{else}}
+      <div class="text-center">
+        沒有儲備員工！
+      </div>
+    {{/each}}
   </div>
 </template>
 


### PR DESCRIPTION
儲備員工列表應該一列顯示一個報名的使用者
但出現排版錯誤導致用同行接續的方式顯示一串使用者資料
這邊修正這個問題
