### PR TITLE
修正因產品新制，季度報告計算上沒修改到，而計算結果與排序錯誤的問題

### DIFF
--- a/dev-utils/imports/mongo-scripts/fix-rankCompanyPrice-profit.js
+++ b/dev-utils/imports/mongo-scripts/fix-rankCompanyPrice-profit.js
@@ -1,0 +1,129 @@
+// 更新所有賽季的股票熱門排行榜資訊，補上因新制產品計算上缺失，而缺少的產品營利資訊
+
+const seasonData = db.season.find({}).sort({ beginData: 1 }).toArray();
+seasonData.pop();
+
+seasonData.forEach(({ _id: seasonId, beginDate, endDate }) => {
+  db.rankCompanyPrice.remove({ seasonId });
+
+  const productProfitMap = {};
+
+  db.products.aggregate([
+    {
+      $match: {
+        seasonId: seasonId
+      }
+    },
+    {
+      $group: {
+        _id: '$companyId',
+        totalProfit: {
+          $sum: '$profit'
+        }
+      }
+    }
+  ]).forEach((profitData) => {
+    const { _id: companyId, totalProfit } = profitData;
+
+    productProfitMap[companyId] = totalProfit;
+  });
+
+  const rankCompanyPriceList = [];
+  db.log.aggregate([
+    {
+      $match: {
+        logType: '交易紀錄',
+        createdAt: {
+          $gt: beginDate,
+          $lte: endDate
+        }
+      }
+    },
+    {
+      $project: {
+        companyId: 1,
+        dealAmount: '$data.amount',
+        dealMoney: {
+          $multiply: ['$data.amount', '$data.price']
+        }
+      }
+    },
+    {
+      $group: {
+        _id: '$companyId',
+        totalDealAmount: {
+          $sum: '$dealAmount'
+        },
+        totalDealMoney: {
+          $sum: '$dealMoney'
+        }
+      }
+    },
+    {
+      $lookup: {
+        from: 'companies',
+        localField: '_id',
+        foreignField: '_id',
+        as: 'companyData'
+      }
+    },
+    {
+      $project: {
+        _id: 1,
+        totalDealAmount: 1,
+        totalDealMoney: 1,
+        isSeal: {
+          $arrayElemAt: ['$companyData.isSeal', 0]
+        }
+      }
+    },
+    {
+      $match: {
+        isSeal: false
+      }
+    }
+  ]).forEach((dealData) => {
+    const companyId = dealData._id;
+
+    dealData.productProfit = productProfitMap[companyId] || 0;
+    dealData.totalMoney = dealData.productProfit + dealData.totalDealMoney;
+
+    rankCompanyPriceList.push(dealData);
+  });
+
+  rankCompanyPriceList.sort((prev, next) => {
+    if (next.totalMoney > prev.totalMoney) {
+      return 1;
+    }
+    else if (next.totalMoney === prev.totalMoney) {
+      if (next.productProfit > prev.productProfit) {
+        return 1;
+      }
+      else if (next.productProfit === prev.productProfit) {
+        return 0;
+      }
+      else {
+        return -1;
+      }
+    }
+    else {
+      return -1;
+    }
+  }).splice(100);
+
+  if (rankCompanyPriceList.length > 0) {
+    const rankCompanyPriceBulk = db.rankCompanyPrice.initializeUnorderedBulkOp();
+
+    rankCompanyPriceList.forEach((rankData) => {
+      rankCompanyPriceBulk.insert({
+        seasonId: seasonId,
+        companyId: rankData._id,
+        totalDealAmount: rankData.totalDealAmount,
+        totalDealMoney: rankData.totalDealMoney,
+        productProfit: rankData.productProfit
+      });
+    });
+
+    print(rankCompanyPriceBulk.execute());
+  }
+});

--- a/server/seasonRankAndTaxes.js
+++ b/server/seasonRankAndTaxes.js
@@ -3,6 +3,7 @@ import { _ } from 'meteor/underscore';
 import { Meteor } from 'meteor/meteor';
 import { dbCompanies } from '/db/dbCompanies';
 import { dbDirectors } from '/db/dbDirectors';
+import { dbProducts } from '/db/dbProducts';
 import { dbLog } from '/db/dbLog';
 import { dbRankCompanyPrice } from '/db/dbRankCompanyPrice';
 import { dbRankCompanyProfit } from '/db/dbRankCompanyProfit';
@@ -40,7 +41,31 @@ export function generateRankAndTaxesData(seasonData) {
 
 function rankCompany(seasonData) {
   if (dbCompanies.find().count() > 0) {
-    const rankCompanyPriceList = dbLog.aggregate([
+    const productProfitMap = {};
+
+    dbProducts.aggregate([
+      {
+        $match: {
+          seasonId: seasonData._id
+        }
+      },
+      {
+        $group: {
+          _id: '$companyId',
+          totalProfit: {
+            $sum: '$profit'
+          }
+        }
+      }
+    ]).forEach((profitData) => {
+      const { _id: companyId, totalProfit } = profitData;
+
+      productProfitMap[companyId] = totalProfit;
+    });
+
+    const rankCompanyPriceList = [];
+
+    dbLog.aggregate([
       {
         $match: {
           logType: '交易紀錄',
@@ -91,61 +116,35 @@ function rankCompany(seasonData) {
         $match: {
           isSeal: false
         }
-      },
-      {
-        $project: {
-          _id: 1,
-          totalDealAmount: 1,
-          totalDealMoney: 1
-        }
-      },
-      {
-        $lookup: {
-          from: 'voteRecord',
-          localField: '_id',
-          foreignField: 'companyId',
-          as: 'voteData'
-        }
-      },
-      {
-        $project: {
-          _id: 1,
-          totalDealAmount: 1,
-          totalDealMoney: 1,
-          productProfit: {
-            $multiply: [
-              {
-                $size: '$voteData'
-              },
-              seasonData.votePrice
-            ]
-          }
-        }
-      },
-      {
-        $project: {
-          _id: 1,
-          totalDealAmount: 1,
-          totalDealMoney: 1,
-          productProfit: 1,
-          totalMoney: {
-            $add: [
-              '$totalDealMoney',
-              '$productProfit'
-            ]
-          }
-        }
-      },
-      {
-        $sort: {
-          totalMoney: -1,
-          totalDealMoney: -1
-        }
-      },
-      {
-        $limit: 100
       }
-    ]);
+    ]).forEach((dealData) => {
+      const companyId = dealData._id;
+
+      dealData.productProfit = productProfitMap[companyId] || 0;
+      dealData.totalMoney = dealData.productProfit + dealData.totalDealMoney;
+
+      rankCompanyPriceList.push(dealData);
+    });
+
+    rankCompanyPriceList.sort((prev, next) => {
+      if (next.totalMoney > prev.totalMoney) {
+        return 1;
+      }
+      else if (next.totalMoney === prev.totalMoney) {
+        if (next.productProfit > prev.productProfit) {
+          return 1;
+        }
+        else if (next.productProfit === prev.productProfit) {
+          return 0;
+        }
+        else {
+          return -1;
+        }
+      }
+      else {
+        return -1;
+      }
+    }).splice(100);
 
     const rankCompanyValueList = dbCompanies
       .find(


### PR DESCRIPTION
1. 修正因產品新制，季度報告計算上沒修改到，而計算結果與排序錯誤的問題

內含一個mongo-script，執行後，會重新計算第一季到上一季的rankCompanyPrice，並覆蓋原本的結果