### PR TITLE
將低量釋股的交易量統計區間設定獨立出來

### DIFF
--- a/config.js
+++ b/config.js
@@ -44,6 +44,7 @@ export const config = {
   announceBonusTime: 86400000, //季度結束前多久開放設定分紅，單位為微秒
   vacationModeZombieTaxPerDay: 500, // 渡假當季的殭屍稅率 (每天)
   minIntervalTimeBetweenVacations: 604800000, // 收假後再次放假所需間隔 (ms)
-  taxExpireTime: 259200000 // 稅單的繳費期限 (ms)
+  taxExpireTime: 259200000, // 稅單的繳費期限 (ms)
+  releaseStocksForNoDealTradeLogLookbackIntervalTime: 86400000 // 低量釋股的成交量統計區間 (ms)
 };
 export default config;

--- a/config.json
+++ b/config.json
@@ -43,6 +43,7 @@
     "announceBonusTime": 86400000,
     "vacationModeZombieTaxPerDay": 500,
     "minIntervalTimeBetweenVacations": 604800000,
-    "taxExpireTime": 259200000
+    "taxExpireTime": 259200000,
+    "releaseStocksForNoDealTradeLogLookbackIntervalTime": 86400000
   }
 }

--- a/server/company.js
+++ b/server/company.js
@@ -109,8 +109,7 @@ export function releaseStocksForNoDeal() {
     console.info('releaseStocksForNoDeal triggered! next counter: ', releaseStocksForNoDealCounter);
     updateReleaseStocksForNoDealPeriod();
 
-    // TODO 獨立一個設定值給 checkLogTime
-    const checkLogTime = new Date(Date.now() - (Meteor.settings.public.releaseStocksForNoDealMinCounter * Meteor.settings.public.intervalTimer));
+    const checkLogTime = new Date(Date.now() - Meteor.settings.public.releaseStocksForNoDealTradeLogLookbackIntervalTime);
     const lowPriceThreshold = dbVariables.get('lowPriceThreshold');
     dbCompanies
       .find(


### PR DESCRIPTION
原先是以最小 counter 乘上 intervalTimer 做計算，現在獨立出一個 config 選項以便測試時調整