### PR TITLE
最萌亂鬥大賽更新

### DIFF
--- a/client/arenaInfo/arenaInfo.html
+++ b/client/arenaInfo/arenaInfo.html
@@ -112,19 +112,19 @@
             <div>{{>companyLink fighter.companyId}}</div>
           </td>
           <td class="text-right text-truncate">
-            {{fighter.hp}}
+            {{getAttributeNumber fighter 'hp'}}
           </td>
           <td class="text-right text-truncate">
-            {{fighter.sp}}
+            {{getAttributeNumber fighter 'sp'}}
           </td>
           <td class="text-right text-truncate">
-            {{fighter.atk}}
+            {{getAttributeNumber fighter 'atk'}}
           </td>
           <td class="text-right text-truncate">
-            {{fighter.def}}
+            {{getAttributeNumber fighter 'def'}}
           </td>
           <td class="text-right text-truncate">
-            {{fighter.agi}}
+            {{getAttributeNumber fighter 'agi'}}
           </td>
           <td class="text-center text-truncate">
             {{fighter.winnerIndex}}

--- a/client/arenaInfo/arenaInfo.js
+++ b/client/arenaInfo/arenaInfo.js
@@ -209,7 +209,7 @@ Template.arenaFighterTable.helpers({
             return (fighter1.createdAt.getTime() - fighter2.createdAt.getTime()) * sortDir * -1;
           }
           else {
-            return agi1 - agi2 * sortDir;
+            return (agi1 - agi2) * sortDir;
           }
         }
         default: {

--- a/client/arenaInfo/arenaInfo.js
+++ b/client/arenaInfo/arenaInfo.js
@@ -5,7 +5,7 @@ import { Template } from 'meteor/templating';
 import { ReactiveVar } from 'meteor/reactive-var';
 import { FlowRouter } from 'meteor/kadira:flow-router';
 import { dbArena } from '/db/dbArena';
-import { dbArenaFighters } from '/db/dbArenaFighters';
+import { dbArenaFighters, getAttributeNumber } from '/db/dbArenaFighters';
 import { dbArenaLog } from '/db/dbArenaLog';
 import { inheritedShowLoadingOnSubscribing } from '../layout/loading';
 import { shouldStopSubscribe } from '../utils/idle';
@@ -217,6 +217,9 @@ Template.arenaFighterTable.helpers({
         }
       }
     });
