### PR TITLE
增加金管會對新創或上市公司標記違規的能力

### DIFF
--- a/client/company/companyDetail.html
+++ b/client/company/companyDetail.html
@@ -29,6 +29,15 @@
                 <a class="btn btn-danger float-right" href="#" data-action="seal">
                   查封關停
                 </a>
+                {{#if this.illegalReason}}
+                  <a class="btn btn-danger float-right" href="#" data-action="unmarkCompanyIllegal">
+                    解除違規標記
+                  </a>
+                {{else}}
+                  <a class="btn btn-danger float-right" href="#" data-action="markCompanyIllegal">
+                    標記違規
+                  </a>
+                {{/if}}
                 <a class="btn btn-warning float-right" href="#" data-action="changeCompanyName">
                   更名
                 </a>
@@ -58,6 +67,12 @@
               {{/if}}
             {{/if}}
           </h1>
+          {{#if this.illegalReason}}
+            <div class="mb-1 text-danger">
+              <i class="fa fa-warning"></i>
+              本公司已被標記為違規！原因：{{sanitizeHtml this.illegalReason}}
+            </div>
+          {{/if}}
           {{#if showAllTags this.tags}}
             {{#each tag in this.tags}}
               <span class="badge badge-default">{{tag}}</span>

--- a/client/company/companyDetail.js
+++ b/client/company/companyDetail.js
@@ -290,6 +290,42 @@ Template.companyDetail.events({
         Meteor.customCall('resignManager', companyId);
       }
     });
+  },
+  'click [data-action="markCompanyIllegal"]'(event) {
+    event.preventDefault();
+    const companyId = FlowRouter.getParam('companyId');
+    const companyData = dbCompanies.findOne(companyId, {
+      fields: {
+        companyName: 1
+      }
+    });
+    alertDialog.dialog({
+      type: 'prompt',
+      title: '設定違規標記',
+      message: '請輸入違規事由：',
+      defaultValue: companyData.illegalReason,
+      callback: (reason) => {
+        if (! reason) {
+          return;
+        }
+        if (reason.length > 10) {
+          alertDialog.alert('違規標記事由不可大於十個字！');
+
+          return;
+        }
+
+        Meteor.customCall('markCompanyIllegal', companyId, reason);
+      }
+    });
+  },
+  'click [data-action="unmarkCompanyIllegal"]'(event) {
+    event.preventDefault();
+    const companyId = FlowRouter.getParam('companyId');
+    alertDialog.confirm('是否解除違規標記？', (result) => {
+      if (result) {
+        Meteor.customCall('unmarkCompanyIllegal', companyId);
+      }
+    });
   }
 });
 

--- a/client/company/companyList.html
+++ b/client/company/companyList.html
@@ -83,7 +83,16 @@
           {{/if}}
         {{/if}}
       </div>
-      <hr style="margin: 0px;" />
+      <hr class="m-0"/>
+      {{#if this.illegalReason}}
+        <div class="row text-left illegal-description">
+          <div class="col text-center text-white text-truncate" title="{{sanitizeHtml this.illegalReason}}">
+            <i class="fa fa-warning"></i>
+            {{sanitizeHtml this.illegalReason}}
+          </div>
+        </div>
+        <hr class="m-0"/>
+      {{/if}}
       <div class="row row-cover d-flex justify-content-around">
         <div class="d-flex flex-column align-self-center">
           <div class="picture">
@@ -199,6 +208,12 @@
       {{/if}}
     </div>
     <div class="media-body row border-grid-body">
+      {{#if this.illegalReason}}
+        <div class="col-12 text-center text-danger text-truncate border-grid" title="{{showIllegalDescription}}">
+          <i class="fa fa-warning"></i>
+          本公司已被標記為違規！原因：{{sanitizeHtml this.illegalReason}}
+        </div>
+      {{/if}}
       <div class="col-4 col-lg-3 text-right border-grid">角色名稱：</div>
       <div class="col-8 col-lg-3 text-truncate border-grid">
         {{>companyLink this._id}}

--- a/client/foundation/foundationDetail.html
+++ b/client/foundation/foundationDetail.html
@@ -12,9 +12,24 @@
               <a class="btn btn-warning" href="{{getEditHref this._id}}">
                 修改計劃
               </a>
+              {{#if this.illegalReason}}
+                <a class="btn btn-danger" href="#" data-action="unmarkFoundationIllegal">
+                  解除違規標記
+                </a>
+              {{else}}
+                <a class="btn btn-danger" href="#" data-action="markFoundationIllegal">
+                  標記違規
+                </a>
+              {{/if}}
             {{/if}}
           {{/if}}
         </h1>
+        {{#if this.illegalReason}}
+          <div class="mb-1 text-danger">
+            <i class="fa fa-warning"></i>
+            本公司已被標記為違規！原因：{{sanitizeHtml this.illegalReason}}
+          </div>
+        {{/if}}
         {{#if showAllTags this.tags}}
           {{#each tag in this.tags}}
             <span class="badge badge-default">{{tag}}</span>

--- a/client/foundation/foundationDetail.js
+++ b/client/foundation/foundationDetail.js
@@ -80,6 +80,42 @@ Template.foundationDetail.events({
   'click [data-action="showAllTags"]'(event) {
     event.preventDefault();
     rShowAllTags.set(true);
+  },
+  'click [data-action="markFoundationIllegal"]'(event) {
+    event.preventDefault();
+    const foundationId = FlowRouter.getParam('foundationId');
+    const companyData = dbFoundations.findOne(foundationId, {
+      fields: {
+        companyName: 1
+      }
+    });
+    alertDialog.dialog({
+      type: 'prompt',
+      title: '設定違規標記',
+      message: '請輸入違規事由：',
+      defaultValue: companyData.illegalReason,
+      callback: (reason) => {
+        if (! reason) {
+          return;
+        }
+        if (reason.length > 10) {
+          alertDialog.alert('違規標記事由不可大於十個字！');
+
+          return;
+        }
+
+        Meteor.customCall('markFoundationIllegal', foundationId, reason);
+      }
+    });
+  },
+  'click [data-action="unmarkFoundationIllegal"]'(event) {
+    event.preventDefault();
+    const foundationId = FlowRouter.getParam('foundationId');
+    alertDialog.confirm('是否解除違規標記？', (result) => {
+      if (result) {
+        Meteor.customCall('unmarkFoundationIllegal', foundationId);
+      }
+    });
   }
 });
 

--- a/client/foundation/foundationList.html
+++ b/client/foundation/foundationList.html
@@ -56,8 +56,6 @@
   </form>
 </template>
 
-
-
 <template name="foundationListCard">
   <div class="col-12 col-md-6 col-lg-4 col-xl-3" style="margin-bottom: 25px;">
     <div class="company-card {{cardDisplayClass this}}">
@@ -65,7 +63,16 @@
         <div class="row row-info">
           <small>{{getExpireDateText this.createdAt}} 截止</small>
         </div>
-        <hr style="margin: 0px;" />
+        <hr class="m-0"/>
+        {{#if this.illegalReason}}
+          <div class="row text-left illegal-description">
+            <div class="col text-center text-white text-truncate" title="{{sanitizeHtml this.illegalReason}}">
+              <i class="fa fa-warning"></i>
+              {{sanitizeHtml this.illegalReason}}
+            </div>
+          </div>
+          <hr class="m-0"/>
+        {{/if}}
         <div class="row row-cover d-flex justify-content-around">
           <div class="d-flex flex-column align-self-center">
             <div class="picture">
@@ -89,7 +96,7 @@
             </div>
           </div>
         </div>
-        <div class="title-starter">
+        <div class="row title-starter">
           {{>companyLink this._id}}
         </div>
         <div class="row row-info d-flex justify-content-between">
@@ -120,7 +127,7 @@
           </div>
         </div>
         {{#if currentUser}}
-          <hr style="margin: 0px;" />
+          <hr class="m-0">
           <div class="row btn-group">
             {{#if currentUser.profile.isAdmin}}
               <a class="btn btn-tab" href="{{getEditHref this._id}}">
@@ -147,6 +154,12 @@
       {{/if}}
     </div>
     <div class="media-body row border-grid-body">
+      {{#if this.illegalReason}}
+        <div class="col-12 text-center text-danger text-truncate border-grid" title="{{showIllegalDescription}}">
+          <i class="fa fa-warning"></i>
+          本公司已被標記為違規！原因：{{sanitizeHtml this.illegalReason}}
+        </div>
+      {{/if}}
       <div class="col-4 col-lg-3 text-right border-grid">角色名稱：</div>
       <div class="col-8 col-lg-3 text-truncate border-grid" title="{{this.companyName}}">
         {{>companyLink this._id}}

--- a/client/utils/displayLog.js
+++ b/client/utils/displayLog.js
@@ -3,7 +3,8 @@ import { _ } from 'meteor/underscore';
 import { $ } from 'meteor/jquery';
 import { Template } from 'meteor/templating';
 import { FlowRouter } from 'meteor/kadira:flow-router';
-import { currencyFormat } from './helpers.js';
+
+import { currencyFormat, sanitizeHtml } from './helpers.js';
 
 Template.displayLog.onRendered(function() {
   if (this.data.userId) {
@@ -399,10 +400,4 @@ function companySpan(companyId) {
 
 function productSpan(productId) {
   return `<span data-product-link="${productId}"></span>`;
-}
-
-function sanitizeHtml(str) {
-  return $('<span></span>')
-    .text(str)
-    .html();
 }

--- a/client/utils/helpers.js
+++ b/client/utils/helpers.js
@@ -2,9 +2,12 @@
 import { Meteor } from 'meteor/meteor';
 import { Template } from 'meteor/templating';
 import { FlowRouter } from 'meteor/kadira:flow-router';
+import { $ } from 'meteor/jquery';
+
 import { dbCompanies } from '/db/dbCompanies';
 import { dbEmployees } from '/db/dbEmployees';
 import { dbVariables } from '/db/dbVariables';
+
 
 Meteor.subscribe('variables');
 
@@ -170,3 +173,10 @@ Template.registerHelper('minus', function(value1, value2) {
 Template.registerHelper('displayManager', function(manager) {
   return manager === '!none' ? '無' : manager;
 });
+
+export function sanitizeHtml(str) {
+  return $('<span></span>')
+    .text(str)
+    .html();
+}
+Template.registerHelper('sanitizeHtml', sanitizeHtml);

--- a/client/utils/styles.css
+++ b/client/utils/styles.css
@@ -113,6 +113,13 @@
   text-overflow: ellipsis;
   display: block;
 }
+.company-card .illegal-description {
+  background: #ff0000;
+  background: -webkit-linear-gradient(left, transparent, #ff0000 5%, #ff0000 95%, transparent);
+  background: -o-linear-gradient(left, transparent, #ff0000 5%, #ff0000 95%, transparent);
+  background: -moz-linear-gradient(left, transparent, #ff0000 5%, #ff0000 95%, transparent);
+  background: -linear-gradient(left, transparent, #ff0000 5%, #ff0000 95%, transparent);
+}
 .company-card .row {
   color: #000;
   vertical-align: middle;
@@ -162,7 +169,7 @@
 .company-card div.description {
   font-size: 0.8rem;
   white-space: pre-wrap;
-  word-break: break-all;  
+  word-break: break-all;
 }
 
 .company-summary-item {
@@ -237,30 +244,30 @@
 
 @media only screen and (max-width: 800px) {
   /* Force table to not be like tables anymore */
-  #tax-info-table table, 
-  #tax-info-table thead, 
-  #tax-info-table tbody, 
-  #tax-info-table th, 
-  #tax-info-table td, 
-  #tax-info-table tr { 
-    display: block; 
+  #tax-info-table table,
+  #tax-info-table thead,
+  #tax-info-table tbody,
+  #tax-info-table th,
+  #tax-info-table td,
+  #tax-info-table tr {
+    display: block;
   }
- 
+
   /* Hide table headers (but not display: none;, for accessibility) */
-  #tax-info-table thead tr { 
+  #tax-info-table thead tr {
     position: absolute;
     top: -9999px;
     left: -9999px;
   }
- 
+
   #tax-info-table tr { border: 2px solid #ccc; }
- 
-  #tax-info-table td { 
+
+  #tax-info-table td {
     /* Behave  like a "row" */
     border: none;
-    border-bottom: 1px solid #eee; 
+    border-bottom: 1px solid #eee;
     position: relative;
-    padding-left: 35%; 
+    padding-left: 35%;
     white-space: normal;
     text-align: left !important;
   }
@@ -268,21 +275,21 @@
   #tax-info-table td:last-child {
     border-bottom: none;
   }
- 
-  #tax-info-table td:before { 
+
+  #tax-info-table td:before {
     /* Now like a table header */
     position: absolute;
     /* Top/left values mimic padding */
     top: 6px;
     left: 6px;
-    width: 45%; 
+    width: 45%;
     padding-right: 10px;
     padding-bottom: 0px;
     white-space: nowrap;
     text-align: left;
     font-weight: bold;
   }
- 
+
   /*
   Label the data
   */

--- a/db/dbCompanies.js
+++ b/db/dbCompanies.js
@@ -58,6 +58,12 @@ const schema = new SimpleSchema({
     min: 10,
     max: 3000
   },
+  // 違規描述
+  illegalReason: {
+    type: String,
+    max: 10,
+    optional: true
+  },
   //目前總釋出股份
   totalRelease: {
     type: SimpleSchema.Integer,

--- a/db/dbFoundations.js
+++ b/db/dbFoundations.js
@@ -47,6 +47,12 @@ const schema = new SimpleSchema({
     min: 10,
     max: 3000
   },
+  // 違規描述
+  illegalReason: {
+    type: String,
+    max: 10,
+    optional: true
+  },
   //投資人列表
   invest: {
     type: Array,

--- a/server/foundation.js
+++ b/server/foundation.js
@@ -95,6 +95,7 @@ export function checkFoundCompany() {
             pictureSmall: foundationData.pictureSmall,
             pictureBig: foundationData.pictureBig,
             description: foundationData.description,
+            illegalReason: foundationData.illegalReason,
             totalRelease: totalRelease,
             lastPrice: stockUnitPrice,
             listPrice: stockUnitPrice,

--- a/server/methods/company/markCompanyIllegal.js
+++ b/server/methods/company/markCompanyIllegal.js
@@ -2,8 +2,8 @@ import { Meteor } from 'meteor/meteor';
 import { check } from 'meteor/check';
 
 import { dbCompanies } from '/db/dbCompanies';
-import { limitMethod } from '/server/imports/rateLimit';
-import { debug } from '/server/imports/debug';
+import { limitMethod } from '/server/imports/utils/rateLimit';
+import { debug } from '/server/imports/utils/debug';
 
 Meteor.methods({
   markCompanyIllegal(companyId, reason) {

--- a/server/methods/company/markCompanyIllegal.js
+++ b/server/methods/company/markCompanyIllegal.js
@@ -1,0 +1,30 @@
+import { Meteor } from 'meteor/meteor';
+import { check } from 'meteor/check';
+
+import { dbCompanies } from '/db/dbCompanies';
+import { limitMethod } from '/server/imports/rateLimit';
+import { debug } from '/server/imports/debug';
+
+Meteor.methods({
+  markCompanyIllegal(companyId, reason) {
+    check(this.userId, String);
+    check(companyId, String);
+    check(reason, String);
+    markCompanyIllegal(Meteor.user(), companyId, reason);
+
+    return true;
+  }
+});
+function markCompanyIllegal(user, companyId, reason) {
+  debug.log('markCompanyIllegal', {user, companyId, reason});
+  if (! user.profile.isAdmin) {
+    throw new Meteor.Error(403, '您並非金融管理會委員，無法進行此操作！');
+  }
+
+  if (dbCompanies.find(companyId).count() === 0) {
+    throw new Meteor.Error(404, `找不到識別碼為「${companyId}」的公司！`);
+  }
+
+  dbCompanies.update(companyId, { $set: { illegalReason: reason } });
+}
+limitMethod('markCompanyIllegal');

--- a/server/methods/company/unmarkCompanyIllegal.js
+++ b/server/methods/company/unmarkCompanyIllegal.js
@@ -2,8 +2,8 @@ import { Meteor } from 'meteor/meteor';
 import { check } from 'meteor/check';
 
 import { dbCompanies } from '/db/dbCompanies';
-import { limitMethod } from '/server/imports/rateLimit';
-import { debug } from '/server/imports/debug';
+import { limitMethod } from '/server/imports/utils/rateLimit';
+import { debug } from '/server/imports/utils/debug';
 
 Meteor.methods({
   unmarkCompanyIllegal(companyId) {

--- a/server/methods/company/unmarkCompanyIllegal.js
+++ b/server/methods/company/unmarkCompanyIllegal.js
@@ -1,0 +1,29 @@
+import { Meteor } from 'meteor/meteor';
+import { check } from 'meteor/check';
+
+import { dbCompanies } from '/db/dbCompanies';
+import { limitMethod } from '/server/imports/rateLimit';
+import { debug } from '/server/imports/debug';
+
+Meteor.methods({
+  unmarkCompanyIllegal(companyId) {
+    check(this.userId, String);
+    check(companyId, String);
+    unmarkCompanyIllegal(Meteor.user(), companyId);
+
+    return true;
+  }
+});
+function unmarkCompanyIllegal(user, companyId) {
+  debug.log('unmarkCompanyIllegal', {user, companyId});
+  if (! user.profile.isAdmin) {
+    throw new Meteor.Error(403, '您並非金融管理會委員，無法進行此操作！');
+  }
+
+  if (dbCompanies.find(companyId).count() === 0) {
+    throw new Meteor.Error(404, `找不到識別碼為「${companyId}」的公司！`);
+  }
+
+  dbCompanies.update(companyId, { $unset: { illegalReason: 1 } });
+}
+limitMethod('unmarkCompanyIllegal');

--- a/server/methods/foundation/markFoundationIllegal.js
+++ b/server/methods/foundation/markFoundationIllegal.js
@@ -2,8 +2,8 @@ import { Meteor } from 'meteor/meteor';
 import { check } from 'meteor/check';
 
 import { dbFoundations } from '/db/dbFoundations';
-import { limitMethod } from '/server/imports/rateLimit';
-import { debug } from '/server/imports/debug';
+import { limitMethod } from '/server/imports/utils/rateLimit';
+import { debug } from '/server/imports/utils/debug';
 
 Meteor.methods({
   markFoundationIllegal(companyId, reason) {

--- a/server/methods/foundation/markFoundationIllegal.js
+++ b/server/methods/foundation/markFoundationIllegal.js
@@ -1,0 +1,30 @@
+import { Meteor } from 'meteor/meteor';
+import { check } from 'meteor/check';
+
+import { dbFoundations } from '/db/dbFoundations';
+import { limitMethod } from '/server/imports/rateLimit';
+import { debug } from '/server/imports/debug';
+
+Meteor.methods({
+  markFoundationIllegal(companyId, reason) {
+    check(this.userId, String);
+    check(companyId, String);
+    check(reason, String);
+    markFoundationIllegal(Meteor.user(), companyId, reason);
+
+    return true;
+  }
+});
+function markFoundationIllegal(user, companyId, reason) {
+  debug.log('markFoundationIllegal', {user, companyId, reason});
+  if (! user.profile.isAdmin) {
+    throw new Meteor.Error(403, '您並非金融管理會委員，無法進行此操作！');
+  }
+
+  if (dbFoundations.find(companyId).count() === 0) {
+    throw new Meteor.Error(404, '找不到要編輯的新創計劃，該新創計劃可能已經創立成功或失敗！');
+  }
+
+  dbFoundations.update(companyId, { $set: { illegalReason: reason } });
+}
+limitMethod('markFoundationIllegal');

--- a/server/methods/foundation/unmarkFoundationIllegal.js
+++ b/server/methods/foundation/unmarkFoundationIllegal.js
@@ -1,0 +1,29 @@
+import { Meteor } from 'meteor/meteor';
+import { check } from 'meteor/check';
+
+import { dbFoundations } from '/db/dbFoundations';
+import { limitMethod } from '/server/imports/rateLimit';
+import { debug } from '/server/imports/debug';
+
+Meteor.methods({
+  unmarkFoundationIllegal(companyId) {
+    check(this.userId, String);
+    check(companyId, String);
+    unmarkFoundationIllegal(Meteor.user(), companyId);
+
+    return true;
+  }
+});
+function unmarkFoundationIllegal(user, companyId) {
+  debug.log('unmarkFoundationIllegal', {user, companyId});
+  if (! user.profile.isAdmin) {
+    throw new Meteor.Error(403, '您並非金融管理會委員，無法進行此操作！');
+  }
+
+  if (dbFoundations.find(companyId).count() === 0) {
+    throw new Meteor.Error(404, '找不到要編輯的新創計劃，該新創計劃可能已經創立成功或失敗！');
+  }
+
+  dbFoundations.update(companyId, { $unset: { illegalReason: 1 } });
+}
+limitMethod('unmarkFoundationIllegal');

--- a/server/methods/foundation/unmarkFoundationIllegal.js
+++ b/server/methods/foundation/unmarkFoundationIllegal.js
@@ -2,8 +2,8 @@ import { Meteor } from 'meteor/meteor';
 import { check } from 'meteor/check';
 
 import { dbFoundations } from '/db/dbFoundations';
-import { limitMethod } from '/server/imports/rateLimit';
-import { debug } from '/server/imports/debug';
+import { limitMethod } from '/server/imports/utils/rateLimit';
+import { debug } from '/server/imports/utils/debug';
 
 Meteor.methods({
   unmarkFoundationIllegal(companyId) {

--- a/server/publications/company/companyList.js
+++ b/server/publications/company/companyList.js
@@ -93,6 +93,7 @@ Meteor.publish('companyList', function({keyword, matchType, onlyShow, sortBy, of
     chairmanTitle: 1,
     chairman: 1,
     pictureSmall: 1,
+    illegalReason: 1,
     totalRelease: 1,
     lastPrice: 1,
     listPrice: 1,


### PR DESCRIPTION
實作 #261 提到的功能

* 金管會成員可以在公司新創時期或公司上市後，設定該公司的違規標記，最多十個字
* 違規標記設定後，會在公司(新創)列表或該公司的資訊頁顯示標記原因
* 公司在新創時期的違規標記，在該公司上市時仍會留存著
* 金管會成員可以隨時解除違規標記