### PR TITLE
實作公司 VIP 機制

### DIFF
--- a/client/accountInfo/accountInfo.html
+++ b/client/accountInfo/accountInfo.html
@@ -175,6 +175,9 @@
       {{#if viewType 'employee'}}
         {{> employeeTitleList}}
       {{/if}}
+      {{#if viewType 'vip'}}
+        {{> vipTitleList}}
+      {{/if}}
     </div>
   </div>
 </template>
@@ -189,6 +192,9 @@
     </li>
     <li class="nav-item">
       <a class="{{getClass 'employee'}}" href="#" data-type="employee">員工</a>
+    </li>
+    <li class="nav-item">
+      <a class="{{getClass 'vip'}}" href="#" data-type="vip">VIP</a>
     </li>
   </ul>
 </template>
@@ -239,6 +245,15 @@
   {{else}}
     查無資料！
   {{/each}}
+</template>
+
+<template name="vipTitleList">
+  {{#each vip in vips}}
+    {{> companyTitle companyId=vip.companyId title=(getTitle vip)}}
+  {{else}}
+    查無資料！
+  {{/each}}
+  {{> pagination paginationData}}
 </template>
 
 <template name="companyTitle">

--- a/client/accountInfo/accountInfo.js
+++ b/client/accountInfo/accountInfo.js
@@ -8,6 +8,7 @@ import { ReactiveVar } from 'meteor/reactive-var';
 
 import { dbCompanies } from '/db/dbCompanies';
 import { dbEmployees } from '/db/dbEmployees';
+import { dbVips } from '/db/dbVips';
 import { inheritedShowLoadingOnSubscribing } from '../layout/loading';
 import { alertDialog } from '../layout/alertDialog';
 import { shouldStopSubscribe } from '../utils/idle';
@@ -384,5 +385,31 @@ Template.employeeTitleList.helpers({
     const companyData = dbCompanies.findOne(companyId);
 
     return companyData ? companyData.isSeal : false;
+  }
+});
+
+Template.vipTitleList.onCreated(function() {
+  this.offset = new ReactiveVar(0);
+
+  this.autorunWithIdleSupport(() => {
+    const userId = paramUserId();
+    if (userId) {
+      this.subscribe('accountVipTitle', userId, this.offset.get());
+    }
+  });
+});
+Template.vipTitleList.helpers({
+  vips() {
+    return dbVips.find({ userId: paramUserId }, { sort: { level: -1 } });
+  },
+  getTitle(vip) {
+    return `Level ${vip.level} VIP`;
+  },
+  paginationData() {
+    return {
+      useVariableForTotalCount: 'totalCountOfVipTitle',
+      dataNumberPerPage: 10,
+      offset: Template.instance().offset
+    };
   }
 });

--- a/client/company/companyDetail.html
+++ b/client/company/companyDetail.html
@@ -252,7 +252,7 @@
 
         <div class="col-6 col-md-3 col-lg-2 border-grid d-flex flex-column align-items-center justify-content-between">
           <span class="text-nowrap">本季營利</span>
-          <span class="text-nowrap">$ {{currencyFormat this.profit}}</span>
+          <span class="text-nowrap">$ {{currencyFormat (round this.profit)}}</span>
         </div>
         <div class="col-6 col-md-3 col-lg-2 border-grid d-flex flex-column align-items-center justify-content-between">
           <span class="text-nowrap">每股盈餘</span>
@@ -310,6 +310,11 @@
         {{> companyDirectorList}}
         {{> companyElectInfo}}
       {{/if}}
+      <div class="col-12 border-grid">
+        {{#panelFolder name='vipList' title='VIP名冊'}}
+          {{> companyVipListPanel}}
+        {{/panelFolder}}
+      </div>
       <div class="col-12 border-grid">
         <a class="d-block h4 my-1" href="#" data-toggle-panel="employee">
           員工名冊
@@ -463,7 +468,7 @@
 </template>
 
 <template name="companyDirectorList">
-  <div class="col-12 border-grid company-director-list">
+  <div class="col-12 border-grid grid-table">
     <div class="row mb-1">
       <div class="col-md-3 text-center text-nowrap d-none d-md-block">使用者帳號</div>
       <div class="col-md-1 text-center text-nowrap d-none d-md-block">股份數</div>
@@ -471,24 +476,24 @@
       <div class="col-md-7 text-center text-nowrap d-none d-md-block">留言</div>
     </div>
     {{#each director in directorList}}
-      <div class="row mb-1 data-row">
-        <div class="hidden-title d-block d-md-none">使用者帳號</div>
-        <div class="col-md-3 text-truncate data-content">
+      <div class="row mb-1 grid-table-row">
+        <div class="grid-table-hidden-title">使用者帳號</div>
+        <div class="col-md-3 text-truncate grid-table-content">
           {{#if isDirectorInVacation director.userId}}
             <small><span class="badge badge-info">渡假中</span></small>
           {{/if}}
           {{>userLink director.userId}}
         </div>
-        <div class="hidden-title d-block d-md-none">股份數</div>
-        <div class="col-md-1 text-right data-content" title="{{director.stocks}}">
+        <div class="grid-table-hidden-title">股份數</div>
+        <div class="col-md-1 text-right grid-table-content" title="{{director.stocks}}">
           {{director.stocks}}
         </div>
-        <div class="hidden-title d-block d-md-none">比例</div>
-        <div class="col-md-1 text-right data-content" title="{{getPercentage director.stocks}}%">
+        <div class="grid-table-hidden-title">比例</div>
+        <div class="col-md-1 text-right grid-table-content" title="{{getPercentage director.stocks}}%">
           {{getPercentage director.stocks}}%
         </div>
-        <div class="hidden-title d-block d-md-none">留言</div>
-        <div class="col-md-7 text-left data-content"
+        <div class="grid-table-hidden-title">留言</div>
+        <div class="col-md-7 text-left grid-table-content"
           style="word-break: break-all;"
           title="{{getMessage director.message}}">
           {{getMessage director.message}}
@@ -619,7 +624,7 @@
 </template>
 
 <template name="companyEmployeeList">
-  <div class="col-12 border-grid company-employee-list">
+  <div class="col-12 border-grid grid-table">
     <h4 class="my-1">
       在職員工
     </h4>
@@ -631,17 +636,17 @@
 
     <div style="max-height: 240px; overflow-y: auto; margin-left: -15px; margin-right: -15px;">
       {{#each employee in employeeList}}
-        <div class="d-flex flex-wrap mb-1 data-row">
-          <div class="hidden-title d-block d-md-none">使用者帳號</div>
-          <div class="col-md-2 text-truncate data-content">
+        <div class="d-flex flex-wrap mb-1 grid-table-row">
+          <div class="grid-table-hidden-title">使用者帳號</div>
+          <div class="col-md-2 text-truncate grid-table-content">
             {{>userLink employee.userId}}
           </div>
-          <div class="hidden-title d-block d-md-none">報名時間</div>
-          <div class="col-md-3 data-content" title="{{formatDateText employee.registerAt}}">
+          <div class="grid-table-hidden-title">報名時間</div>
+          <div class="col-md-3 grid-table-content" title="{{formatDateText employee.registerAt}}">
             {{formatDateText employee.registerAt}}
           </div>
-          <div class="hidden-title d-block d-md-none">留言</div>
-          <div class="col-md-7 data-content" title="{{showMessage employee.message}}" style="word-break: break-all;">
+          <div class="grid-table-hidden-title">留言</div>
+          <div class="col-md-7 grid-table-content" title="{{showMessage employee.message}}" style="word-break: break-all;">
             {{showMessage employee.message}}
           </div>
         </div>
@@ -672,24 +677,24 @@
       </form>
     {{/if}}
   </div>
-  <div class="col-12 border-grid company-trainee-list">
+  <div class="col-12 border-grid grid-table">
     <h4 class="my-1">
       儲備員工
     </h4>
-    <div class="row mb-1">
+    <div class="row mb-1 grid-table-head">
       <div class="col-md-2 text-center d-none d-md-block">使用者帳號</div>
       <div class="col-md-3 text-center d-none d-md-block">報名時間</div>
       <div class="col-md-7 d-none d-md-block"></div>
     </div>
     <div style="overflow-y: auto; max-height: 240px; margin-left: -15px; margin-right: -15px;">
       {{#each employee in nextSeasonEmployeeList}}
-        <div class="d-flex flex-wrap mb-1 data-row">
-          <div class="hidden-title d-block d-md-none">使用者帳號</div>
-          <div class="col-md-2 text-truncate data-content">
+        <div class="d-flex flex-wrap mb-1 grid-table-row">
+          <div class="grid-table-hidden-title">使用者帳號</div>
+          <div class="col-md-2 text-truncate grid-table-content">
             {{>userLink employee.userId}}
           </div>
-          <div class="hidden-title d-block d-md-none">報名時間</div>
-          <div class="col-md-3 data-content">
+          <div class="grid-table-hidden-title">報名時間</div>
+          <div class="col-md-3 grid-table-content">
             {{formatDateText employee.registerAt}}
           </div>
           <div class="col-md-7 d-block d-md-none"></div>

--- a/client/company/companyVipListPanel.html
+++ b/client/company/companyVipListPanel.html
@@ -1,0 +1,78 @@
+<template name="companyVipListPanel">
+  <div class="row">
+    <div class="col-12 col-md-8 col-lg-9 grid-table company-vip-table">
+      <div class="form-inline my-2">
+        <div class="input-group input-group-sm">
+          <div class="input-group-addon">顯示等級</div>
+          <select class="form-control" name="displayVipLevel">
+            {{#each option in displayVipLevelOptions}}
+              <option value="{{option.value}}" {{displayVipLevelOptionSelectedAttr option.value}}>
+                {{option.text}}
+              </option>
+            {{/each}}
+          </select>
+        </div>
+      </div>
+      <div class="row mb-1 grid-table-head">
+        <div class="col-md-6 text-center text-nowrap">使用者帳號</div>
+        <div class="col-md-3 text-center text-nowrap">VIP 等級</div>
+        <div class="col-md-3 text-center text-nowrap">分數</div>
+      </div>
+      <div>
+        {{#each vip in companyVips}}
+          <div class="row mb-1 grid-table-row {{vipLevelClass vip}}">
+            <div class="grid-table-hidden-title">使用者帳號</div>
+            <div class="col-md-6 text-truncate grid-table-content">{{>userLink vip.userId}}</div>
+            <div class="grid-table-hidden-title">VIP 等級</div>
+            <div class="col-md-3 text-md-center grid-table-content" title="Level {{vip.level}}">Level {{vip.level}}</div>
+            <div class="grid-table-hidden-title">分數</div>
+            <div class="col-md-3 text-md-center grid-table-content" title="{{vip.score}}">{{vip.score}}</div>
+          </div>
+        {{else}}
+          <div class="text-center">
+            <em>查無資料！</em>
+          </div>
+        {{/each}}
+      </div>
+      <div class="justify-content-center mb-1">
+        {{>pagination paginationData}}
+      </div>
+    </div>
+    <div class="col-12 col-md-4 col-lg-3">
+      <h5>分級門檻一覽</h5>
+      <table class="table table-bordered table-sm">
+        <thead>
+          <tr>
+            <th class="text-center">VIP 等級</th>
+            <th class="text-center">門檻分數</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{#each threshold in vipThresholds}}
+            <tr>
+              <td class="text-center">Level {{threshold.level}}</td>
+              <td class="text-center">{{threshold.score}}</td>
+            </tr>
+          {{/each}}
+        </tbody>
+      </table>
+
+      {{#if currentUser}}
+        <hr class="my-2">
+        <h5>我的 VIP 資訊</h5>
+        <div class="mb-2">
+          {{#if currentUserVipData}}
+            <div>
+              VIP 等級：<span class="text-info">Level {{currentUserVipData.level}}</span>
+            </div>
+            <div>
+              分數：<span class="{{vipScoreClass currentUserVipData}}">{{currentUserVipData.score}}</span>
+            </div>
+          {{else}}
+            <em>您並非此公司的 VIP！</em>
+          {{/if}}
+        </div>
+      {{/if}}
+    </div>
+  </div>
+</template>

--- a/client/company/companyVipListPanel.js
+++ b/client/company/companyVipListPanel.js
@@ -1,0 +1,103 @@
+import { Meteor } from 'meteor/meteor';
+import { _ } from 'meteor/underscore';
+import { $ } from 'meteor/jquery';
+import { Template } from 'meteor/templating';
+import { ReactiveVar } from 'meteor/reactive-var';
+
+import { dbVips, getVipThresholds } from '/db/dbVips';
+import { wrapScopeKey } from '/common/imports/utils/wrapScopeKey';
+import { inheritedShowLoadingOnSubscribing } from '../layout/loading';
+import { paramCompany, paramCompanyId } from './helpers';
+
+const displayVipLevelOptions = [
+  { value: 'all', text: '全部' },
+  ...[5, 4, 3, 2, 1, 0].map((i) => {
+    return { value: `${i}`, text: `Level ${i}` };
+  })
+];
+const defaultDisplayVipLevel = displayVipLevelOptions[0].value;
+
+inheritedShowLoadingOnSubscribing(Template.companyVipListPanel);
+
+Template.companyVipListPanel.onCreated(function() {
+  this.vipListOffset = new ReactiveVar(0);
+  this.selectedDisplayVipLevel = new ReactiveVar(defaultDisplayVipLevel);
+
+  this.autorunWithIdleSupport(() => {
+    const displayVipLevel = this.selectedDisplayVipLevel.get();
+    const level = displayVipLevel === 'all' ? undefined : Number.parseInt(displayVipLevel, 10);
+
+    this.subscribe('companyVips', {
+      companyId: paramCompanyId(),
+      level,
+      offset: this.vipListOffset.get()
+    });
+  });
+
+  this.autorunWithIdleSupport(() => {
+    if (Meteor.userId()) {
+      this.subscribe('currentUserCompanyVip', paramCompanyId());
+    }
+  });
+});
+
+Template.companyVipListPanel.helpers({
+  vipThresholds() {
+    return getVipThresholds(paramCompany())
+      .map((score, i) => {
+        return { level: i, score };
+      })
+      .slice(1)
+      .reverse();
+  },
+  currentUserVipData() {
+    const userId = Meteor.userId();
+    if (! userId) {
+      return;
+    }
+
+    return dbVips.findOne({ userId });
+  },
+  companyVips() {
+    return dbVips.find({ [wrapScopeKey('companyVips')]: 1 }, { sort: { score: -1, createdAt: 1 } });
+  },
+  vipScoreClass(vip) {
+    const vipThresholds = getVipThresholds(paramCompany());
+    const nextLevelThreshold = vipThresholds[vip.level + 1] || Infinity;
+    const currentLevelThreshold = vipThresholds[vip.level];
+
+    if (vip.score >= nextLevelThreshold) {
+      return 'px-1 bg-success text-white';
+    }
+
+    if (vip.score < currentLevelThreshold) {
+      return 'px-1 bg-danger text-white';
+    }
+
+    return 'text-info';
+  },
+  vipLevelClass(vip) {
+    return `vip-level-${vip.level}`;
+  },
+  displayVipLevelOptions() {
+    return displayVipLevelOptions;
+  },
+  displayVipLevelOptionSelectedAttr(value) {
+    return Template.instance().selectedDisplayVipLevel.get() === value ? 'selected' : '';
+  },
+  paginationData() {
+    return {
+      useVariableForTotalCount: 'totalCountOfCompanyVips',
+      dataNumberPerPage: Meteor.settings.public.dataNumberPerPage.companyVips,
+      offset: Template.instance().vipListOffset
+    };
+  }
+});
+
+Template.companyVipListPanel.events({
+  'change select[name="displayVipLevel"]': _.debounce(function(event, templateInstance) {
+    event.preventDefault();
+    templateInstance.selectedDisplayVipLevel.set($(event.currentTarget).val());
+    templateInstance.vipListOffset.set(0);
+  }, 250)
+});

--- a/client/company/helpers.js
+++ b/client/company/helpers.js
@@ -1,0 +1,13 @@
+import { FlowRouter } from 'meteor/kadira:flow-router';
+
+import { dbCompanies } from '/db/dbCompanies';
+
+export function paramCompanyId() {
+  return FlowRouter.getParam('companyId');
+}
+
+export function paramCompany() {
+  const companyId = paramCompanyId();
+
+  return companyId ? dbCompanies.findOne(companyId) : null;
+}

--- a/client/layout/tutorial.html
+++ b/client/layout/tutorial.html
@@ -135,6 +135,14 @@
               <li>除此之外，公司的經理人隨時可以辭職不幹。</li>
               <li>經理人可以在商業季度結束前<span class="text-info">72</span>小時調整下個商業季度的員工薪資，調整範圍為<span class="text-info">$500~$2000</span>，以及在商業季度結束前<span class="text-info">24</span>小時調整本商業季度的員工分紅，調整範圍為總盈利額的<span class="text-info">1%~5%</span>。</li>
               <li>商業季度結束後，公司的收益金額將分出<span class="text-info">5%</span>作為經理人的薪水、<span class="text-info">15%</span>作為營運成本、<span class="text-info">1%~5%</span>作為員工分紅。剩餘的收益金額作為董事會分紅，依照董事會成員個人之持股數量對所有董事的總持股數量之比例來分配。</li>
+              <li>
+                若該董事為公司的 VIP，持股數量將依據 VIP 等級來加成計算：
+                <ul>
+                  {{#each vipParameter in vipParameters}}
+                    <li>Level {{vipParameter.level}}：{{vipParameter.stockBonusFactorPercent}}%</li>
+                  {{/each}}
+                </ul>
+              </li>
               <li>商業季度中<span class="text-danger">未曾上線</span>、<span class="text-danger">被禁止交易權限</span>的使用者將<span class="text-danger">無法</span>得到公司的季度分紅；計算董事會分紅時，持數數量也將以<span class="text-danger">0%</span>計算。</li>
               <li>商業季度中，若是未登入天數達到<span class="text-danger">四天</span>，則在計算董事會分紅時，該董事的持股數量將以<span class="text-danger">50%</span>計算，因此會拿到與比原本少的董事會分紅。</li>
               <li>商業季度中，若是未登入天數達到<span class="text-danger">五天以上</span>，則在計算董事會分紅時，該董事的持股數量將以<span class="text-danger">0%</span>計算，也就是說，拿不到董事會分紅！</li>
@@ -168,7 +176,14 @@
                   <li>玩家只能購買有剩餘數量的產品，若是數量不足則需等待下次補貨。</li>
                   <li>玩家可在自己的帳號資訊下，檢視自己持有哪些產品。</li>
                   <li>使用者在同一商業季度的同一間公司裡，購買的總額度不得超過公司資本額的10%。</li>
-                  <li>產品售出時，公司將得到產品成本的{{productProfitFactor}}倍作為營利額。</li>
+                  <li>
+                    每個售出的產品，售價乘上倍數後，將成為公司的營利額，其倍數由買入玩家的 VIP 等級決定：
+                    <ul>
+                      {{#each vipParameter in vipParameters}}
+                        <li>Level {{vipParameter.level}}：{{vipParameter.productProfitFactorPercent}}%</li>
+                      {{/each}}
+                    </ul>
+                  </li>
                   <li>在進入下一個商業季度時，產品將停止販售。</li>
                   <li>玩家在一間公司消費每滿${{currencyFormat productRebateDivisorAmount}}，在商業季度結算時，可得${{currencyFormat productRebateDeliverAmount}}的產品消費回饋。</li>
                 </ul>
@@ -188,6 +203,26 @@
       <div class="card">
         <div class="card-header pointer" role="tab">
           <h5 class="mb-0">
+            公司 VIP 相關
+          </h5>
+        </div>
+        <div class="collapse">
+          <div class="card-block">
+            <ol>
+              <li>玩家在一間公司購買產品之後，即可成為該公司的 VIP，名列在公司的 VIP 名冊中。</li>
+              <li>VIP 共分 5 級，由低至高為 Level 0 至 Level 5，系統將間隔固定時間，由 VIP 分數的高低來評定。</li>
+              <li>玩家可藉由持續購買產品，以增加自己的 VIP 分數。購買單價較高的產品，可以提升較多的分數。</li>
+              <li>在 Level 0 至 Level 4，玩家得到的 VIP 分數只要大於等於每個等級的門檻分數，即可升級至對應等級。</li>
+              <li>在 VIP 名冊中，將取最多 {{vipLevel5MaxCount}} 位分數大於等於 Level 5 門檻的玩家作為 Level 5 VIP，其餘則評定為 Level 4。</li>
+              <li>在商業季度結束時，若是玩家的 VIP 分數低於其所在等級的門檻分數，則有 {{vipLevelDownChancePercent}}% 機率降低一級。</li>
+              <li>在新的商業季度開始時，玩家在上季度所得的 VIP 分數，將乘上 {{vipPreviousSeasonScoreWeightPercent}}% 後，加入本季度的分數計算之中。</li>
+            </ol>
+          </div>
+        </div>
+      </div>
+      <div class="card">
+        <div class="card-header pointer" role="tab">
+          <h5 class="mb-0">
             員工相關
           </h5>
         </div>
@@ -195,7 +230,7 @@
           <div class="card-block">
             <ol>
               <li>玩家可以在任意時間向已創立的公司報名成為儲備員工，每次商業季度更替時儲備員工將轉為正職員工，員工任期為一個商業季度，不得中途轉任或離任。</li>
-              <li>每位正職員工在系統配發薪資時將從公司領取該公司指定的薪資，同時使公司產生與一張推薦票等價的營利額。所有正職員工將不會再從系統領取薪資。</li>
+              <li>每位正職員工在系統配發薪資時將從公司領取該公司指定的薪資，同時使公司產生營利。所有正職員工將不會再從系統領取薪資。</li>
               <li>玩家在一個商業季度內只能選擇一間公司報名，若再次報名則會自動從上次報名公司的儲備員工名單中刪除。</li>
               <li>商業季度結束後，所有正職員工將均分經理人設定的員工分紅，分紅額非整數時無條件退位。</li>
               <li>玩家可以在帳號資訊與公司資訊頁面確認是否正確報名或取消報名為儲備員工。</li>

--- a/client/layout/tutorial.js
+++ b/client/layout/tutorial.js
@@ -3,6 +3,7 @@ import { Meteor } from 'meteor/meteor';
 import { Template } from 'meteor/templating';
 
 import { dbVariables } from '/db/dbVariables';
+import { VIP_LEVEL5_MAX_COUNT } from '/db/dbVips';
 import { importantAccuseLogTypeList } from '/db/dbLog';
 import { stonePowerTable } from '/db/dbCompanyStones';
 
@@ -35,9 +36,6 @@ Template.tutorial.helpers({
   miningMachineSaintStoneLimit() {
     return Meteor.settings.public.miningMachineSaintStoneLimit;
   },
-  productProfitFactor() {
-    return Meteor.settings.public.productProfitFactor;
-  },
   productFinalSaleHours() {
     return Math.floor(Meteor.settings.public.productFinalSaleTime / 1000 / 60 / 60);
   },
@@ -55,5 +53,23 @@ Template.tutorial.helpers({
   },
   productRebateDeliverAmount() {
     return Meteor.settings.public.productRebates.deliverAmount;
+  },
+  vipLevelDownChancePercent() {
+    return Math.round(Meteor.settings.public.vipLevelDownChance * 100);
+  },
+  vipPreviousSeasonScoreWeightPercent() {
+    return Math.round(Meteor.settings.public.vipPreviousSeasonScoreWeight * 100);
+  },
+  vipLevel5MaxCount() {
+    return VIP_LEVEL5_MAX_COUNT;
+  },
+  vipParameters() {
+    return Object.entries(Meteor.settings.public.vipParameters).map(([level, parameters]) => {
+      return {
+        level,
+        productProfitFactorPercent: Math.round(parameters.productProfitFactor * 100),
+        stockBonusFactorPercent: Math.round(parameters.stockBonusFactor * 100)
+      };
+    });
   }
 });

--- a/client/seasonalReport/seasonalReport.html
+++ b/client/seasonalReport/seasonalReport.html
@@ -122,7 +122,7 @@
             {{>companyLink rankData.companyId}}
           </td>
           <td class="text-right text-nowrap">
-            $ {{currencyFormat rankData.profit}}
+            $ {{currencyFormat (round rankData.profit)}}
           </td>
           <td class="text-right text-nowrap">
             {{rankData.totalRelease}}

--- a/client/utils/helpers.js
+++ b/client/utils/helpers.js
@@ -228,3 +228,5 @@ export function isCompanyManager(kwargs) {
   return company.manager === user._id;
 }
 Template.registerHelper('isCompanyManager', isCompanyManager);
+
+Template.registerHelper('round', Math.round);

--- a/client/utils/styles.css
+++ b/client/utils/styles.css
@@ -367,56 +367,51 @@ body {
   object-fit: scale-down;
 }
 
-/* 公司資訊頁 > 董事會 */
+/* grid system 風格的表格排版 */
+@media only screen and (min-width: 768px) {
+  .grid-table .grid-table-hidden-title {
+    display: none !important;
+  }
+}
+
 @media only screen and (max-width: 767.9px) {
-  div.company-director-list .hidden-title {
+  .grid-table .grid-table-head {
+    display: none !important;
+  }
+  .grid-table .grid-table-hidden-title {
     padding-left: 15px;
     width: 35%;
   }
-  div.company-director-list .data-content {
+  .grid-table .grid-table-content {
     width: 65%;
   }
-  div.company-director-list .data-row {
+  .grid-table .grid-table-row {
     border-bottom: 1px dashed;
   }
-  div.company-director-list .data-row:first-of-type,
-  div.company-director-list .data-row:last-of-type {
+  .grid-table .grid-table-row:last-of-type {
     border-bottom: none;
   }
 }
 
-/* 公司資訊頁 > 員工名冊 > 在職員工 */
-@media only screen and (max-width: 767.9px) {
-  div.company-employee-list .data-row {
-    border-bottom: 1px dashed;
-  }
-  div.company-employee-list .data-row:last-of-type {
-    border-bottom: none;
-  }
-  div.company-employee-list .hidden-title {
-    padding-left: 15px;
-    width: 35%;
-  }
-  div.company-employee-list .data-content {
-    width: 65%;
-  }
+/* 公司資訊 > VIP 名冊 的 VIP 表格樣式*/
+.container-dark .company-vip-table .vip-level-5 {
+  background-color: rgba(192, 96, 96, 0.5);
+  color: white;
+  font-weight: bold;
 }
 
-/* 公司資訊頁 > 員工名冊 > 儲備員工 */
-@media only screen and (max-width: 767.9px) {
-  div.company-trainee-list .data-row {
-    border-bottom: 1px dashed;
-  }
-  div.company-trainee-list .data-row:last-of-type {
-    border-bottom: none;
-  }
-  div.company-trainee-list .hidden-title {
-    padding-left: 15px;
-    width: 35%;
-  }
-  div.company-trainee-list .data-content {
-    width: 65%;
-  }
+.container-dark .company-vip-table .vip-level-5 a {
+  color: yellow;
+}
+
+.container-light .company-vip-table .vip-level-5 {
+  background-color: rgba(255, 175, 175, 0.5);
+  color: black;
+  font-weight: bold;
+}
+
+.container-light .company-vip-table .vip-level-5 a {
+  color: rgb(2, 117, 215);
 }
 
 /* 經營管理介面 > 角色大圖預覽 */

--- a/common/imports/utils/MathUtil.js
+++ b/common/imports/utils/MathUtil.js
@@ -1,0 +1,8 @@
+export const MathUtil = {
+  // round 至最接近的小數位
+  roundToDecimalPlaces(x, d) {
+    const p = Math.pow(10, d);
+
+    return Math.round(x * p) / p;
+  }
+};

--- a/common/imports/utils/wrapScopeKey.js
+++ b/common/imports/utils/wrapScopeKey.js
@@ -1,0 +1,3 @@
+export function wrapScopeKey(scopeKey) {
+  return `_scope_${scopeKey}`;
+}

--- a/config.js
+++ b/config.js
@@ -55,16 +55,45 @@ export const config = {
   dataNumberPerPage: { // 分頁時每個分頁有多少資料
     userPlacedStones: 10,
     userOwnedProducts: 10,
-    companyMarketingProducts: 10
+    companyMarketingProducts: 10,
+    companyVips: 10
   },
   productFinalSaleTime: 43200000, // 產品最後出清時間 (ms)
-  productProfitFactor: 2.00, // 產品售出的營利乘數
   systemProductVotingReward: 4096, // 系統派發的推薦票回饋金
   employeeProductVotingRewardFactor: 0.01, // 員工投推薦票的回饋金比例
   productVoucherAmount: 7000, // 產品消費券的數量
   productRebates: { // 產品滿額回饋設定
     divisorAmount: 3500, // 滿額條件
     deliverAmount: 100 // 每達成一次滿額條件可得回饋
-  }
+  },
+  vipParameters: { // VIP 各等級的參數
+    0: {
+      productProfitFactor: 2.00, // 產品營利乘數
+      stockBonusFactor: 1.00 // 分紅股權乘數
+    },
+    1: {
+      productProfitFactor: 2.05,
+      stockBonusFactor: 1.01
+    },
+    2: {
+      productProfitFactor: 2.20,
+      stockBonusFactor: 1.02
+    },
+    3: {
+      productProfitFactor: 2.50,
+      stockBonusFactor: 1.03
+    },
+    4: {
+      productProfitFactor: 3.00,
+      stockBonusFactor: 1.04
+    },
+    5: {
+      productProfitFactor: 4.00,
+      stockBonusFactor: 1.05
+    }
+  },
+  vipLevelCheckInterval: 3600000, // VIP 等級更新時間 (ms)
+  vipLevelDownChance: 0.05, // VIP 掉級的機率
+  vipPreviousSeasonScoreWeight: 0.80 // VIP 上季分數的權重
 };
 export default config;

--- a/config.json
+++ b/config.json
@@ -53,16 +53,45 @@
     "dataNumberPerPage": {
       "userPlacedStones": 10,
       "userOwnedProducts": 10,
-      "companyMarketingProducts": 10
+      "companyMarketingProducts": 10,
+      "companyVips": 10
     },
     "productFinalSaleTime": 43200000,
-    "productProfitFactor": 2.00,
     "systemProductVotingReward": 4096,
     "employeeProductVotingRewardFactor": 0.01,
     "productVoucherAmount": 7000,
     "productRebates": {
       "divisorAmount": 3500,
       "deliverAmount": 100
-    }
+    },
+    "vipParameters": {
+      "0": {
+        "productProfitFactor": 2.00,
+        "stockBonusFactor": 1.00
+      },
+      "1": {
+        "productProfitFactor": 2.05,
+        "stockBonusFactor": 1.01
+      },
+      "2": {
+        "productProfitFactor": 2.20,
+        "stockBonusFactor": 1.02
+      },
+      "3": {
+        "productProfitFactor": 2.50,
+        "stockBonusFactor": 1.03
+      },
+      "4": {
+        "productProfitFactor": 3.00,
+        "stockBonusFactor": 1.04
+      },
+      "5": {
+        "productProfitFactor": 4.00,
+        "stockBonusFactor": 1.05
+      }
+    },
+    "vipLevelCheckInterval": 3600000,
+    "vipLevelDownChance": 0.05,
+    "vipPreviousSeasonScoreWeight": 0.80
   }
 }

--- a/db/dbArenaLog.js
+++ b/db/dbArenaLog.js
@@ -86,7 +86,7 @@ export const dbArenaLog = {
 //   },
 //   //紀錄若防禦者被擊倒，攻擊者得到的收益
 //   profit: {
-//     type: SimpleSchema.Integer,
+//     type: Number,
 //     optional: true
 //   }
 // });

--- a/db/dbCompanies.js
+++ b/db/dbCompanies.js
@@ -111,7 +111,7 @@ const schema = new SimpleSchema({
   },
   // 當季已營利
   profit: {
-    type: SimpleSchema.Integer,
+    type: Number,
     min: 0,
     defaultValue: 0
   },

--- a/db/dbProducts.js
+++ b/db/dbProducts.js
@@ -95,7 +95,7 @@ const schema = new SimpleSchema({
   },
   // 產品所貢獻的營利
   profit: {
-    type: SimpleSchema.Integer,
+    type: Number,
     min: 0,
     defaultValue: 0
   },

--- a/db/dbRankCompanyPrice.js
+++ b/db/dbRankCompanyPrice.js
@@ -35,7 +35,7 @@ const schema = new SimpleSchema({
   },
   // 當季營利額
   profit: {
-    type: SimpleSchema.Integer
+    type: Number
   }
 });
 dbRankCompanyPrice.attachSchema(schema);

--- a/db/dbRankCompanyProfit.js
+++ b/db/dbRankCompanyProfit.js
@@ -35,7 +35,7 @@ const schema = new SimpleSchema({
   },
   // 當季營利額
   profit: {
-    type: SimpleSchema.Integer
+    type: Number
   }
 });
 dbRankCompanyProfit.attachSchema(schema);

--- a/db/dbRankCompanyValue.js
+++ b/db/dbRankCompanyValue.js
@@ -35,7 +35,7 @@ const schema = new SimpleSchema({
   },
   // 當季營利額
   profit: {
-    type: SimpleSchema.Integer
+    type: Number
   }
 });
 dbRankCompanyValue.attachSchema(schema);

--- a/db/dbVips.js
+++ b/db/dbVips.js
@@ -1,0 +1,56 @@
+import { Mongo } from 'meteor/mongo';
+import SimpleSchema from 'simpl-schema';
+
+import { MathUtil } from '/common/imports/utils/MathUtil';
+
+// VIP level 5 最多人數
+export const VIP_LEVEL5_MAX_COUNT = 7;
+
+// VIP 分數要保持的小數位數
+const VIP_SCORE_DECIMAL_PLACES = 3;
+
+// 將分數四捨五入至 VIP 分數所需之小數位
+export function roundVipScore(x) {
+  return MathUtil.roundToDecimalPlaces(x, VIP_SCORE_DECIMAL_PLACES);
+}
+
+// 取得各等級 VIP 的門檻值
+export function getVipThresholds({ capital }) {
+  const baseThreshold = Math.pow(1487 / capital, 0.6) * capital;
+
+  return [0, 0.2, 0.4, 0.6, 0.8, 1].map((n) => {
+    return roundVipScore(n * baseThreshold);
+  });
+}
+
+// 公司 VIP 會員資料集
+export const dbVips = new Mongo.Collection('vips', { idGeneration: 'MONGO' });
+
+const schema = new SimpleSchema({
+  // 公司id
+  companyId: {
+    type: String
+  },
+  // 玩家id
+  userId: {
+    type: String
+  },
+  // 目前等級
+  level: {
+    type: SimpleSchema.Integer,
+    min: 0,
+    defaultValue: 0
+  },
+  // 目前分數
+  score: {
+    type: Number,
+    min: 0,
+    defaultValue: 0
+  },
+  // 建立時間
+  createdAt: {
+    type: Date
+  }
+});
+
+dbVips.attachSchema(schema);

--- a/db/migrate.js
+++ b/db/migrate.js
@@ -30,6 +30,7 @@ import { dbUserArchive } from './dbUserArchive';
 import { dbUserOwnedProducts } from './dbUserOwnedProducts';
 import { dbValidatingUsers } from './dbValidatingUsers';
 import { dbVariables } from './dbVariables';
+import { dbVips, roundVipScore } from './dbVips';
 import { dbVoteRecord } from './dbVoteRecord';
 
 if (Meteor.isServer) {
@@ -1264,6 +1265,116 @@ if (Meteor.isServer) {
         $rename: { 'data.cost': 'data.moneyCost' },
         $set: { 'data.voucherCost': 0 }
       });
+    }
+  });
+
+  Migrations.add({
+    version: 19,
+    name: 'add company VIP system',
+    up() {
+      // 建立 VIP 資訊的 indexes
+      dbVips.rawCollection().createIndex({ userId: 1, companyId: 1 }, { unique: true });
+      dbVips.rawCollection().createIndex({ companyId: 1, score: -1, createdAt: -1 });
+      dbVips.rawCollection().createIndex({ companyId: 1, level: -1 });
+      dbVips.rawCollection().createIndex({ userId: 1, level: -1 });
+
+      // 增加當季公司產品對價格的 index（產品購買分數計算用）
+      dbProducts.rawCollection().createIndex({ seasonId: 1, companyId: 1, price: 1 }, {
+        partialFilterExpression: { state: 'marketing' }
+      });
+
+      const seasons = dbSeason.find({}, { sort: { beginDate: -1 } }).fetch();
+      if (seasons.length === 0) {
+        return;
+      }
+
+      const { _id: currentSeasonId } = seasons[0];
+
+      /**
+       * 處理過去的產品購買分數
+       * 當季：以 1 倍計算
+       * 過去所有季度：以 0.8 倍計算
+       */
+      const vipScoreMap = {};
+
+      seasons.forEach(({ _id: seasonId }) => {
+        // 該季度各公司的產品價格最高與最低值
+        const companyProductPriceMinMaxMap = dbProducts
+          .aggregate([ {
+            $match: { seasonId }
+          }, {
+            $group: {
+              _id: '$companyId',
+              min: { $min: '$price' },
+              max: { $max: '$price' }
+            }
+          } ])
+          .reduce((obj, { _id, min, max }) => {
+            obj[_id] = { min, max };
+
+            return obj;
+          }, {});
+
+        // 以玩家持有的產品來回推 VIP 分數
+        dbUserOwnedProducts
+          .find({ seasonId })
+          .forEach(({ userId, companyId, price, amount }) => {
+            const { min: priceMin, max: priceMax } = companyProductPriceMinMaxMap[companyId];
+
+            const seasonScoreFactor = seasonId === currentSeasonId ? 1.0 : 0.8;
+
+            const totalCost = price * amount;
+            const scoreFactor = priceMin === priceMax ? 1 : 1 + 0.2 * (price - priceMin) / (priceMax - priceMin);
+            const scoreIncrease = totalCost * scoreFactor * seasonScoreFactor;
+
+            if (scoreIncrease > 0) {
+              _.defaults(vipScoreMap, { [userId]: {} });
+              const oldScore = vipScoreMap[userId][companyId] || 0;
+              const newScore = roundVipScore(oldScore + scoreIncrease);
+              vipScoreMap[userId][companyId] = newScore;
+            }
+          });
+      });
+
+      if (_.isEmpty(vipScoreMap)) {
+        return;
+      }
+
+      // 計算每個玩家在公司的第一次購買產品時間
+      const firstBoughtDateMap = dbLog
+        .aggregate([ {
+          $match: { logType: '購買產品' }
+        }, {
+          $unwind: '$userId'
+        }, {
+          $group: {
+            _id: { userId: '$userId', companyId: '$companyId' },
+            firstBoughtAt: { $min: '$createdAt' }
+          }
+        } ])
+        .reduce((obj, { _id, firstBoughtAt }) => {
+          const { userId, companyId } = _id;
+          _.defaults(obj, { [userId]: {} });
+          obj[userId][companyId] = firstBoughtAt;
+
+          return obj;
+        }, {});
+
+      const vipBulk = dbVips.rawCollection().initializeUnorderedBulkOp();
+
+      Object.entries(vipScoreMap).forEach(([userId, subMap]) => {
+        Object.entries(subMap).forEach(([companyId, score]) => {
+          vipBulk.insert({
+            userId,
+            companyId,
+            score,
+            level: 0,
+            createdAt: firstBoughtDateMap[userId][companyId]
+          });
+        });
+      });
+
+      Meteor.wrapAsync(vipBulk.execute, vipBulk)();
     }
   });
 

--- a/server/functions/vip/adjustPreviousSeasonVipScores.js
+++ b/server/functions/vip/adjustPreviousSeasonVipScores.js
@@ -1,0 +1,29 @@
+import { Meteor } from 'meteor/meteor';
+
+import { dbVips, roundVipScore } from '/db/dbVips';
+
+// 調整前一季得到的 VIP 分數
+export function adjustPreviousSeasonVipScores() {
+  const { vipPreviousSeasonScoreWeight } = Meteor.settings.public;
+
+  const vipModifyList = [];
+
+  dbVips.find().forEach(({ userId, companyId, score }) => {
+    const newScore = roundVipScore(score * vipPreviousSeasonScoreWeight);
+
+    if (newScore !== score) {
+      vipModifyList.push({
+        query: { userId, companyId },
+        update: { $set: { score: newScore } }
+      });
+    }
+  });
+
+  if (vipModifyList.length > 0) {
+    const vipBulk = dbVips.rawCollection().initializeUnorderedBulkOp();
+    vipModifyList.forEach(({ query, update }) => {
+      vipBulk.find(query).update(update);
+    });
+    Meteor.wrapAsync(vipBulk.execute, vipBulk)();
+  }
+}

--- a/server/functions/vip/checkVipLevels.js
+++ b/server/functions/vip/checkVipLevels.js
@@ -1,0 +1,98 @@
+import { Meteor } from 'meteor/meteor';
+import { _ } from 'meteor/underscore';
+
+import { dbCompanies } from '/db/dbCompanies';
+import { dbVips, getVipThresholds, VIP_LEVEL5_MAX_COUNT } from '/db/dbVips';
+import { debug } from '/server/imports/utils/debug';
+
+// 更新全市場的 VIP 等級
+export function checkVipLevels() {
+  debug.log('checkVipLevels');
+  adjustVipLevelsByScore();
+  levelDownExcessiveLevel5Vips();
+}
+
+// 依據目前分數更新的 vip 等級
+function adjustVipLevelsByScore() {
+  // 計算所有公司的分數門檻
+  const companyVipThresholdsMap = dbCompanies
+    .find({ isSeal: false }, { fields: { capital: 1 } })
+    .fetch()
+    .reduce((obj, { _id, capital }) => {
+      obj[_id] = getVipThresholds({ capital });
+
+      return obj;
+    }, {});
+  const vipModifyList = [];
+
+  dbVips.find().forEach(({ userId, companyId, score, level }) => {
+    const vipThresholds = companyVipThresholdsMap[companyId];
+
+    const index = [...vipThresholds, Infinity].findIndex((threshold) => {
+      return threshold > score;
+    });
+
+    if (index === -1) {
+      return;
+    }
+
+    const maxLevel = index - 1;
+
+    // 低於 level 5 者不降級
+    if (maxLevel <= level && level < 5) {
+      return;
+    }
+
+    vipModifyList.push({
+      query: { userId, companyId },
+      update: { $set: { level: maxLevel } }
+    });
+  });
+
+  if (vipModifyList.length > 0) {
+    const vipBulk = dbVips.rawCollection().initializeUnorderedBulkOp();
+    vipModifyList.forEach(({ query, update }) => {
+      vipBulk.find(query).update(update);
+    });
+    Meteor.wrapAsync(vipBulk.execute, vipBulk)();
+  }
+}
+
+// 降級超過人數的 level 5 VIP
+function levelDownExcessiveLevel5Vips() {
+  const vipModifyList = [];
+
+  // 若是 level 5 超過人數，將剩餘的退級回 level 4
+  dbVips
+    .aggregate([ {
+      $match: { level: 5 }
+    }, {
+      $sort: { score: -1, createdAt: 1 }
+    }, {
+      $group: {
+        _id: '$companyId',
+        candidates: { $push: '$userId' },
+        candidateCount: { $sum: 1 }
+      }
+    }, {
+      $match: {
+        candidateCount: { $gt: VIP_LEVEL5_MAX_COUNT }
+      }
+    } ])
+    .forEach(({ _id: companyId, candidates }) => {
+      const winners = _.take(candidates, VIP_LEVEL5_MAX_COUNT);
+
+      vipModifyList.push({
+        query: { companyId, userId: { $nin: winners } },
+        update: { $set: { level: 4 } }
+      });
+    });
+
+  if (vipModifyList.length > 0) {
+    const vipBulk = dbVips.rawCollection().initializeUnorderedBulkOp();
+    vipModifyList.forEach(({ query, update }) => {
+      vipBulk.find(query).update(update);
+    });
+    Meteor.wrapAsync(vipBulk.execute, vipBulk)();
+  }
+}

--- a/server/functions/vip/levelDownThresholdUnmetVips.js
+++ b/server/functions/vip/levelDownThresholdUnmetVips.js
@@ -1,0 +1,58 @@
+import { Meteor } from 'meteor/meteor';
+
+import { dbCompanies } from '/db/dbCompanies';
+import { dbVips, getVipThresholds } from '/db/dbVips';
+
+// 降級末達成門檻的 VIP
+export function levelDownThresholdUnmetVips() {
+  // 計算所有公司的分數門檻
+  const companyVipThresholdsMap = dbCompanies
+    .find({ isSeal: false }, { fields: { capital: 1 } })
+    .fetch()
+    .reduce((obj, { _id, capital }) => {
+      obj[_id] = getVipThresholds({ capital });
+
+      return obj;
+    }, {});
+
+  const { vipLevelDownChance } = Meteor.settings.public;
+  const vipModifyList = [];
+
+  dbVips.find().forEach(({ userId, companyId, score, level }) => {
+    const vipThresholds = companyVipThresholdsMap[companyId];
+
+    const index = [...vipThresholds, Infinity].findIndex((threshold) => {
+      return threshold > score;
+    });
+
+    if (index === -1) {
+      return;
+    }
+
+    const maxLevel = index - 1;
+
+    // 不處理升級或同級
+    if (maxLevel >= level) {
+      return;
+    }
+
+    // 機率性降級
+    if (Math.random() > vipLevelDownChance) {
+      return;
+    }
+
+    // 符合條件的 VIP，調降一級
+    vipModifyList.push({
+      query: { userId, companyId },
+      update: { $set: { level: level - 1 } }
+    });
+  });
+
+  if (vipModifyList.length > 0) {
+    const vipBulk = dbVips.rawCollection().initializeUnorderedBulkOp();
+    vipModifyList.forEach(({ query, update }) => {
+      vipBulk.find(query).update(update);
+    });
+    Meteor.wrapAsync(vipBulk.execute, vipBulk)();
+  }
+}

--- a/server/imports/utils/publishWithScope.js
+++ b/server/imports/utils/publishWithScope.js
@@ -1,0 +1,26 @@
+import { wrapScopeKey } from '/common/imports/utils/wrapScopeKey';
+
+// 發佈 cursor 內容的同時增加 scopeKey 的屬性，以便識別來自不同 publication 的資料
+export function publishWithScope(subscription, { collection, scope, cursor }) {
+  const transformFields = (fields) => {
+    return { ...fields, [wrapScopeKey(scope)]: 1 };
+  };
+
+  const observer = cursor.observeChanges({
+    added: (id, fields) => {
+      subscription.added(collection, id, transformFields(fields));
+    },
+    changed: (id, fields) => {
+      subscription.changed(collection, id, transformFields(fields));
+    },
+    removed: (id) => {
+      subscription.removed(collection, id);
+    }
+  });
+
+  subscription.onStop(() => {
+    observer.stop();
+  });
+
+  return observer;
+}

--- a/server/publications/accounts/accountVipTitle.js
+++ b/server/publications/accounts/accountVipTitle.js
@@ -1,0 +1,27 @@
+import { Meteor } from 'meteor/meteor';
+import { check, Match } from 'meteor/check';
+
+import { dbVips } from '/db/dbVips';
+import { limitSubscription } from '/server/imports/utils/rateLimit';
+import { debug } from '/server/imports/utils/debug';
+import { publishTotalCount } from '/server/imports/utils/publishTotalCount';
+
+Meteor.publish('accountVipTitle', function(userId, offset) {
+  debug.log('publish accountVipTitle', { userId, offset });
+  check(userId, String);
+  check(offset, Match.Integer);
+
+  const filter = { userId };
+
+  publishTotalCount('totalCountOfVipTitle', dbVips.find(filter), this);
+
+  return dbVips
+    .find(filter, {
+      sort: { level: -1 },
+      skip: offset,
+      limit: 10,
+      disableOplog: true
+    });
+});
+// 一分鐘最多20次
+limitSubscription('accountVipTitle');

--- a/server/publications/vip/companyVips.js
+++ b/server/publications/vip/companyVips.js
@@ -1,0 +1,38 @@
+import { check, Match } from 'meteor/check';
+import { Meteor } from 'meteor/meteor';
+
+import { dbVips } from '/db/dbVips';
+import { limitSubscription } from '/server/imports/utils/rateLimit';
+import { publishTotalCount } from '/server/imports/utils/publishTotalCount';
+import { publishWithScope } from '/server/imports/utils/publishWithScope';
+import { debug } from '/server/imports/utils/debug';
+
+Meteor.publish('companyVips', function({ companyId, level, offset }) {
+  debug.log('publish companyVips', { companyId, level, offset });
+  check(companyId, String);
+  check(level, new Match.Optional(Number));
+  check(offset, Match.Integer);
+
+  const filter = { companyId, level };
+  if (! Number.isFinite(level)) {
+    delete filter.level;
+  }
+
+  publishTotalCount('totalCountOfCompanyVips', dbVips.find(filter), this);
+
+  publishWithScope(this, {
+    collection: 'vips',
+    scope: 'companyVips',
+    cursor: dbVips.find(filter, {
+      sort: { score: -1, createdAt: 1 },
+      skip: offset,
+      limit: Meteor.settings.public.dataNumberPerPage.companyVips,
+      disableOplog: true
+    })
+  });
+
+  this.ready();
+});
+
+// 一分鐘最多20次
+limitSubscription('companyVips');

--- a/server/publications/vip/currentUserCompanyVip.js
+++ b/server/publications/vip/currentUserCompanyVip.js
@@ -1,0 +1,20 @@
+import { check } from 'meteor/check';
+import { Meteor } from 'meteor/meteor';
+
+import { dbVips } from '/db/dbVips';
+import { limitSubscription } from '/server/imports/utils/rateLimit';
+import { debug } from '/server/imports/utils/debug';
+
+Meteor.publish('currentUserCompanyVip', function(companyId) {
+  debug.log('publish currentUserCompanyVip', { companyId });
+  check(companyId, String);
+
+  if (! this.userId) {
+    return [];
+  }
+
+  return dbVips.find({ userId: this.userId, companyId });
+});
+
+// 一分鐘最多20次
+limitSubscription('currentUserCompanyVip');

--- a/server/startup/initializeEventSchedules.js
+++ b/server/startup/initializeEventSchedules.js
@@ -1,6 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 
 import { replenishProducts } from '/server/functions/product/replenishProducts';
+import { checkVipLevels } from '/server/functions/vip/checkVipLevels';
 import { eventScheduler } from '/server/imports/utils/eventScheduler';
 
 Meteor.startup(() => {
@@ -8,5 +9,15 @@ Meteor.startup(() => {
   eventScheduler.setEventCallback('product.finalSale', () => {
     console.log('event triggered: product.finalSale');
     replenishProducts({ finalSale: true });
+  });
+
+  // 定期更新 VIP 等級
+  eventScheduler.defineRecurringEvent('vip.checkVipLevels', {
+    onTriggered() {
+      checkVipLevels();
+    },
+    nextScheduledAt() {
+      return Date.now() + Meteor.settings.public.vipLevelCheckInterval;
+    }
   });
 });


### PR DESCRIPTION
根據 https://acgn-stock.com/ruleDiscuss/view/wyocofM8vqkE9i4mW
實作公司 VIP 相關機制

1. 新增 vips 存放 VIP 相關資訊
2. 購買產品時，將增加 VIP 分數
3. migration v19 將過去玩家購買產品的行為計入更新後的 VIP 初始分數
4. 定期（預設 1 小時）檢查VIP 的升級與 level 5 超過人數或未達門檻的降級
5. 新季度產生時將前一季 VIP 得分乘上 0.8
6. 賽季結束時將 vips 清空
7. 商業季度結束時機率性降級未達成門檻的 VIP
8. 帳號資訊新增玩家在公司的 VIP 列表
9. 公司資訊新增 VIP 名冊，顯示 VIP 列表、分級門檻與個人 VIP 資訊
10. 加入 VIP 等級對股東分紅計算加權以及產品營利加成的影響

其他修改
1. 賽季結束時將使用者所持產品清空，避免影響新賽季的計算
2. 將公司資訊中各式名單的表格排版樣式重構
3. 增加 publishWithScope 工具，可在發佈 cursor 內容時加入指定的 property 作為 scope
的分辨，以處理來自不同 subscription 的資料範圍發生交疊時產生的問題
4. 將公司 schema 的營利型態更改為支援浮點數
  a. 更改各項與 profit 有關欄位的型態至 Number
  b. 取消產品營利產生時的進退位運算
  c. 公司營利在顯示時 round 至整數位
5. 修正並補充 tutorial 資訊