### PR TITLE
重整帳號資訊相關程式碼

### DIFF
--- a/client/accountInfo/accountInfo.html
+++ b/client/accountInfo/accountInfo.html
@@ -1,32 +1,32 @@
 <template name="accountInfo">
   <div class="card">
-    {{#with lookUser}}
+    {{#with paramUser}}
       {{> accountInfoBasic}}
       <div class="card-block">
         <div class="row border-grid-body">
           <div class="col-12 border-grid">
             {{#panelFolder name='tax' title='稅務資訊' }}
-              {{> accountInfoTaxList user=this}}
+              {{> accountInfoTaxList}}
             {{/panelFolder}}
           </div>
           <div class="col-12 border-grid">
             {{#panelFolder name='ownStock' title='持股資訊' }}
-              {{> accountInfoOwnStockList user=this}}
+              {{> accountInfoOwnStockList}}
             {{/panelFolder}}
           </div>
           <div class="col-12 border-grid">
             {{#panelFolder name='stone' title='石頭資訊' }}
-              {{> accountInfoStonePanel user=this}}
+              {{> accountInfoStonePanel}}
             {{/panelFolder}}
           </div>
           <div class="col-12 border-grid">
             {{#panelFolder name='ownedProducts' title='持有產品' }}
-              {{> accountInfoOwnedProductsPanel user=this}}
+              {{> accountInfoOwnedProductsPanel}}
             {{/panelFolder}}
           </div>
           <div class="col-12 border-grid">
             {{#panelFolder name='log' title='玩家紀錄' }}
-              {{> accountLogViewer user=this}}
+              {{> accountLogViewer}}
             {{/panelFolder}}
           </div>
         </div>

--- a/client/accountInfo/accountInfoOwnStockList.js
+++ b/client/accountInfo/accountInfoOwnStockList.js
@@ -3,6 +3,7 @@ import { ReactiveVar } from 'meteor/reactive-var';
 
 import { dbDirectors } from '/db/dbDirectors';
 import { inheritedShowLoadingOnSubscribing } from '../layout/loading';
+import { paramUserId } from './helpers';
 
 inheritedShowLoadingOnSubscribing(Template.accountInfoOwnStockList);
 
@@ -10,7 +11,7 @@ Template.accountInfoOwnStockList.onCreated(function() {
   this.ownStocksOffset = new ReactiveVar(0);
 
   this.autorun(() => {
-    const { user: { _id: userId } } = Template.instance().data;
+    const userId = paramUserId();
 
     if (userId) {
       const offset = this.ownStocksOffset.get();
@@ -20,7 +21,7 @@ Template.accountInfoOwnStockList.onCreated(function() {
 });
 Template.accountInfoOwnStockList.helpers({
   directorList() {
-    const { user: { _id: userId } } = Template.instance().data;
+    const userId = paramUserId();
 
     return dbDirectors.find({ userId }, {
       limit: 10

--- a/client/accountInfo/accountInfoOwnedProductsPanel.js
+++ b/client/accountInfo/accountInfoOwnedProductsPanel.js
@@ -4,7 +4,7 @@ import { ReactiveVar } from 'meteor/reactive-var';
 
 import { dbUserOwnedProducts } from '/db/dbUserOwnedProducts';
 import { inheritedShowLoadingOnSubscribing } from '../layout/loading';
-import { accountInfoCommonHelpers } from './helpers';
+import { accountInfoCommonHelpers, paramUserId } from './helpers';
 
 inheritedShowLoadingOnSubscribing(Template.accountInfoOwnedProductsPanel);
 
@@ -12,8 +12,7 @@ Template.accountInfoOwnedProductsPanel.onCreated(function() {
   this.ownedProductsOffset = new ReactiveVar(0);
 
   this.autorunWithIdleSupport(() => {
-    const { user: { _id: userId } } = Template.instance().data;
-
+    const userId = paramUserId();
     if (userId) {
       const offset = this.ownedProductsOffset.get();
       this.subscribe('userOwnedProducts', { userId, offset });
@@ -24,9 +23,7 @@ Template.accountInfoOwnedProductsPanel.onCreated(function() {
 Template.accountInfoOwnedProductsPanel.helpers({
   ...accountInfoCommonHelpers,
   ownedProducts() {
-    const { user: { _id: userId } } = Template.instance().data;
-
-    return dbUserOwnedProducts.find({ userId });
+    return dbUserOwnedProducts.find({ userId: paramUserId() });
   },
   paginationData() {
     return {

--- a/client/accountInfo/accountInfoStonePanel.js
+++ b/client/accountInfo/accountInfoStonePanel.js
@@ -6,7 +6,7 @@ import { dbCompanyStones, stoneTypeList, stonePowerTable } from '/db/dbCompanySt
 import { inheritedShowLoadingOnSubscribing } from '../layout/loading';
 import { alertDialog } from '../layout/alertDialog';
 import { stoneDisplayName } from '../utils/helpers';
-import { accountInfoCommonHelpers } from './helpers';
+import { accountInfoCommonHelpers, paramUserId, paramUser } from './helpers';
 
 inheritedShowLoadingOnSubscribing(Template.accountInfoStonePanel);
 
@@ -14,8 +14,7 @@ Template.accountInfoStonePanel.onCreated(function() {
   this.placedStonesOffset = new ReactiveVar(0);
 
   this.autorunWithIdleSupport(() => {
-    const { user: { _id: userId } } = Template.instance().data;
-
+    const userId = paramUserId();
     if (userId) {
       const offset = this.placedStonesOffset.get();
       this.subscribe('userPlacedStones', { userId, offset });
@@ -26,9 +25,7 @@ Template.accountInfoStonePanel.onCreated(function() {
 Template.accountInfoStonePanel.helpers({
   ...accountInfoCommonHelpers,
   placedStones() {
-    const { user: { _id: userId } } = Template.instance().data;
-
-    return dbCompanyStones.find({ userId });
+    return dbCompanyStones.find({ userId: paramUserId() });
   },
   stoneTypeList() {
     return stoneTypeList;
@@ -43,9 +40,7 @@ Template.accountInfoStonePanel.helpers({
     return Meteor.settings.public.stonePrice[stoneType];
   },
   userStoneCount(stoneType) {
-    const { user } = Template.instance().data;
-
-    return user.profile.stones[stoneType] || 0;
+    return paramUser().profile.stones[stoneType] || 0;
   },
   paginationData() {
     return {

--- a/client/accountInfo/accountInfoTaxList.js
+++ b/client/accountInfo/accountInfoTaxList.js
@@ -8,7 +8,7 @@ import { dbTaxes } from '/db/dbTaxes';
 import { inheritedShowLoadingOnSubscribing } from '../layout/loading';
 import { alertDialog } from '../layout/alertDialog';
 import { currencyFormat } from '../utils/helpers';
-import { accountInfoCommonHelpers } from './helpers';
+import { accountInfoCommonHelpers, paramUserId, paramUser } from './helpers';
 
 inheritedShowLoadingOnSubscribing(Template.accountInfoTaxList);
 
@@ -16,7 +16,7 @@ Template.accountInfoTaxList.onCreated(function() {
   this.taxListOffset = new ReactiveVar(0);
 
   this.autorunWithIdleSupport(() => {
-    const { user: { _id: userId } } = Template.instance().data;
+    const userId = paramUserId();
 
     if (userId) {
       const offset = this.taxListOffset.get();
@@ -27,7 +27,7 @@ Template.accountInfoTaxList.onCreated(function() {
 Template.accountInfoTaxList.helpers({
   ...accountInfoCommonHelpers,
   taxesList() {
-    const { user: { _id: userId } } = Template.instance().data;
+    const userId = paramUserId();
 
     return dbTaxes.find({ userId }, {
       limit: 10,
@@ -49,7 +49,7 @@ Template.accountInfoTaxList.events({
     const taxId = new Mongo.ObjectID($(event.currentTarget).attr('data-pay'));
     const taxData = dbTaxes.findOne(taxId);
     if (taxData) {
-      const { user } = Template.instance().data;
+      const user = paramUser();
       const totalNeedPay = taxData.tax + taxData.zombie + taxData.fine - taxData.paid;
       const maxPayMoney = Math.min(user.profile.money, totalNeedPay);
       if (maxPayMoney < 1) {

--- a/client/accountInfo/accountLogViewer.js
+++ b/client/accountInfo/accountLogViewer.js
@@ -3,6 +3,7 @@ import { ReactiveVar } from 'meteor/reactive-var';
 
 import { dbLog, accuseLogTypeList } from '/db/dbLog';
 import { inheritedShowLoadingOnSubscribing } from '../layout/loading';
+import { paramUserId } from './helpers';
 
 const accountLogViewerMode = new ReactiveVar('accuse');
 Template.accountLogViewer.helpers({
@@ -16,7 +17,7 @@ Template.accountAccuseLogList.onCreated(function() {
   this.accuseOffset = new ReactiveVar(0);
 
   this.autorun(() => {
-    const { user: { _id: userId } } = Template.instance().data;
+    const userId = paramUserId();
 
     if (userId) {
       const offset = this.accuseOffset.get();
@@ -26,7 +27,7 @@ Template.accountAccuseLogList.onCreated(function() {
 });
 Template.accountAccuseLogList.helpers({
   accuseList() {
-    const { user: { _id: userId } } = Template.instance().data;
+    const userId = paramUserId();
 
     return dbLog.find(
       {
@@ -63,7 +64,7 @@ Template.accountInfoLogList.onCreated(function() {
   this.logOffset = new ReactiveVar(0);
 
   this.autorun(() => {
-    const { user: { _id: userId } } = Template.instance().data;
+    const userId = paramUserId();
 
     if (userId) {
       const offset = this.logOffset.get();
@@ -73,7 +74,7 @@ Template.accountInfoLogList.onCreated(function() {
 });
 Template.accountInfoLogList.helpers({
   logList() {
-    const { user: { _id: userId } } = Template.instance().data;
+    const userId = paramUserId();
 
     return dbLog.find(
       {

--- a/client/accountInfo/helpers.js
+++ b/client/accountInfo/helpers.js
@@ -1,13 +1,25 @@
 import { Meteor } from 'meteor/meteor';
 import { FlowRouter } from 'meteor/kadira:flow-router';
 
-export const accountInfoCommonHelpers = {
-  isCurrentUser() {
-    const user = Meteor.user();
-    if (user && user._id === FlowRouter.getParam('userId')) {
-      return true;
-    }
+export function paramUserId() {
+  return FlowRouter.getParam('userId');
+}
 
-    return false;
+export function paramUser() {
+  const userId = paramUserId();
+
+  return userId ? Meteor.users.findOne(userId) : null;
+}
+
+export function isCurrentUser() {
+  const currentUserId = Meteor.userId();
+  if (currentUserId && currentUserId === paramUserId()) {
+    return true;
   }
+}
+
+export const accountInfoCommonHelpers = {
+  paramUserId,
+  paramUser,
+  isCurrentUser
 };


### PR DESCRIPTION
1. 將 lookUser 提升至 helpers，並改名為 paramUser
2. 以 paramUser 與 paramUserId 取代取得目前頁面 userId 與 user 的邏輯
3. 以 paramUser 與 paramUserId 取代 Template instance data 的 user，新的 panel
不再需要 user 引數
4. 金管會通告對話框將顯示被通告的使用者名稱
5. 與 idle 相關的 autorun 使用 autorunWithIdleSupport 代替