### PR TITLE
修正解除放假模式只更新到一個人的問題

### DIFF
--- a/server/intervalCheck.js
+++ b/server/intervalCheck.js
@@ -427,6 +427,8 @@ export function processEndVacationRequests() {
       'profile.isInVacation': false,
       'profile.isEndingVacation': false
     }
+  }, {
+    multi: true
   });
 }
 


### PR DESCRIPTION
解除放假的程式缺少 ``{ multi: true }`` 的 option，無法讓全部已標記解除放假的人解除放假
這邊修正這個問題