### PR TITLE
最萌亂鬥大賽修正

### DIFF
--- a/client/arenaInfo/arenaInfo.html
+++ b/client/arenaInfo/arenaInfo.html
@@ -108,12 +108,12 @@
     </thead>
     <tbody>
       {{#each fighter in fighterList}}
-        <tr>
+        <tr data-id="{{fighter.companyId}}">
           <td class="text-left px-1 text-truncate">
-            <div>{{>companyLink fighter.companyId}}</div>
+            <a href="{{fighterUrl fighter.companyId}}">{{fighterName fighter.companyId}}</a>
           </td>
           <td class="text-left px-1 text-truncate">
-            <div>{{>userLink fighter.manager}}</div>
+            <a href="{{managerUrl fighter.manager}}">{{managerName fighter.manager}}</a>
           </td>
           <td class="text-right px-1 text-truncate">
             {{getAttributeNumber fighter 'hp'}}

--- a/client/arenaInfo/arenaInfo.js
+++ b/client/arenaInfo/arenaInfo.js
@@ -372,7 +372,8 @@ Template.arenaLogList.events({
   'click [data-filter]'(event, templateInstance) {
     event.preventDefault();
     const companyId = $(event.currentTarget).attr('data-filter');
-    rCompanyId.set(companyId);
+    rFilterCompanyId.set(companyId);
+    rLogOffset.set(0);
     rFilterResultList.set([]);
     const fighterData = _.find(rFighterList.get(), (fighter) => {
       return fighter._id === companyId;

--- a/client/arenaInfo/arenaInfo.js
+++ b/client/arenaInfo/arenaInfo.js
@@ -424,12 +424,8 @@ Template.arenaLogList.events({
     rFilterCompanyId.set(companyId);
     rLogOffset.set(0);
     rFilterResultList.set([]);
-    const fighterData = _.find(rFighterList.get(), (fighter) => {
-      return fighter._id === companyId;
-    });
-    if (fighterData) {
-      templateInstance.$('[name="companyId"]').val(fighterData.name || '');
-    }
+    const fighterName = rFighterNameHash.get()[companyId];
+    templateInstance.$('[name="companyId"]').val(fighterName || '');
   }
 });
 
@@ -437,8 +433,14 @@ function generateFilterResult(event) {
   const searchName = $(event.currentTarget).val();
   if (searchName) {
     const searchRegExp = new RegExp(searchName);
-    const filterResultList = _.filter(rFighterList.get(), (fighter) => {
-      return searchRegExp.test(fighter.name);
+    const filterResultList = [];
+    _.each(rFighterNameHash.get(), (fighterName, companyId) => {
+      if (searchRegExp.test(fighterName)) {
+        filterResultList.push({
+          _id: companyId,
+          name: fighterName
+        });
+      }
     });
     rFilterResultList.set(filterResultList);
   }

--- a/client/arenaInfo/arenaInfo.js
+++ b/client/arenaInfo/arenaInfo.js
@@ -145,6 +145,83 @@ Template.arenaInfoNav.helpers({
   }
 });
 
+//auto load company/fighter name info
+const rFighterIdList = new ReactiveVar([]);
+const rFighterUrlHash = new ReactiveVar({});
+const rFighterNameHash = new ReactiveVar({});
+const rManagerIdList = new ReactiveVar([]);
+const rManagerUrlHash = new ReactiveVar({});
+const rManagerNameHash = new ReactiveVar({});
+Template.arenaInfo.onCreated(function() {
+  this.autorun(() => {
+    const arenaId = FlowRouter.getParam('arenaId');
+    const fighterIdList = new Set();
+    const managerIdList = new Set();
+    dbArenaFighters.find({arenaId}).forEach((fighter) => {
+      fighterIdList.add(fighter.companyId);
+      managerIdList.add(fighter.manager);
+    });
+    rFighterIdList.set([...fighterIdList]);
+    rManagerIdList.set([...managerIdList]);
+  });
+  const fighterAjaxList = [];
+  this.autorun(() => {
+    _.invoke(fighterAjaxList, 'abort');
+    fighterAjaxList.splice(0);
+    const fighterUrlHash = {};
+    const fighterNameHash = {};
+    _.each(rFighterIdList.get(), (companyId) => {
+      fighterUrlHash[companyId] = FlowRouter.path('companyDetail', {companyId});
+      const ajaxResult = $.ajax({
+        url: '/companyInfo',
+        data: {
+          id: companyId
+        },
+        dataType: 'json',
+        success: (companyData) => {
+          fighterNameHash[companyId] = companyData.name;
+        },
+        error: () => {
+          fighterNameHash[companyId] = '???';
+        }
+      });
+      fighterAjaxList.push(ajaxResult);
+    });
+    $.when(...fighterAjaxList).always(() => {
+      rFighterUrlHash.set(fighterUrlHash);
+      rFighterNameHash.set(fighterNameHash);
+    });
+  });
+  const managerAjaxList = [];
+  this.autorun(() => {
+    _.invoke(managerAjaxList, 'abort');
+    managerAjaxList.splice(0);
+    const managerUrlHash = {};
+    const managerNameHash = {};
+    _.each(rManagerIdList.get(), (userId) => {
+      managerUrlHash[userId] = FlowRouter.path('accountInfo', {userId});
+      const ajaxResult = $.ajax({
+        url: '/userInfo',
+        data: {
+          id: userId
+        },
+        dataType: 'json',
+        success: (userData) => {
+          managerNameHash[userId] = userData.name;
+        },
+        error: () => {
+          managerNameHash[userId] = '???';
+        }
+      });
+      managerAjaxList.push(ajaxResult);
+    });
+    $.when(...managerAjaxList).always(() => {
+      rManagerUrlHash.set(managerUrlHash);
+      rManagerNameHash.set(managerNameHash);
+    });
+  });
+});
+
 const rFighterSortBy = new ReactiveVar('');
 const rFighterSortDir = new ReactiveVar(-1);
 Template.arenaFighterTable.onCreated(function() {
@@ -218,6 +295,18 @@ Template.arenaFighterTable.helpers({
       }
     });
   },
+  fighterUrl(companyId) {
+    return rFighterUrlHash.get()[companyId];
+  },
+  fighterName(companyId) {
+    return rFighterNameHash.get()[companyId];
+  },
+  managerUrl(manager) {
+    return rManagerUrlHash.get()[manager];
+  },
+  managerName(manager) {
+    return rManagerNameHash.get()[manager];
+  },
   getAttributeNumber(fighter, attributeName) {
     return getAttributeNumber(attributeName, fighter[attributeName]);
   }
@@ -236,9 +325,7 @@ Template.arenaFighterTable.events({
 });
 
 const rLogOffset = new ReactiveVar(0);
-const rCompanyId = new ReactiveVar('');
-const rFighterIdList = new ReactiveVar([]);
-const rFighterList = new ReactiveVar([]);
+const rFilterCompanyId = new ReactiveVar('');
 const rFilterResultList = new ReactiveVar([]);
 inheritedShowLoadingOnSubscribing(Template.arenaLogList);
 Template.arenaLogList.onCreated(function() {
@@ -249,46 +336,8 @@ Template.arenaLogList.onCreated(function() {
     }
     const arenaId = FlowRouter.getParam('arenaId');
     if (arenaId) {
-      this.subscribe('arenaLog', arenaId, rCompanyId.get(), rLogOffset.get());
+      this.subscribe('arenaLog', arenaId, rFilterCompanyId.get(), rLogOffset.get());
     }
-  });
-  this.autorun(() => {
-    const arenaId = FlowRouter.getParam('arenaId');
-    const fighterIdList = dbArenaFighters.find({arenaId}).map((fighter) => {
-      return fighter.companyId;
-    });
-    rFighterIdList.set(fighterIdList);
-  });
-  const ajaxList = [];
-  this.autorun(() => {
-    _.invoke(ajaxList, 'abort');
-    ajaxList.splice(0);
-    const fighterList = [];
-    _.each(rFighterIdList.get(), (companyId, index) => {
-      const ajaxResult = $.ajax({
-        url: '/companyInfo',
-        data: {
-          id: companyId
-        },
-        dataType: 'json',
-        success: (companyData) => {
-          fighterList[index] = {
-            _id: companyId,
-            name: companyData.name
-          };
-        },
-        error: () => {
-          fighterList[index] = {
-            _id: companyId,
-            name: '???'
-          };
-        }
-      });
-      ajaxList.push(ajaxResult);
-    });
-    $.when(...ajaxList).always(() => {
-      rFighterList.set(fighterList);
-    });
   });
 });
 Template.arenaLogList.helpers({

--- a/db/dbArenaFighters.js
+++ b/db/dbArenaFighters.js
@@ -86,13 +86,21 @@ const schema = new SimpleSchema({
     maxCount: MAX_MANNER_SIZE,
     defaultValue: []
   },
-  'normalManner.$': String,
+  'normalManner.$': {
+    type: String,
+    min: 1,
+    max: 150
+  },
   //特殊攻擊招式表
   specialManner: {
     type: Array,
     maxCount: MAX_MANNER_SIZE,
     defaultValue: []
   },
-  'specialManner.$': String
+  'specialManner.$': {
+    type: String,
+    min: 1,
+    max: 150
+  }
 });
 dbArenaFighters.attachSchema(schema);


### PR DESCRIPTION
1.招式名稱限制150字。
2.修正篩選公司變更後，紀錄頁碼沒有跳回第一頁的bug。
3.重寫參賽者表格的參賽者與經理連結顯示方式，避免重新排序導致的錯亂。