### PR TITLE
新增模糊比對搜尋功能

### DIFF
--- a/client/company/companyList.html
+++ b/client/company/companyList.html
@@ -46,29 +46,26 @@
         {{/if}}
       </div>
     </div>
-    <button class="{{sortByBtnClass 'lastPrice'}}" value="lastPrice" type="button" data-action="sortBy">
-      依股價排序
-    </button>
-    <button class="{{sortByBtnClass 'totalValue'}}" value="totalValue" type="button" data-action="sortBy">
-      依總市值排序
-    </button>
-    <button class="{{sortByBtnClass 'createdAt'}}" value="createdAt" type="button" data-action="sortBy">
-      依上市日期排序
-    </button>
-    <div class="input-group">
-      <input
-        class="form-control"
-        type="text"
-        name="keyword"
-        placeholder="請輸入關鍵字"
-        value="{{keyword}}"
-      />
-      <span class="input-group-btn">
+    <div class="d-flex flex-wrap">
+      <button class="{{sortByBtnClass 'lastPrice'}}" value="lastPrice" type="button" data-action="sortBy">
+        依股價排序
+      </button>
+      <button class="{{sortByBtnClass 'totalValue'}}" value="totalValue" type="button" data-action="sortBy">
+        依總市值排序
+      </button>
+      <button class="{{sortByBtnClass 'createdAt'}}" value="createdAt" type="button" data-action="sortBy">
+        依上市日期排序
+      </button>
+    </div>
+    <div class="d-flex flex-wrap justify-content-center">
+        <input class="form-control" type="text" name="keyword" placeholder="請輸入關鍵字" value="{{keyword}}" />
+        <select class="form-control" name="matchType">
+          <option value="exact">完全比對</option>
+          <option value="fuzzy">模糊比對</option>
+        </select>
         <button type="submit" class="btn btn-primary">
-          <i class="fa fa-search" aria-hidden="true"></i>
-          搜索
+          <i class="fa fa-search" aria-hidden="true"></i> 搜索
         </button>
-      </span>
     </div>
   </form>
 </template>
