### PR TITLE
關閉 meteor/eventmap-params 規則，避免 eslint crash

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,6 +24,7 @@
     "import/resolver": "meteor"
   },
   "rules": {
+    "meteor/eventmap-params": "off",
     "import/prefer-default-export": "off",
     "import/order": ["error", {
       "newlines-between": "ignore"


### PR DESCRIPTION
``eslint-plugin-meteor`` 的 ``eventmap-params`` 規則遇到 object spread 時會 crash

因為此規則似乎只能檢查 ``Template.xxx.events`` call 中 object literal 的 function 參數名稱
以其他 mixin 方式來寫，無法被這個規則檢查到，所以決定直接停用此規則