### PR TITLE
最萌亂鬥大賽規則調整

### DIFF
--- a/client/arenaInfo/arenaInfo.js
+++ b/client/arenaInfo/arenaInfo.js
@@ -361,14 +361,12 @@ Template.arenaLogList.helpers({
   },
   logList() {
     const arenaId = FlowRouter.getParam('arenaId');
-    window.dbArenaLog = dbArenaLog;
 
     return dbArenaLog
-      .find({arenaId}, {
+      .find(arenaId, {}, {
         sort: {
           sequence: 1
-        },
-        limit: 30
+        }
       })
       .map((log) => {
         log.attackerId = log.companyId[0];

--- a/client/company/companyDetail.html
+++ b/client/company/companyDetail.html
@@ -896,6 +896,9 @@
       <div class="form-group col-12 col-lg-6">
         <div class="mb-2">
           排列優先攻擊順序：
+          <button class="btn btn-success btn-sm float-right" type="button" data-action="randomAll">
+            隨機排序<i class="fa fa-angle-double-right" aria-hidden="true"></i>
+          </button>
           <button class="btn btn-success btn-sm float-right" type="button" data-action="sortAll">
             自動排序<i class="fa fa-angle-double-right" aria-hidden="true"></i>
           </button>

--- a/client/company/companyDetail.js
+++ b/client/company/companyDetail.js
@@ -1287,13 +1287,16 @@ Template.arenaStrategyForm.helpers({
   }
 });
 Template.arenaStrategyForm.events({
+  'click [data-action="randomAll"]'(event, templateInstance) {
+    const model = templateInstance.model.get();
+    const attackSequence = rSortedAttackSequence.get();
+    const shuffledAttackSequence = _.shuffle(model.attackSequence);
+    rSortedAttackSequence.set(_.union(attackSequence, shuffledAttackSequence));
+  },
   'click [data-action="sortAll"]'(event, templateInstance) {
     const model = templateInstance.model.get();
     const attackSequence = rSortedAttackSequence.get();
-    const needSortAttackSequence = _.reject(model.attackSequence, (attackIndex) => {
-      return _.contains(rSortedAttackSequence.get(), attackIndex);
-    });
-    rSortedAttackSequence.set(_.union(attackSequence, needSortAttackSequence));
+    rSortedAttackSequence.set(_.union(attackSequence, model.attackSequence));
   },
   'click [data-add]'(event) {
     const index = parseFloat($(event.currentTarget).attr('data-add'));

--- a/client/layout/tutorial.html
+++ b/client/layout/tutorial.html
@@ -333,7 +333,7 @@
                 <li>在報名亂鬥大賽之後，所有經理人皆可自由設定參賽公司的「特殊攻擊消耗點數」、至多三個的「普通攻擊招式名稱」與至多三個的「特殊攻擊招式名稱」。</li>
                 <li>設定「特殊攻擊消耗點數」時，不可以超過角色當前的SP值總量，也不可以超過10。</li>
                 <li>在亂鬥大賽報名截止之後（經理人選舉活動之後），新任經理人將可以決定該公司的「優先攻擊順序」，對所有自身之外參賽者進行排序。</li>
-                <li><span class="text-danger">特殊注意事項</span>：在報名截止之後，系統會將所有的參賽者進行隨機排列，產生一張「預設優先攻擊順序表」作為所有參賽者的「預設優先攻擊順序」。考慮到若參賽者眾多，大多數經理人很可能不會對所有參賽者進行重新拍序，這張「預設優先攻擊順序表」將是「優先攻擊順序」與投注屬性策略的重要參考。</li>
+                <li><span class="text-danger">特殊注意事項</span>：在報名截止之後，系統會將所有的參賽者進行隨機排列，產生一張「預設優先攻擊順序表」作為所有參賽者的「預設優先攻擊順序」，這個預設攻擊順序可以在報名截止後、亂鬥結束前在最萌亂鬥大賽的資訊頁中看到。考慮到若參賽者眾多，大多數經理人很可能不會對所有參賽者進行重新拍序，這張「預設優先攻擊順序表」可以成為使用者投注的重要參考。</li>
               </ol>
               <li>
                 亂鬥程序：
@@ -346,18 +346,19 @@
                 <li>若攻擊者發動的是普通攻擊，則需要進行命中檢定以決定是否擊中防禦者。系統將決定一個<span class="text-info">1到100之間</span>的命中隨機數字，其加上攻擊者AGI後大於等於防禦者的AGI則命中成功，否則視為攻擊落空。<span class="text-danger">但是</span>若命中隨機數字<span class="text-info">大於95</span>，則無論攻防方的AGI差距多少都必然會命中。</li>
                 <li>若攻擊者發動的是普通攻擊，在命中防禦者後，將造成<span class="text-info">攻擊者ATK減去防禦者DEF</span>的傷害，<span class="text-danger">但</span>只要攻擊命中，最小也會造成<span class="text-info">1</span>點傷害。</li>
                 <li>若攻擊者發動的是特殊攻擊，那該次攻擊將無視AGI、DEF，必然對防禦者造成等同於<span class="text-info">攻擊者ATK數值</span>的傷害。</li>
-                <li>若防禦者在攻擊者攻擊之後，殘餘HP小於或等於0，則視為落敗。攻擊者將獲得<span class="text-info">防禦者各屬性的總投注金額數量</span>的收益。</li>
+                <li>若防禦者在攻擊者攻擊之後，殘餘HP小於或等於0，則視為落敗。攻擊者將獲得<span class="text-info">防禦者各屬性的總投注金額數量</span>再加上<span class="text-info">$5000</span>的收益。</li>
                 <li>已經落敗的參賽者將無法行動。</li>
                 <li>當所有存活的參賽者結束行動後，一個回合結束，所有尚且存活的參賽者將恢復<span class="text-info">1</span>點SP。</li>
-                <li>當存活者<span class="text-info">剩下一位</span>時，大賽結束。</li>
-                <li>當存活者剩下多位但戰鬥已超過<span class="text-info">500</span>回合時，大賽結束，剩餘存活者將依據殘餘HP進行排名，HP相同者將以行動順序決定先後。</li>
               </ol>
               <li>
                 排名與收益：
               </li>
               <ol>
-                <li>亂鬥大賽的優勝者收獲的<span class="text-danger">只有榮譽</span>。所有參賽者的獲利皆來自其擊倒其他參賽者獎勵，且<span class="text-danger">只有</span>最後一擊的攻擊者能夠獲得擊倒獎勵。</li>
-                <li>參賽者的參賽收益將直接算入該公司在當季度的本季營利中，並在之後的商業季度結算依照規則對經理人與董事分紅。跟投注者<span class="text-danger">沒有</span>直接關係。</li>
+                <li>亂鬥中，第一位陣亡者為最後一名，第二位陣亡者為倒數第二名，依此類推。</li>
+                <li>當存活者<span class="text-info">剩下一位</span>時，存活者為第一名，且大賽結束。</li>
+                <li>若存活者剩下多位但戰鬥已超過<span class="text-info">1000</span>回合時，大賽也會結束，剩餘存活者將依據殘餘HP進行排名，HP相同者將以行動順序決定先後。</li>
+                <li>所有參賽者除了各自的擊倒獎勵之外，亦將依照存活排名獲得排名獎勵。存活獎勵變數為<span class="text-info">所有參賽者的總投入金額</span>除以<span class="text-info">log(所有參賽者數量)</span>乘以<span class="text-info">0.177</span>。第一名可以獲得獎勵變數除以一的排名獎勵金，第二名可以獲得獎勵變數除以二的排名獎勵金，依此類推。</li>
+                <li>參賽者的參賽總收益將直接算入該公司在當季度的本季營利中，並在之後的商業季度結算依照規則對經理人與董事分紅。跟投注者<span class="text-danger">沒有</span>直接關係。</li>
               </ol>
             </ol>
           </div>
@@ -405,8 +406,7 @@
                 <li><a href="https://www.ptt.cc/bbs/ACGN_stock/M.1508997814.A.816.html" target="_blank">高價釋股調整</a></li>
                 <li><a href="https://www.ptt.cc/bbs/ACGN_stock/M.1508953441.A.0B4.html" target="_blank">公司管理法</a></li>
                 <li><a href="https://www.ptt.cc/bbs/ACGN_stock/M.1509118436.A.3FA.html" target="_blank">高價釋股再次調整</a></li>
-                <li><a href="https://acgn-stock.com/ruleDiscuss/view/SHWDBSyGEWivx2kxs" target="_blank">未登入天數計算</a></li>
-                <li><a href="/ruleDiscuss/view/u4fC8N8LinC49ScME">員工系統</a></li>
+                <li><a href="/ruleDiscuss/list">其他系統內置規則投票</a></li>
               </ol>
               <li>要維持股市市場的健康運作，適當的人工介入是必需的，目前的金管會加入<a href="https://www.ptt.cc/bbs/ACGN_stock/M.1509025008.A.ABF.html" target="_blank">章程</a>在此，制定的規則<a href="https://docs.google.com/document/d/1INBDMg1MFOcEucdJDO57qIkTsFR7iNiZpC2JW2qoYso/edit" target="_blank">在此</a>，成員如下：</li>
               <ol>

--- a/config.js
+++ b/config.js
@@ -22,7 +22,7 @@ export const config = {
   salaryPerPay: 1000, //所有驗證通過的使用者每隔一段時間可以固定領取的薪資數量
   seasonNumberInRound: 12, //一個賽季有幾個商業季度
   arenaIntervalSeasonNumber: 1, //最萌亂鬥大賽的舉行會間隔多少個商業季度，0為每個商業季度都會舉辦一次
-  arenaMaximumRound: 500, //最萌亂鬥大賽的最大回合數
+  arenaMaximumRound: 1000, //最萌亂鬥大賽的最大回合數
   seasonTime: 604800000, //每個商業季度的持續時間，單位為微秒
   electManagerTime: 86400000, //每個商業季度結束前多久時間會進行經理競選，單位為微秒
   seasonProfitPerUser: 140000, //每個商業季度、每個驗證的使用者的「所有推薦票加總」將產生多少可能營利額

--- a/config.json
+++ b/config.json
@@ -21,7 +21,7 @@
     "salaryPerPay": 1000,
     "seasonNumberInRound": 12,
     "arenaIntervalSeasonNumber": 1,
-    "arenaMaximumRound": 500,
+    "arenaMaximumRound": 1000,
     "seasonTime": 604800000,
     "electManagerTime": 86400000,
     "seasonProfitPerUser": 140000,

--- a/db/dbArenaLog.js
+++ b/db/dbArenaLog.js
@@ -1,53 +1,83 @@
 'use strict';
+import { Meteor } from 'meteor/meteor';
 import { Mongo } from 'meteor/mongo';
-import SimpleSchema from 'simpl-schema';
+// import SimpleSchema from 'simpl-schema';
 
 //最萌亂鬥大賽紀錄資料集
-export const dbArenaLog = new Mongo.Collection('arenaLog', {
-  idGeneration: 'MONGO'
-});
-export default dbArenaLog;
+const collectionHash = {};
+export const dbArenaLog = {
+  getCollectionName(arenaId) {
+    return `arenaLog${arenaId}`;
+  },
+  getCollection(arenaId) {
+    if (! collectionHash[arenaId]) {
+      const collectionName = this.getCollectionName(arenaId);
+      const collection = new Mongo.Collection(collectionName, {
+        idGeneration: 'MONGO'
+      });
+      collectionHash[arenaId] = collection;
+    }
 
-const schema = new SimpleSchema({
-  //對應的大賽id
-  arenaId: {
-    type: String
+    return collectionHash[arenaId];
   },
-  //紀錄的順序
-  sequence: {
-    type: SimpleSchema.Integer
+  create(arenaId) {
+    if (collectionHash[arenaId]) {
+      throw new Meteor.Error(500, `重複建立已存在的arena log collection arenaLog${arenaId}！`);
+    }
+    const collection = this.getCollection(arenaId);
+    // 加schema好像沒啥意義?  Bulk insert的不會被SimpleSchema檢查到
+    // collection.attachSchema(schema);
+    collection.rawCollection().createIndex(
+      {
+        sequence: 1
+      },
+      {
+        unique: true
+      }
+    );
+
+    return collection.rawCollection().initializeUnorderedBulkOp();
   },
-  //紀錄的回合數
-  round: {
-    type: SimpleSchema.Integer
-  },
-  //紀錄相關的公司ID陣列, 0為攻擊者, 1為防禦者
-  companyId: {
-    type: Array
-  },
-  'companyId.$': {
-    type: String
-  },
-  //紀錄攻擊者使用的招式index，正數-1對應dbArenaFighters資料集的normalManner陣列index，負數+1對應specialManner的陣列index
-  attackManner: {
-    type: SimpleSchema.Integer
-  },
-  //紀錄當次攻擊動作造成的傷害，0為未命中
-  damage: {
-    type: SimpleSchema.Integer
-  },
-  //紀錄攻擊者發動攻擊時的sp
-  attackerSp: {
-    type: SimpleSchema.Integer
-  },
-  //紀錄防禦者被攻擊後的hp
-  defenderHp: {
-    type: SimpleSchema.Integer
-  },
-  //紀錄若防禦者被擊倒，攻擊者得到的收益
-  profit: {
-    type: SimpleSchema.Integer,
-    optional: true
+  find(arenaId, filter = {}, options = {}) {
+    return this.getCollection(arenaId).find(filter, options);
   }
-});
-dbArenaLog.attachSchema(schema);
+};
+
+// const schema = new SimpleSchema({
+//   //紀錄的順序
+//   sequence: {
+//     type: SimpleSchema.Integer
+//   },
+//   //紀錄的回合數
+//   round: {
+//     type: SimpleSchema.Integer
+//   },
+//   //紀錄相關的公司ID陣列, 0為攻擊者, 1為防禦者
+//   companyId: {
+//     type: Array
+//   },
+//   'companyId.$': {
+//     type: String
+//   },
+//   //紀錄攻擊者使用的招式index，正數-1對應dbArenaFighters資料集的normalManner陣列index，負數+1對應specialManner的陣列index
+//   attackManner: {
+//     type: SimpleSchema.Integer
+//   },
+//   //紀錄當次攻擊動作造成的傷害，0為未命中
+//   damage: {
+//     type: SimpleSchema.Integer
+//   },
+//   //紀錄攻擊者發動攻擊時的sp
+//   attackerSp: {
+//     type: SimpleSchema.Integer
+//   },
+//   //紀錄防禦者被攻擊後的hp
+//   defenderHp: {
+//     type: SimpleSchema.Integer
+//   },
+//   //紀錄若防禦者被擊倒，攻擊者得到的收益
+//   profit: {
+//     type: SimpleSchema.Integer,
+//     optional: true
+//   }
+// });

--- a/db/migrate.js
+++ b/db/migrate.js
@@ -6,7 +6,6 @@ import { Migrations } from 'meteor/percolate:migrations';
 import { dbAdvertising } from './dbAdvertising';
 import { dbArena } from '/db/dbArena';
 import { dbArenaFighters } from '/db/dbArenaFighters';
-import { dbArenaLog } from '/db/dbArenaLog';
 import { dbCompanies } from './dbCompanies';
 import { dbCompanyArchive } from './dbCompanyArchive';
 import { dbDirectors } from './dbDirectors';
@@ -604,15 +603,6 @@ if (Meteor.isServer) {
         {
           arenaId: 1,
           companyId: 1
-        },
-        {
-          unique: true
-        }
-      );
-      dbArenaLog.rawCollection().createIndex(
-        {
-          arenaId: 1,
-          sequence: 1
         },
         {
           unique: true

--- a/server/publications/arena/arenaLog.js
+++ b/server/publications/arena/arenaLog.js
@@ -11,15 +11,16 @@ Meteor.publish('arenaLog', function(arenaId, companyId, offset) {
   check(companyId, String);
   check(offset, Match.Integer);
 
-  const filter = { arenaId };
+  const filter = {};
   if (companyId) {
     filter.companyId = companyId;
   }
 
-  publishTotalCount('totalCountOfArenaLog', dbArenaLog.find(filter), this);
+  publishTotalCount('totalCountOfArenaLog', dbArenaLog.find(arenaId, filter), this);
 
+  const collectionName = dbArenaLog.getCollectionName(arenaId);
   const pageObserver = dbArenaLog
-    .find(filter, {
+    .find(arenaId, filter, {
       sort: {
         sequence: 1
       },
@@ -29,13 +30,13 @@ Meteor.publish('arenaLog', function(arenaId, companyId, offset) {
     })
     .observeChanges({
       added: (id, fields) => {
-        this.added('arenaLog', id, fields);
+        this.added(collectionName, id, fields);
       },
       changed: (id, fields) => {
-        this.changed('arenaLog', id, fields);
+        this.changed(collectionName, id, fields);
       },
       removed: (id) => {
-        this.removed('arenaLog', id);
+        this.removed(collectionName, id);
       }
     });
 


### PR DESCRIPTION
1.優化最萌亂鬥大賽的戰鬥紀錄存取機制，並將最大戰鬥回合數增加到1000回合。
2.經理人決策增加隨機排序按鈕。
3.增加擊倒獎勵。
4.增加排名獎勵。