### PR TITLE
修正員工列表的排版問題

### DIFF
--- a/client/company/companyDetail.html
+++ b/client/company/companyDetail.html
@@ -569,26 +569,26 @@
     <div class="row mb-1">
       <div class="col-2 text-center">使用者帳號</div>
       <div class="col-3 text-center">報名時間</div>
-      <div class="col text-center">留言</div>
+      <div class="col-7 text-center">留言</div>
     </div>
 
-    {{#each employee in employeeList}}
-      <div class="row mb-1" style="overflow-y: auto; max-height: 240px;">
+    <div class="row mb-1" style="overflow-y: auto; max-height: 240px;">
+      {{#each employee in employeeList}}
         <div class="col-2 text-truncate">
           {{>userLink employee.userId}}
         </div>
-        <div class="col-3 text-center">
+        <div class="col-3">
           {{formatDateText employee.registerAt}}
         </div>
-        <div class="col text-left">
+        <div class="col-7">
           {{showMessage employee.message}}
         </div>
-      </div>
-    {{else}}
-      <div class="mb-1 text-center">
-        沒有在職員工！
-      </div>
-    {{/each}}
+      {{else}}
+        <div class="col-12 text-center">
+          沒有在職員工！
+        </div>
+      {{/each}}
+    </div>
 
     {{#if isCurrentUserEmployed}}
       <form>
@@ -616,22 +616,22 @@
     </h4>
     <div class="row mb-1">
       <div class="col-2 text-center">使用者帳號</div>
-      <div class="col-3 text-center">報名時間</div>
+      <div class="col-10">報名時間</div>
     </div>
-    {{#each employee in nextSeasonEmployeeList}}
-      <div class="row mb-1" style="overflow-y: auto; max-height: 240px;">
-        <div class="col-2 text-truncate">
-          {{>userLink employee.userId}}
+    <div class="row mb-1" style="overflow-y: auto; max-height: 240px;">
+      {{#each employee in nextSeasonEmployeeList}}
+          <div class="col-2 text-truncate">
+            {{>userLink employee.userId}}
+          </div>
+          <div class="col-10">
+            {{formatDateText employee.registerAt}}
+          </div>
+      {{else}}
+        <div class="col-12 text-center">
+          沒有儲備員工！
         </div>
-        <div class="col-3 text-center">
-          {{formatDateText employee.registerAt}}
-        </div>
-      </div>
-    {{else}}
-      <div class="mb-1 text-center">
-        沒有儲備員工！
-      </div>
-    {{/each}}
+      {{/each}}
+    </div>
   </div>
 </template>
 

--- a/client/company/companyDetail.html
+++ b/client/company/companyDetail.html
@@ -571,8 +571,9 @@
       <div class="col-3 text-center">報名時間</div>
       <div class="col text-center">留言</div>
     </div>
-    <div class="row mb-1" style="overflow-y: auto; max-height: 240px;">
-      {{#each employee in employeeList}}
+
+    {{#each employee in employeeList}}
+      <div class="row mb-1" style="overflow-y: auto; max-height: 240px;">
         <div class="col-2 text-truncate">
           {{>userLink employee.userId}}
         </div>
@@ -582,12 +583,13 @@
         <div class="col text-left">
           {{showMessage employee.message}}
         </div>
-      {{else}}
-        <div class="col text-center">
-          沒有在職員工！
-        </div>
-      {{/each}}
-    </div>
+      </div>
+    {{else}}
+      <div class="mb-1 text-center">
+        沒有在職員工！
+      </div>
+    {{/each}}
+
     {{#if isCurrentUserEmployed}}
       <form>
         <div class="form-group">
@@ -626,7 +628,7 @@
         </div>
       </div>
     {{else}}
-      <div class="text-center">
+      <div class="mb-1 text-center">
         沒有儲備員工！
       </div>
     {{/each}}

--- a/tests/mock/mongo.js
+++ b/tests/mock/mongo.js
@@ -14,6 +14,7 @@ const CollectionImpl = function() {
   this.attachSchema = sinon.stub();
   this.insert = sinon.stub();
   this.update = sinon.stub();
+  this.upsert = sinon.stub();
   this.remove = sinon.stub();
   this.findOne = sinon.stub();
   this.find = sinon.stub();


### PR DESCRIPTION
1. 在職員工列表應該一列顯示一個報名的使用者
但出現排版錯誤導致用同行接續的方式顯示一串使用者資料與留言
這邊修正這個問題

2. 員工列表過長時，原本應該出現捲軸，現在補上了