### PR TITLE
修正跳頁之後搜尋比對方式顯示會重置的問題

### DIFF
--- a/client/company/companyList.html
+++ b/client/company/companyList.html
@@ -58,14 +58,14 @@
       </button>
     </div>
     <div class="d-flex flex-wrap justify-content-center">
-        <input class="form-control" type="text" name="keyword" placeholder="請輸入關鍵字" value="{{keyword}}" />
-        <select class="form-control" name="matchType">
-          <option value="exact">完全比對</option>
-          <option value="fuzzy">模糊比對</option>
-        </select>
-        <button type="submit" class="btn btn-primary">
-          <i class="fa fa-search" aria-hidden="true"></i> 搜索
-        </button>
+      <input class="form-control" type="text" name="keyword" placeholder="請輸入關鍵字" value="{{keyword}}" />
+      <select class="form-control" name="matchType">
+        <option value="exact" {{showMatchTypeSelectedAttr 'exact'}}>完全比對</option>
+        <option value="fuzzy" {{showMatchTypeSelectedAttr 'fuzzy'}}>模糊比對</option>
+      </select>
+      <button type="submit" class="btn btn-primary">
+        <i class="fa fa-search" aria-hidden="true"></i> 搜索
+      </button>
     </div>
   </form>
 </template>

--- a/client/company/companyList.js
+++ b/client/company/companyList.js
@@ -103,6 +103,9 @@ Template.companyFilterForm.helpers({
   },
   keyword() {
     return rKeyword.get();
+  },
+  showMatchTypeSelectedAttr(matchType) {
+    return matchType === rMatchType.get() ? 'selected' : '';
   }
 });
 Template.companyFilterForm.events({

--- a/client/companyArchive/companyArchiveList.html
+++ b/client/companyArchive/companyArchiveList.html
@@ -38,14 +38,14 @@
       <i class="fa {{viewModeBtnClass}}" aria-hidden="true"></i>
     </button>
     <div class="d-flex flex-wrap justify-content-center">
-        <input class="form-control" type="text" name="keyword" placeholder="請輸入關鍵字" value="{{keyword}}" />
-        <select class="form-control" name="matchType">
-          <option value="exact">完全比對</option>
-          <option value="fuzzy">模糊比對</option>
-        </select>
-        <button type="submit" class="btn btn-primary">
-          <i class="fa fa-search" aria-hidden="true"></i> 搜索
-        </button>
+      <input class="form-control" type="text" name="keyword" placeholder="請輸入關鍵字" value="{{keyword}}" />
+      <select class="form-control" name="matchType">
+        <option value="exact" {{showMatchTypeSelectedAttr 'exact'}}>完全比對</option>
+        <option value="fuzzy" {{showMatchTypeSelectedAttr 'fuzzy'}}>模糊比對</option>
+      </select>
+      <button type="submit" class="btn btn-primary">
+        <i class="fa fa-search" aria-hidden="true"></i> 搜索
+      </button>
     </div>
   </form>
 </template>

--- a/client/companyArchive/companyArchiveList.js
+++ b/client/companyArchive/companyArchiveList.js
@@ -59,6 +59,9 @@ Template.companyArchiveListFilterForm.helpers({
   },
   keyword() {
     return rKeyword.get();
+  },
+  showMatchTypeSelectedAttr(matchType) {
+    return matchType === rMatchType.get() ? 'selected' : '';
   }
 });
 Template.companyArchiveListFilterForm.events({

--- a/client/foundation/foundationList.html
+++ b/client/foundation/foundationList.html
@@ -44,14 +44,14 @@
       <i class="fa {{viewModeBtnClass}}" aria-hidden="true"></i>
     </button>
     <div class="d-flex flex-wrap justify-content-center">
-        <input class="form-control" type="text" name="keyword" placeholder="請輸入關鍵字" value="{{keyword}}" />
-        <select class="form-control" name="matchType">
-          <option value="exact">完全比對</option>
-          <option value="fuzzy">模糊比對</option>
-        </select>
-        <button type="submit" class="btn btn-primary">
-          <i class="fa fa-search" aria-hidden="true"></i> 搜索
-        </button>
+      <input class="form-control" type="text" name="keyword" placeholder="請輸入關鍵字" value="{{keyword}}" />
+      <select class="form-control" name="matchType">
+        <option value="exact" {{showMatchTypeSelectedAttr 'exact'}}>完全比對</option>
+        <option value="fuzzy" {{showMatchTypeSelectedAttr 'fuzzy'}}>模糊比對</option>
+      </select>
+      <button type="submit" class="btn btn-primary">
+        <i class="fa fa-search" aria-hidden="true"></i> 搜索
+      </button>
     </div>
   </form>
 </template>

--- a/client/foundation/foundationList.js
+++ b/client/foundation/foundationList.js
@@ -76,6 +76,9 @@ Template.foundationListFilterForm.helpers({
   },
   keyword() {
     return rKeyword.get();
+  },
+  showMatchTypeSelectedAttr(matchType) {
+    return matchType === rMatchType.get() ? 'selected' : '';
   }
 });
 Template.foundationListFilterForm.events({


### PR DESCRIPTION
目前頁面跳轉之後再回來的話，公司搜尋欄位的比對方式顯示上會維持在「完全比對」而非目前所選擇的狀態
這邊修正這個問題