### PR TITLE
修正亂鬥大賽排名獎金與只有一人參賽時的運算

### DIFF
--- a/server/arena.js
+++ b/server/arena.js
@@ -130,8 +130,8 @@ export function startArenaFight() {
       return arenaFighter;
     });
 
-  // 實際參賽人數不足兩人，不開打
-  if (fighterListBySequence.length < 2) {
+  // 實際參賽人數不足一人，直接結束大賽運算
+  if (fighterListBySequence.length < 1) {
     dbArena.update(arenaId, {
       $set: {
         winnerList: [],
@@ -251,7 +251,7 @@ export function startArenaFight() {
   //取的排名列表
   const winnerList = sortedWinnerIdList.concat(loser.reverse());
   //計算排名獎勵
-  const rankReward = allFighterTotalInvest / (Math.log(winnerList.length) + 0.57722 + (1 / (2 * winnerList.length)));
+  const rankReward = 0.177 * allFighterTotalInvest / (Math.log(winnerList.length) + 0.57722 + (1 / (2 * winnerList.length)));
   _.each(winnerList, (companyId, index) => {
     const rank = index + 1;
     gainProfitHash[companyId] += Math.floor(rankReward / rank);


### PR DESCRIPTION
1. 當只有一人參賽時，仍然完整跑完整個大賽流程
2. 大賽排名獎金補上缺少的 0.177 常數項