### PR TITLE
Markdown顯示效果修正

### DIFF
--- a/client/utils/helpers.js
+++ b/client/utils/helpers.js
@@ -241,7 +241,7 @@ const katexExtension = {
   }
 };
 
-const preTagEscapedCharacterTranser = {
+const codeTagEscapedCharacterTranser = {
   type: 'output',
   filter: function(text) {
     const output = text.replace(/<code>((.|\r|\n)*?)<\/code>/g, function(match, capture) {
@@ -256,7 +256,7 @@ const preTagEscapedCharacterTranser = {
 
 // Advance(KaTeX, image)
 export function markdown(content, disableAdvance = true) {
-  const extensionsArray = [xssFilter, footnotes, preTagEscapedCharacterTranser];
+  const extensionsArray = [xssFilter, footnotes, codeTagEscapedCharacterTranser];
 
   let preprocessContent = content.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
   if (disableAdvance) {

--- a/client/utils/helpers.js
+++ b/client/utils/helpers.js
@@ -241,9 +241,22 @@ const katexExtension = {
   }
 };
 
+const preTagEscapedCharacterTranser = {
+  type: 'output',
+  filter: function(text) {
+    const output = text.replace(/<code>((.|\r|\n)*?)<\/code>/g, function(match, capture) {
+      const text = capture.replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&quot;/g, '"').replace(/&excl;/g, '!');
+
+      return `<code>${text}</code>`;
+    });
+
+    return output;
+  }
+};
+
 // Advance(KaTeX, image)
 export function markdown(content, disableAdvance = true) {
-  const extensionsArray = [xssFilter, footnotes];
+  const extensionsArray = [xssFilter, footnotes, preTagEscapedCharacterTranser];
 
   let preprocessContent = content.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
   if (disableAdvance) {

--- a/client/utils/styles.css
+++ b/client/utils/styles.css
@@ -197,7 +197,7 @@ body {
 .agenda-description blockquote {
   font-weight: bold;
   font-style: italic;
-  margin: 1rem 3rem; 
+  margin-left: 1rem; 
   border-left: 2px solid #999;
   padding-left: 1rem;
 }


### PR DESCRIPTION
將Markdown產生之<code>區塊內的跳脫字元反跳脫回來以使顯示正常化
調整引用的左內縮程度、拔除右內縮，以優化手機顯示效果