@@ -156,7 +153,7 @@
             <div class="order-panel">
               {{#each ownOrderList this._id}}
                 <div class="mb-1">
-                  {{orderType}}{{done}}/{{amount}} (${{unitPrice}}) 
+                  {{orderType}}{{done}}/{{amount}} (${{unitPrice}})
                   <button class="btn btn-danger btn-sm" type="button" data-cancel-order="{{_id}}">
                     取消
                   </button>

--- a/client/company/companyList.js
+++ b/client/company/companyList.js
@@ -15,6 +15,7 @@ import { rCompanyListViewMode } from '../utils/styles';
 
 inheritedShowLoadingOnSubscribing(Template.companyList);
 const rKeyword = new ReactiveVar('');
+const rMatchType = new ReactiveVar('exact');
 const rFilterBy = new ReactiveVar('none');
 const rSortBy = new ReactiveVar('lastPrice');
 export const rCompanyOffset = new ReactiveVar(0);
@@ -24,10 +25,11 @@ Template.companyList.onCreated(function() {
       return false;
     }
     const keyword = rKeyword.get();
+    const matchType = rMatchType.get();
     const onlyShow = rFilterBy.get();
     const sortBy = rSortBy.get();
     const offset = rCompanyOffset.get();
-    this.subscribe('companyList', {keyword, onlyShow, sortBy, offset});
+    this.subscribe('companyList', {keyword, matchType, onlyShow, sortBy, offset});
   });
   this.autorun(() => {
     if (shouldStopSubscribe()) {
@@ -63,6 +65,7 @@ Template.companyList.helpers({
 
 Template.companyFilterForm.onRendered(function() {
   this.$keyword = this.$('[name="keyword"]');
+  this.$matchType = this.$('[name="matchType"]');
 });
 Template.companyFilterForm.helpers({
   viewModeBtnClass() {
@@ -143,6 +146,7 @@ Template.companyFilterForm.events({
       page: 1
     });
     rKeyword.set(templateInstance.$keyword.val());
+    rMatchType.set(templateInstance.$matchType.val());
   }
 });
 

--- a/client/companyArchive/companyArchiveList.html
+++ b/client/companyArchive/companyArchiveList.html
@@ -23,7 +23,7 @@
           {{> companyArchiveListTable}}
         {{else}}
           <div>目前沒有任何公司在保管庫中！</div>
-        {{/each}} 
+        {{/each}}
       {{/if}}
       {{#with paginationData}}
         {{> pagination}}
@@ -37,21 +37,15 @@
     <button class="btn btn-secondary mr-1" type="button" data-action="toggleViewMode">
       <i class="fa {{viewModeBtnClass}}" aria-hidden="true"></i>
     </button>
-    <div class="input-group">
-      <input
-        class="form-control"
-        style="width: 300px"
-        type="text"
-        name="keyword"
-        placeholder="請輸入關鍵字"
-        value="{{keyword}}"
-      />
-      <span class="input-group-btn">
+    <div class="d-flex flex-wrap justify-content-center">
+        <input class="form-control" type="text" name="keyword" placeholder="請輸入關鍵字" value="{{keyword}}" />
+        <select class="form-control" name="matchType">
+          <option value="exact">完全比對</option>
+          <option value="fuzzy">模糊比對</option>
+        </select>
         <button type="submit" class="btn btn-primary">
-          <i class="fa fa-search" aria-hidden="true"></i>
-          搜索
+          <i class="fa fa-search" aria-hidden="true"></i> 搜索
         </button>
-      </span>
     </div>
   </form>
 </template>

--- a/client/companyArchive/companyArchiveList.js
+++ b/client/companyArchive/companyArchiveList.js
@@ -12,13 +12,18 @@ import { investArchiveCompany } from '../utils/methods';
 
 inheritedShowLoadingOnSubscribing(Template.companyArchiveList);
 const rKeyword = new ReactiveVar('');
+const rMatchType = new ReactiveVar('exact');
 export const rArchiveOffset = new ReactiveVar(0);
 Template.companyArchiveList.onCreated(function() {
   this.autorun(() => {
     if (shouldStopSubscribe()) {
       return false;
     }
-    this.subscribe('companyArchiveList', rKeyword.get(), rArchiveOffset.get());
+    this.subscribe('companyArchiveList', {
+      keyword: rKeyword.get(),
+      matchType: rMatchType.get(),
+      offset: rArchiveOffset.get()
+    });
   });
 });
 Template.companyArchiveList.helpers({
@@ -42,6 +47,7 @@ Template.companyArchiveList.helpers({
 
 Template.companyArchiveListFilterForm.onRendered(function() {
   this.$keyword = this.$('[name="keyword"]');
+  this.$matchType = this.$('[name="matchType"]');
 });
 Template.companyArchiveListFilterForm.helpers({
   viewModeBtnClass() {
@@ -70,6 +76,7 @@ Template.companyArchiveListFilterForm.events({
   submit(event, templateInstance) {
     event.preventDefault();
     rKeyword.set(templateInstance.$keyword.val());
+    rMatchType.set(templateInstance.$matchType.val());
     FlowRouter.go('companyArchiveList', {
       page: 1
     });

--- a/client/foundation/foundationList.html
+++ b/client/foundation/foundationList.html
@@ -29,7 +29,7 @@
       {{else}}
         {{#each foundationList}}
           {{> foundationListTable}}
-        {{/each}} 
+        {{/each}}
       {{/if}}
       {{#with paginationData}}
         {{> pagination}}
@@ -43,21 +43,15 @@
     <button class="btn btn-secondary mr-1" type="button" data-action="toggleViewMode">
       <i class="fa {{viewModeBtnClass}}" aria-hidden="true"></i>
     </button>
-    <div class="input-group">
-      <input
-        class="form-control"
-        style="width: 300px"
-        type="text"
-        name="keyword"
-        placeholder="請輸入關鍵字"
-        value="{{keyword}}"
-      />
-      <span class="input-group-btn">
+    <div class="d-flex flex-wrap justify-content-center">
+        <input class="form-control" type="text" name="keyword" placeholder="請輸入關鍵字" value="{{keyword}}" />
+        <select class="form-control" name="matchType">
+          <option value="exact">完全比對</option>
+          <option value="fuzzy">模糊比對</option>
+        </select>
         <button type="submit" class="btn btn-primary">
-          <i class="fa fa-search" aria-hidden="true"></i>
-          搜索
+          <i class="fa fa-search" aria-hidden="true"></i> 搜索
         </button>
-      </span>
     </div>
   </form>
 </template>

--- a/client/foundation/foundationList.js
+++ b/client/foundation/foundationList.js
@@ -14,13 +14,18 @@ import { currencyFormat } from '../utils/helpers.js';
 
 inheritedShowLoadingOnSubscribing(Template.foundationList);
 const rKeyword = new ReactiveVar('');
+const rMatchType = new ReactiveVar('exact');
 export const rFoundationOffset = new ReactiveVar(0);
 Template.foundationList.onCreated(function() {
   this.autorun(() => {
     if (shouldStopSubscribe()) {
       return false;
     }
-    this.subscribe('foundationList', rKeyword.get(), rFoundationOffset.get());
+    this.subscribe('foundationList', {
+      keyword: rKeyword.get(),
+      matchType: rMatchType.get(),
+      offset: rFoundationOffset.get()
+    });
   });
 });
 Template.foundationList.helpers({
@@ -59,6 +64,7 @@ Template.foundationList.events({
 
 Template.foundationListFilterForm.onRendered(function() {
   this.$keyword = this.$('[name="keyword"]');
+  this.$matchType = this.$('[name="matchType"]');
 });
 Template.foundationListFilterForm.helpers({
   viewModeBtnClass() {
@@ -87,6 +93,7 @@ Template.foundationListFilterForm.events({
   submit(event, templateInstance) {
     event.preventDefault();
     rKeyword.set(templateInstance.$keyword.val());
+    rMatchType.set(templateInstance.$matchType.val());
     FlowRouter.go('foundationList', {
       page: 1
     });

--- a/server/imports/buildSearchRegExp.js
+++ b/server/imports/buildSearchRegExp.js
@@ -1,0 +1,21 @@
+function escapeRegExp(string) {
+  // see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function buildSearchRegExp(keyword, matchType) {
+  if (matchType === 'exact') {
+    // 直接照原樣比對關鍵字
+    return new RegExp(escapeRegExp(keyword), 'i');
+  }
+
+  if (matchType === 'fuzzy') {
+    // 將關鍵字拆成一個一個字，比對中間插入任何字元的狀況
+    const patternString = keyword
+      .split('')
+      .map(escapeRegExp)
+      .join('.*');
+
+    return new RegExp(patternString, 'i');
+  }
+}

--- a/server/publications/companyArchive/companyArchiveList.js
+++ b/server/publications/companyArchive/companyArchiveList.js
@@ -5,23 +5,24 @@ import { dbCompanyArchive } from '/db/dbCompanyArchive';
 import { limitSubscription } from '/server/imports/rateLimit';
 import { debug } from '/server/imports/debug';
 import { publishTotalCount } from '/server/imports/publishTotalCount';
+import { buildSearchRegExp } from '/server/imports/buildSearchRegExp';
 
-Meteor.publish('companyArchiveList', function(keyword, offset) {
-  debug.log('publish companyArchiveList', {keyword, offset});
+Meteor.publish('companyArchiveList', function({keyword, matchType, offset}) {
+  debug.log('publish companyArchiveList', {keyword, matchType, offset});
   check(keyword, String);
+  check(matchType, new Match.OneOf('exact', 'fuzzy'));
   check(offset, Match.Integer);
   const filter = {
     status: 'archived'
   };
   if (keyword) {
-    keyword = keyword.replace(/\\/g, '\\\\');
-    const reg = new RegExp(keyword, 'i');
+    const regexp = buildSearchRegExp(keyword, matchType);
     filter.$or = [
       {
-        name: reg
+        name: regexp
       },
       {
-        tags: reg
+        tags: regexp
       }
     ];
   }

--- a/server/publications/foundation/foundationList.js
+++ b/server/publications/foundation/foundationList.js
@@ -5,21 +5,24 @@ import { dbFoundations } from '/db/dbFoundations';
 import { limitSubscription } from '/server/imports/rateLimit';
 import { debug } from '/server/imports/debug';
 import { publishTotalCount } from '/server/imports/publishTotalCount';
+import { buildSearchRegExp } from '/server/imports/buildSearchRegExp';
 
-Meteor.publish('foundationList', function(keyword, offset) {
-  debug.log('publish foundationPlan', {keyword, offset});
+Meteor.publish('foundationList', function({keyword, matchType, offset}) {
+  debug.log('publish foundationPlan', {keyword, matchType, offset});
   check(keyword, String);
+  check(matchType, new Match.OneOf('exact', 'fuzzy'));
   check(offset, Match.Integer);
+
   const filter = {};
+
   if (keyword) {
-    keyword = keyword.replace(/\\/g, '\\\\');
-    const reg = new RegExp(keyword, 'i');
+    const regexp = buildSearchRegExp(keyword, matchType);
     filter.$or = [
       {
-        companyName: reg
+        name: regexp
       },
       {
-        tags: reg
+        tags: regexp
       }
     ];
   }


### PR DESCRIPTION
為股市總覽、新創計劃與保管庫的搜尋加上了「模糊比對」的能力
當選擇模糊比對時，輸入的關鍵字比對時將會考慮中間被插入任何字元的狀況
而原本的比對行為現稱為「完全比對」，關鍵字必須一字不差且中間沒有任何其他字元才能 match
使用者可視情況選用適合的比對方式

以實際狀況當例子，角色名稱為 ``U -511(艦これ)``
tags 有 ``艦隊收藏``、``艦隊``、``艦これ``、``kancolle``、``潛艦``、``U -511(艦これ)``
若是選用完全比對，使用者以 ``U-511`` 做為關鍵字搜尋，並無法找到該角色
這時就可以選用模糊比對來增加搜尋範圍
可一定程度減少角色名被插入各種特殊字元時，對原本完全比對的搜尋方式造成的障礙