+  },
+  getAttributeNumber(fighter, attributeName) {
+    return getAttributeNumber(attributeName, fighter[attributeName]);
   }
 });
 Template.arenaFighterTable.events({

--- a/client/company/companyDetail.js
+++ b/client/company/companyDetail.js
@@ -1134,11 +1134,14 @@ Template.arenaStrategyForm.onRendered(function() {
 });
 function validateStrategyModel(model) {
   const error = {};
-  if (model.spCost > model.sp) {
+  if (model.spCost > getAttributeNumber('sp', model.sp)) {
     error.spCost = '特攻消耗數值不可超過角色的SP值！';
   }
   else if (model.spCost < 1) {
     error.spCost = '特攻消耗數值不可低於1！';
+  }
+  else if (model.spCost > 10) {
+    error.spCost = '特攻消耗數值不可高於10！';
   }
 
   if (_.size(error) > 0) {
@@ -1183,7 +1186,11 @@ function handleStrategyInputChange(event) {
 }
 function saveStrategyModel(model) {
   const submitData = _.pick(model, 'spCost', 'attackSequence', 'normalManner', 'specialManner');
-  Meteor.customCall('decideArenaStrategy', model.companyId, submitData);
+  Meteor.customCall('decideArenaStrategy', model.companyId, submitData, (error) => {
+    if (! error) {
+      alertDialog.alert('決策完成！');
+    }
+  });
 }
 Template.arenaStrategyForm.helpers({
   getManner(type, index) {

--- a/server/arena.js
+++ b/server/arena.js
@@ -61,8 +61,8 @@ export function startArenaFight() {
   //直到戰到剩下一人為止
   while (loser.length < fighterListBySequence.length - 1) {
     //超過十萬回合後自動中止
-    if (round > 100000) {
-      console.log('round > 100000!');
+    if (round > 500) {
+      console.log('round > 500!');
       break;
     }
     //所有參賽者依序攻擊

--- a/server/methods/arena/decideArenaStrategy.js
+++ b/server/methods/arena/decideArenaStrategy.js
@@ -5,7 +5,7 @@ import { check, Match } from 'meteor/check';
 
 import { resourceManager } from '/server/imports/resourceManager';
 import { dbArena } from '/db/dbArena';
-import { dbArenaFighters } from '/db/dbArenaFighters';
+import { dbArenaFighters, getAttributeNumber } from '/db/dbArenaFighters';
 import { dbCompanies } from '/db/dbCompanies';
 import { debug } from '/server/imports/debug';
 
@@ -88,7 +88,7 @@ function decideArenaStrategy({user, companyId, strategyData}) {
   if (! fighterData) {
     throw new Meteor.Error(403, '這家公司並沒有報名參加這一屆的最萌亂鬥大賽！');
   }
-  if (strategyData.spCost > fighterData.sp) {
+  if (strategyData.spCost > getAttributeNumber('sp', fighterData.sp)) {
     throw new Meteor.Error(403, '特攻消耗數值不可超過角色的SP值！');
   }
   else if (strategyData.spCost > 10) {

--- a/server/methods/arena/decideArenaStrategy.js
+++ b/server/methods/arena/decideArenaStrategy.js
@@ -57,23 +57,25 @@ function decideArenaStrategy({user, companyId, strategyData}) {
   if (! lastArenaData) {
     throw new Meteor.Error(403, '現在並沒有舉辦最萌亂鬥大賽！');
   }
-  if ((lastArenaData.fighterSequence.length - 1) !== strategyData.attackSequence.length) {
-    throw new Meteor.Error(403, '攻擊優先順序的資料格式錯誤！');
-  }
-  let attackSequenceIsInvalid = false;
-  const attackSequenceSet = new Set();
-  _.some(strategyData.attackSequence, (sequence) => {
-    if (sequence < 0) {
-      attackSequenceIsInvalid = true;
-
-      return true;
+  if (lastArenaData.fighterSequence.length) {
+    if ((lastArenaData.fighterSequence.length - 1) !== strategyData.attackSequence.length) {
+      throw new Meteor.Error(403, '攻擊優先順序的資料格式錯誤！');
     }
-    attackSequenceSet.add(sequence);
+    let attackSequenceIsInvalid = false;
+    const attackSequenceSet = new Set();
+    _.some(strategyData.attackSequence, (sequence) => {
+      if (sequence < 0) {
+        attackSequenceIsInvalid = true;
 
-    return false;
-  });
-  if (attackSequenceIsInvalid || attackSequenceSet.size !== strategyData.attackSequence.length) {
-    throw new Meteor.Error(403, '攻擊優先順序的資料格式錯誤！');
+        return true;
+      }
+      attackSequenceSet.add(sequence);
+
+      return false;
+    });
+    if (attackSequenceIsInvalid || attackSequenceSet.size !== strategyData.attackSequence.length) {
+      throw new Meteor.Error(403, '攻擊優先順序的資料格式錯誤！');
+    }
   }
 
   const arenaId = lastArenaData._id;
@@ -88,6 +90,12 @@ function decideArenaStrategy({user, companyId, strategyData}) {
   }
   if (strategyData.spCost > fighterData.sp) {
     throw new Meteor.Error(403, '特攻消耗數值不可超過角色的SP值！');
+  }
+  else if (strategyData.spCost > 10) {
+    throw new Meteor.Error(403, '特攻消耗數值不可超過10！');
+  }
+  else if (strategyData.spCost < 1) {
+    throw new Meteor.Error(403, '特攻消耗數值不可小於1！');
   }
   resourceManager.throwErrorIsResourceIsLock(['season']);
   dbArenaFighters.update(fighterData._id, {


### PR DESCRIPTION
1.修正最萌大賽資訊頁的選手列表，屬性欄位顯示的是投資金額而不是屬性值的bug。
2.修正最萌大賽資訊頁的選手列表在以AGI排序時會錯亂的bug。
3.修正幾個決策修改時驗證錯誤導致無法決策的bug。 
4.決策修改成功後將會跳出提示訊息。
5.將最大戰鬥回合數從10000縮減為500，畢面戰鬥紀錄過多讓資料庫爆炸的bug。