### PR TITLE
增加產品消費券與消費回饋金機制

### DIFF
--- a/client/accountInfo/accountInfo.html
+++ b/client/accountInfo/accountInfo.html
@@ -161,6 +161,9 @@
       帳號當前餘額：{{currencyFormat this.profile.money}}
     </div>
     <div>
+      帳號剩餘消費券：{{currencyFormat this.profile.vouchers}}
+    </div>
+    <div>
       帳號剩餘推薦票：{{this.profile.voteTickets}}
     </div>
     {{#if this.profile.isInVacation}}

--- a/client/company/companyProductCenterPanel.html
+++ b/client/company/companyProductCenterPanel.html
@@ -12,7 +12,14 @@
     <div class="col-12 d-flex flex-wrap align-items-baseline">
       <h4 class="mr-2">當季產品販賣區</h4>
       {{#if currentUser}}
-        <div>您的剩餘購買額度：${{currencyFormat currentUserTradeQuota}}</div>
+        <div>
+          <span>您的購買額度：</span>
+          <div class="d-inline-flex flex-wrap">
+            <span>已用 ${{currencyFormat currentUserSpentTradeQuota}}</span>
+            <span class="mx-2">/</span>
+            <span>剩餘 ${{currencyFormat currentUserAvailableTradeQuota}}</span>
+          </div>
+        </div>
       {{/if}}
     </div>
     <div class="col-12">

--- a/client/company/companyProductCenterPanel.js
+++ b/client/company/companyProductCenterPanel.js
@@ -5,7 +5,7 @@ import { FlowRouter } from 'meteor/kadira:flow-router';
 
 import { dbCompanies } from '/db/dbCompanies';
 import { dbProducts } from '/db/dbProducts';
-import { getAvailableProductTradeQuota } from '/db/dbUserOwnedProducts';
+import { getAvailableProductTradeQuota, getSpentProductTradeQuota } from '/db/dbUserOwnedProducts';
 import { inheritedShowLoadingOnSubscribing } from '../layout/loading';
 
 inheritedShowLoadingOnSubscribing(Template.companyProductCenterPanel);
@@ -44,7 +44,16 @@ Template.companyProductCenterPanel.helpers({
   company() {
     return Template.instance().getCompany();
   },
-  currentUserTradeQuota() {
+  currentUserSpentTradeQuota() {
+    const templateInstance = Template.instance();
+    const { _id: companyId } = templateInstance.getCompany();
+
+    return getSpentProductTradeQuota({
+      userId: Meteor.userId(),
+      companyId
+    });
+  },
+  currentUserAvailableTradeQuota() {
     const templateInstance = Template.instance();
     const { _id: companyId } = templateInstance.getCompany();
 

--- a/client/layout/nav.html
+++ b/client/layout/nav.html
@@ -19,6 +19,12 @@
             </span>
             {{currencyFormat currentUser.profile.money}}
           </div>
+          <div title="現有消費券：{{currentUser.profile.vouchers}}張">
+            <span class="float-left">
+              <i class="fa fa-money" aria-hidden="true"></i>
+            </span>
+            {{currencyFormat currentUser.profile.vouchers}}
+          </div>
           <div title="現有推薦票：{{currentUser.profile.voteTickets}}張">
             <span class="float-left">
               <i class="fa fa-ticket" aria-hidden="true"></i>

--- a/client/layout/tutorial.html
+++ b/client/layout/tutorial.html
@@ -164,11 +164,13 @@
               <li>產品的販售：
                 <ul>
                   <li>產品販售期間，在參考價格變動時，會隨機上架補充一定數量供人購買；在商業季度結束前{{productFinalSaleHours}}小時，進行最後出清，把所有可上架的數量全部上架。</li>
+                  <li>除了使用現金之外，在每個商業季度中，每位玩家會有${{currencyFormat productVoucherAmount}}額度的消費券供產品購買使用，購買產品時將優先使用消費券。</li>
                   <li>玩家只能購買有剩餘數量的產品，若是數量不足則需等待下次補貨。</li>
                   <li>玩家可在自己的帳號資訊下，檢視自己持有哪些產品。</li>
                   <li>使用者在同一商業季度的同一間公司裡，購買的總額度不得超過公司資本額的10%。</li>
                   <li>產品售出時，公司將得到產品成本的{{productProfitFactor}}倍作為營利額。</li>
                   <li>在進入下一個商業季度時，產品將停止販售。</li>
+                  <li>玩家在一間公司消費每滿${{currencyFormat productRebateDivisorAmount}}，在商業季度結算時，可得${{currencyFormat productRebateDeliverAmount}}的產品消費回饋。</li>
                 </ul>
               </li>
               <li>每個商業季度開始時，玩家會得到與公司總數成正比的推薦票，讓玩家投票選出自己所喜愛的產品。</li>

--- a/client/layout/tutorial.js
+++ b/client/layout/tutorial.js
@@ -46,5 +46,14 @@ Template.tutorial.helpers({
   },
   employeeProductVotingRewardPercentage() {
     return Meteor.settings.public.employeeProductVotingRewardFactor * 100;
+  },
+  productVoucherAmount() {
+    return Meteor.settings.public.productVoucherAmount;
+  },
+  productRebateDivisorAmount() {
+    return Meteor.settings.public.productRebates.divisorAmount;
+  },
+  productRebateDeliverAmount() {
+    return Meteor.settings.public.productRebates.deliverAmount;
   }
 });

--- a/client/product/productCard.js
+++ b/client/product/productCard.js
@@ -5,6 +5,7 @@ import { $ } from 'meteor/jquery';
 import { dbProducts } from '/db/dbProducts';
 import { getAvailableProductTradeQuota } from '/db/dbUserOwnedProducts';
 import { voteProduct } from '../utils/methods';
+import { currencyFormat } from '../utils/helpers';
 import { alertDialog } from '../layout/alertDialog';
 
 Template.productCard.helpers({
@@ -58,7 +59,9 @@ Template.productCard.events({
       return;
     }
 
-    if (Meteor.user().profile.money < price) {
+    const { money, vouchers } = Meteor.user().profile;
+    const spendables = money + vouchers;
+    if (spendables < price) {
       alertDialog.alert('您的剩餘現金不足！');
 
       return;
@@ -72,15 +75,15 @@ Template.productCard.events({
 
     const maxAmount = Math.min(
       availableAmount,
-      Math.floor(Meteor.user().profile.money / price),
+      Math.floor(spendables / price),
       Math.floor(tradeQuota / price));
 
     alertDialog.dialog({
       type: 'prompt',
       inputType: 'number',
-      title: '購買產品',
+      title: '購買產品 - 輸入數量',
       message: `請輸入數量：(1~${maxAmount})`,
-      callback: function(result) {
+      callback: (result) => {
         if (! result) {
           return;
         }
@@ -93,7 +96,29 @@ Template.productCard.events({
           return;
         }
 
-        Meteor.customCall('buyProduct', { productId, amount });
+        const totalCost = amount * price;
+        const voucherCost = Math.min(totalCost, vouchers);
+        const moneyCost = totalCost - voucherCost;
+
+        const costMessageList = [];
+        if (voucherCost > 0) {
+          costMessageList.push(`消費券$${currencyFormat(voucherCost)}`);
+        }
+        if (moneyCost > 0) {
+          costMessageList.push(`現金$${currencyFormat(moneyCost)}`);
+        }
+
+        alertDialog.confirm({
+          title: '購買產品 - 確認花費',
+          message: `確定要花費${costMessageList.join('以及')}來購買產品？`,
+          callback: (confirmResult) => {
+            if (! confirmResult) {
+              return;
+            }
+
+            Meteor.customCall('buyProduct', { productId, amount });
+          }
+        });
       }
     });
   }

--- a/client/utils/displayLog.js
+++ b/client/utils/displayLog.js
@@ -203,7 +203,17 @@ Template.displayLog.helpers({
         return `【推薦產品】${users[0]}向「${company}」公司的產品「${productSpan(data.productId)}」投了一張推薦票！`;
       }
       case '購買產品': {
-        return `【購買產品】${users[0]}花費$${currencyFormat(data.cost)}買了「${company}」公司的產品「${productSpan(data.productId)}」共${data.amount}個，使該公司獲得了$${currencyFormat(data.profit)}的營利額！`;
+        const { voucherCost, moneyCost } = data;
+        const costMessageList = [];
+
+        if (voucherCost > 0) {
+          costMessageList.push(`消費券$${currencyFormat(voucherCost)}`);
+        }
+        if (moneyCost > 0) {
+          costMessageList.push(`現金$${currencyFormat(moneyCost)}`);
+        }
+
+        return `【購買產品】${users[0]}花費${costMessageList.join('以及')}買了「${company}」公司的產品「${productSpan(data.productId)}」共${data.amount}個，使該公司獲得了$${currencyFormat(data.profit)}的營利額！`;
       }
       case '員工營利': {
         return `【員工營利】${users.join('、')}等人努力工作，使「${company}」公司獲得了$${currencyFormat(data.profit)}的營利額！`;
@@ -218,6 +228,9 @@ Template.displayLog.helpers({
         const source = companyId ? `「${company}」公司` : '系統';
 
         return `【推薦回饋】${source}向${users[0]}發給了產品投票回饋金$${currencyFormat(data.reward)}！`;
+      }
+      case '消費回饋': {
+        return `【消費回饋】${users[0]}得到了「${company}」公司的產品消費回饋金$${currencyFormat(data.rebate)}！`;
       }
       case '季度賦稅': {
         return `【季度賦稅】${users[0]}在此次商業季度中產生了$${currencyFormat(data.assetTax)}的財富稅與$${currencyFormat(data.zombieTax)}的殭屍稅！`;

--- a/config.js
+++ b/config.js
@@ -60,6 +60,11 @@ export const config = {
   productFinalSaleTime: 43200000, // 產品最後出清時間 (ms)
   productProfitFactor: 2.00, // 產品售出的營利乘數
   systemProductVotingReward: 4096, // 系統派發的推薦票回饋金
-  employeeProductVotingRewardFactor: 0.01 // 員工投推薦票的回饋金比例
+  employeeProductVotingRewardFactor: 0.01, // 員工投推薦票的回饋金比例
+  productVoucherAmount: 7000, // 產品消費券的數量
+  productRebates: { // 產品滿額回饋設定
+    divisorAmount: 3500, // 滿額條件
+    deliverAmount: 100 // 每達成一次滿額條件可得回饋
+  }
 };
 export default config;

--- a/config.json
+++ b/config.json
@@ -58,6 +58,11 @@
     "productFinalSaleTime": 43200000,
     "productProfitFactor": 2.00,
     "systemProductVotingReward": 4096,
-    "employeeProductVotingRewardFactor": 0.01
+    "employeeProductVotingRewardFactor": 0.01,
+    "productVoucherAmount": 7000,
+    "productRebates": {
+      "divisorAmount": 3500,
+      "deliverAmount": 100
+    }
   }
 }

--- a/db/dbLog.js
+++ b/db/dbLog.js
@@ -149,7 +149,7 @@ export const logTypeList = [
   '推薦產品',
 
   /**
-   * 【購買產品】userId0花費$data.cost買了「companyId」公司的產品「data.productId」共data.amount個，使該公司獲得了$data.profit的營利額！`;
+   * 【購買產品】userId0花費(消費券$data.voucherCost)?(以及)?(現金$data.moneyCost)?買了「companyId」公司的產品「data.productId」共data.amount個，使該公司獲得了$data.profit的營利額！`;
    */
   '購買產品',
 
@@ -172,6 +172,11 @@ export const logTypeList = [
    * 【推薦回饋】(「companyId」公司 || 系統)發給了userId0產品投票回饋金$data.reward！
    */
   '推薦回饋',
+
+  /**
+   * 【消費回饋】userId0得到了「companyId」公司的產品消費回饋金$data.rebate！
+   */
+  '消費回饋',
 
   /**
    * 【季度賦稅】userId0在此次商業季度中產生了$data.assetTax的財富稅與$data.zombieTax的殭屍稅！

--- a/db/dbUserOwnedProducts.js
+++ b/db/dbUserOwnedProducts.js
@@ -43,18 +43,24 @@ const schema = new SimpleSchema({
 });
 dbUserOwnedProducts.attachSchema(schema);
 
-// 取得使用者對公司的剩餘購買額度
-export function getAvailableProductTradeQuota({ userId, companyId }) {
+// 取得使用者對公司已使用的購買額度（以當季商品持有總額代表）
+export function getSpentProductTradeQuota({ userId, companyId }) {
   const { _id: seasonId } = getCurrentSeason();
-  const { capital } = dbCompanies.findOne(companyId, { fields: { capital: 1 } });
 
-  const initialQuota = Math.ceil(capital * 0.1);
-  const spentQuota = dbUserOwnedProducts
+  return dbUserOwnedProducts
     .find({ seasonId, companyId, userId }, { fields: { price: 1, amount: 1 } })
     .fetch()
     .reduce((sum, { price, amount }) => {
       return sum + price * amount;
     }, 0);
+}
+
+// 取得使用者對公司的剩餘購買額度
+export function getAvailableProductTradeQuota({ userId, companyId }) {
+  const { capital } = dbCompanies.findOne(companyId, { fields: { capital: 1 } });
+
+  const initialQuota = Math.ceil(capital * 0.1);
+  const spentQuota = getSpentProductTradeQuota({ userId, companyId });
 
   return initialQuota - spentQuota;
 }

--- a/db/migrate.js
+++ b/db/migrate.js
@@ -1250,6 +1250,23 @@ if (Meteor.isServer) {
     }
   });
 
+  Migrations.add({
+    version: 18,
+    name: 'add product vouchers',
+    up() {
+      // 配給現有使用者消費券數量
+      Meteor.users.rawCollection().update({}, {
+        $set: { 'profile.vouchers': Meteor.settings.public.productVoucherAmount }
+      }, { multi: true });
+
+      // 購買產品紀錄的花費欄位擴增為現金與消費券兩個
+      dbLog.rawCollection().update({ logType: '購買產品', cost: { $exists: true } }, {
+        $rename: { 'data.cost': 'data.moneyCost' },
+        $set: { 'data.voucherCost': 0 }
+      });
+    }
+  });
+
   Meteor.startup(() => {
     Migrations.migrateTo('latest');
   });

--- a/db/users.js
+++ b/db/users.js
@@ -79,6 +79,12 @@ const schema = new SimpleSchema({
         min: 0,
         defaultValue: 0
       },
+      // 消費券的數量
+      vouchers: {
+        type: SimpleSchema.Integer,
+        min: 0,
+        defaultValue: Meteor.settings.public.productVoucherAmount
+      },
       // 各類石頭的數量
       stones: {
         type: new SimpleSchema(stoneTypeList.reduce((obj, stoneType) => {

--- a/server/functions/product/deliverProductRebates.js
+++ b/server/functions/product/deliverProductRebates.js
@@ -1,0 +1,66 @@
+import { Meteor } from 'meteor/meteor';
+import { _ } from 'meteor/underscore';
+
+import { dbUserOwnedProducts } from '/db/dbUserOwnedProducts';
+import { dbLog } from '/db/dbLog';
+import { getCurrentSeason } from '/db/dbSeason';
+
+// 發放產品滿額回饋金給使用者
+export function deliverProductRebates() {
+  const { divisorAmount, deliverAmount } = Meteor.settings.public.productRebates;
+
+  const { _id: seasonId } = getCurrentSeason();
+
+  const rebateList = dbUserOwnedProducts
+    .aggregate([ {
+      $match: { seasonId }
+    }, {
+      $lookup: {
+        from: 'companies',
+        localField: 'companyId',
+        foreignField: '_id',
+        as: 'companyData'
+      }
+    }, {
+      $unwind: '$companyData'
+    }, {
+      $match: { 'companyData.isSeal': false }
+    }, {
+      $group: {
+        _id: { userId: '$userId', companyId: '$companyId' },
+        totalCost: { $sum: { $multiply: ['$amount', '$price'] } }
+      }
+    }, {
+      $project: {
+        rebate: { $multiply: [deliverAmount, { $floor: { $divide: ['$totalCost', divisorAmount] } } ] }
+      }
+    }, {
+      $match: { rebate: { $gt: 0 } }
+    } ]);
+
+  if (_.isEmpty(rebateList)) {
+    return;
+  }
+
+  const userBulk = Meteor.users.rawCollection().initializeUnorderedBulkOp();
+  const logBulk = dbLog.rawCollection().initializeUnorderedBulkOp();
+  const logSchema = dbLog.simpleSchema();
+
+  const nowDate = new Date();
+
+  rebateList.forEach(({ _id: { userId, companyId }, rebate }) => {
+    userBulk.find({ _id: userId }).updateOne({ $inc: { 'profile.money': rebate } });
+    const logData = logSchema.clean({
+      logType: '消費回饋',
+      userId: [userId],
+      companyId,
+      data: { rebate },
+      createdAt: nowDate
+    });
+    logSchema.validate(logData);
+    logBulk.insert(logData);
+  });
+
+  Meteor.wrapAsync(userBulk.execute, userBulk)();
+  Meteor.wrapAsync(logBulk.execute, logBulk)();
+}

--- a/server/intervalCheck.js
+++ b/server/intervalCheck.js
@@ -41,6 +41,7 @@ import { countDownRecordListPrice } from './functions/company/recordListPrice';
 import { countDownCheckChairman } from './functions/company/checkChairman';
 import { updateCompanyGrades } from './functions/company/updateCompanyGrades';
 import { deliverProductVotingRewards } from './functions/season/deliverProductVotingRewards';
+import { deliverProductRebates } from './functions/product/deliverProductRebates';
 import { returnCompanyStones } from './functions/miningMachine/returnCompanyStones';
 import { generateMiningProfits } from './functions/miningMachine/generateMiningProfits';
 import { rotateProducts } from './functions/product/rotateProducts';
@@ -163,6 +164,8 @@ export function doRoundWorks(lastRoundData, lastSeasonData) {
     giveBonusByStocksFromProfit();
     // 發放推薦票回饋金
     deliverProductVotingRewards();
+    // 發放產品購買回饋金
+    deliverProductRebates();
     // 更新所有公司的評級
     updateCompanyGrades();
     // 更新所有公司的生產資金
@@ -269,6 +272,8 @@ export function doSeasonWorks(lastRoundData, lastSeasonData) {
     giveBonusByStocksFromProfit();
     // 發放推薦票回饋金
     deliverProductVotingRewards();
+    // 發放產品購買回饋金
+    deliverProductRebates();
     // 更新所有公司的評級
     updateCompanyGrades();
     // 更新所有公司的生產資金
@@ -524,7 +529,12 @@ function generateNewSeason() {
   const seasonData = getCurrentSeason();
   const voteTickets = getInitialVoteTicketCount(seasonData);
 
-  Meteor.users.update({}, { $set: { 'profile.voteTickets': voteTickets } }, { multi: true });
+  Meteor.users.update({}, {
+    $set: {
+      'profile.vouchers': Meteor.settings.public.productVoucherAmount,
+      'profile.voteTickets': voteTickets
+    }
+  }, { multi: true });
   // 產品輪替
   rotateProducts();
   // 排程最後出清時間

--- a/server/startup/accountsOnCreateUserHook.js
+++ b/server/startup/accountsOnCreateUserHook.js
@@ -9,12 +9,14 @@ import { debug } from '/server/imports/utils/debug';
 Accounts.onCreateUser((options, user) => {
   debug.log('onCreateUser', options);
 
-  const { newUserInitialMoney, newUserBirthStones } = Meteor.settings.public;
+  const { newUserInitialMoney, newUserBirthStones, productVouchers } = Meteor.settings.public;
 
+  // TODO: 使用 SimpleSchema 的 clean 自動取得預設值
   user.profile = _.defaults({}, options.profile, {
     money: newUserInitialMoney,
     lastSeasonTotalWealth: 0,
     voteTickets: 0,
+    productVouchers,
     stones: { birth: newUserBirthStones },
     isAdmin: false,
     ban: [],


### PR DESCRIPTION
此為 https://acgn-stock.com/ruleDiscuss/view/wyocofM8vqkE9i4mW 提案中
「回饋金與消費券」這部分的實作

1. 增加 productVoucherAmount 設定，新玩家或換季時將會補充消費券至此數量
2. migration: 現存使用者將直接得到 productVoucherAmount 數量的消費券
3. 產品購買時追加花費確認，讓玩家知道將會花掉的消費券和現金數量
4. 「購買產品」紀錄增加消費券顯示，原本的花費將移至現金顯示
5. 個人產品購買額度新增已用額度的顯示
6. 遊戲規則增加產品消費回饋金與消費券的說明