### PR TITLE
實作進階權限設定 & 重整部分程式碼

### DIFF
--- a/client/accountInfo/accountInfo.html
+++ b/client/accountInfo/accountInfo.html
@@ -49,7 +49,7 @@
     </h1>
     <hr />
     {{#if currentUser}}
-      {{#if currentUser.profile.isAdmin}}
+      {{#if currentUserHasRole 'fscMember'}}
         <button class="btn btn-info btn-sm mt-1" type="button" data-action="fscAnnouncement">金管會通告</button>
         {{#if isBaned 'accuse'}}
           <button class="btn btn-success btn-sm mt-1" type="button" data-ban="accuse">解除舉報禁令</button>
@@ -148,11 +148,11 @@
         <div class="text-info">將於本商業季度結束渡假。</div>
       {{/if}}
     {{/if}}
-    {{#if this.profile.isAdmin}}
-      <div>
-        是<span class="bg-warning text-white">金融管理會委員</span>。
-      </div>
-    {{/if}}
+    <div>
+      {{#each role in this.profile.roles}}
+        <span class="badge badge-warning">{{roleDisplayName role}}</span>
+      {{/each}}
+    </div>
     {{#if this.profile.revokeQualification}}
       <div class="text-danger">
         被撤銷了擔任經理人的資格！

--- a/client/accountInfo/accountInfo.js
+++ b/client/accountInfo/accountInfo.js
@@ -9,6 +9,7 @@ import { ReactiveVar } from 'meteor/reactive-var';
 import { dbCompanies } from '/db/dbCompanies';
 import { dbEmployees } from '/db/dbEmployees';
 import { dbVips } from '/db/dbVips';
+import { roleDisplayName } from '/db/users';
 import { inheritedShowLoadingOnSubscribing } from '../layout/loading';
 import { alertDialog } from '../layout/alertDialog';
 import { shouldStopSubscribe } from '../utils/idle';
@@ -91,6 +92,9 @@ Template.accountInfoBasic.helpers({
   },
   isEndingVacation() {
     return this.profile.isEndingVacation;
+  },
+  roleDisplayName(role) {
+    return roleDisplayName(role);
   }
 });
 

--- a/client/accuseRecord/accuseRecord.html
+++ b/client/accuseRecord/accuseRecord.html
@@ -4,7 +4,7 @@
       <h1 class="card-title mb-1">
         舉報違規與金管會處理紀錄
         {{#if currentUser}}
-          {{#if currentUser.profile.isAdmin}}
+          {{#if currentUserHasRole 'fscMember'}}
             <a href="#" class="btn btn-primary" data-action="announcement">金管會通告</a>
           {{else}}
             <a href="#" class="btn btn-primary" data-action="contactFsc">聯絡金管會</a>

--- a/client/advertising/advertising.html
+++ b/client/advertising/advertising.html
@@ -38,7 +38,7 @@
             <th class="text-center text-truncate" title="廣告內容">廣告內容</th>
             <th class="text-center text-truncate" style="width: 120px;" title="費用">費用</th>
             <th class="text-center text-truncate" style="width: 160px;" title="終止日期">終止日期</th>
-            {{#if currentUser.profile.isAdmin}}
+            {{#if currentUserHasRole 'fscMember'}}
               <th class="text-center" style="width: 120px;" title="管理">管理</th>
             {{/if}}
           </tr>
@@ -68,7 +68,7 @@
               <td class="text-center text-truncate text-nowrap" data-title="終止日期">
                 {{formatExpireDate advertising}}
               </td>
-              {{#if currentUser.profile.isAdmin}}
+              {{#if currentUserHasRole 'fscMember'}}
                 <td class="text-center text-nowrap" data-title="管理">
                   <button class="btn btn-danger btn-sm" type="button" data-take-down="{{advertising._id}}">
                     撤銷
@@ -78,7 +78,7 @@
             </tr>
             {{else}}
             <tr class="default-content">
-              {{#if currentUser.profile.isAdmin}}
+              {{#if currentUserHasRole 'fscMember'}}
                 <td class="text-center text-truncate p-1" colspan="5">目前沒有發布中廣告！</td>
               {{else}}
                 <td class="text-center text-truncate p-1" colspan="4">目前沒有發布中廣告！</td>

--- a/client/announcement/announcement.html
+++ b/client/announcement/announcement.html
@@ -5,7 +5,7 @@
         <div class="text-nowrap">
           系統公告
         </div>
-        {{#if currentUser.profile.isAdmin}}
+        {{#if currentUserHasAnyRoles 'developer' 'planner' 'fscMember'}}
           <div class="d-flex flex-wrap justify-content-end ml-auto">
             <button class="btn btn-warning btn-sm" type="button" data-action="editAnnouncement">
               <i class="fa fa-pencil-square-o" aria-hidden="true"></i>

--- a/client/company/companyDetail.html
+++ b/client/company/companyDetail.html
@@ -16,7 +16,7 @@
 
 <template name="companyDetailContentSealed">
   該公司已被金融管理委員會查封！
-  {{#if currentUser.profile.isAdmin}}
+  {{#if currentUserHasRole 'fscMember'}}
     <a class="btn btn-danger float-right" href="#" data-action="unseal">
       解除查封
     </a>
@@ -40,7 +40,7 @@
     </div>
     <div class="d-flex flex-wrap justify-content-end ml-auto mt-1">
       {{#if currentUser}}
-        {{#unless currentUser.profile.isAdmin}}
+        {{#unless currentUserHasRole 'fscMember'}}
           <a class="btn btn-danger" href="#" data-action="accuseCompany">
             舉報違規
           </a>
@@ -63,7 +63,7 @@
     </div>
   </h1>
   {{#if this.illegalReason}}
-    <div class="mb-1 bg-danger text-white">
+    <div class="mb-1 px-1 bg-danger text-white">
       <i class="fa fa-warning"></i>
       本公司已被標記為違規！原因：{{this.illegalReason}}
     </div>
@@ -101,7 +101,7 @@
   <h3 style="word-break: break-all;">
     經理人：
     {{>userLink this.manager}}
-    {{#if isUserId this.manager}}
+    {{#if isCurrentUser this.manager}}
       <a class="btn btn-primary btn-sm" href="{{getManageHref this._id}}">
         經營管理
       </a>
@@ -119,7 +119,7 @@
       </a>
     {{else}}
       {{#if currentUser}}
-        {{#if currentUser.profile.isAdmin}}
+        {{#if currentUserHasRole 'fscMember'}}
           <a class="btn btn-primary btn-sm" href="{{getManageHref this._id}}">
             經營管理
           </a>
@@ -128,7 +128,7 @@
     {{/if}}
   </h3>
   <hr />
-  {{#if currentUser.profile.isAdmin}}
+  {{#if currentUserHasRole 'fscMember'}}
     {{> companyDetailAdminPanel}}
     <hr/>
   {{/if}}
@@ -712,7 +712,7 @@
       {{else}}
         <div style="word-break: break-all;">
           {{companyData.companyName}}並沒有參加這一屆的最萌亂鬥大賽！
-          {{#if isUserId companyData.manager}}
+          {{#if isCurrentUser companyData.manager}}
             {{#if inCanJoinTime}}
               <button class="btn btn-primary btn-sm" type="button" data-action="joinArena">
                 報名參賽
@@ -849,7 +849,7 @@
           </button>
         </div>
       {{/with}}
-      {{#if isUserId this.joinData.manager}}
+      {{#if isCurrentUser this.joinData.manager}}
         {{> arenaStrategyForm}}
       {{/if}}
     {{else}}

--- a/client/company/companyList.html
+++ b/client/company/companyList.html
@@ -179,16 +179,10 @@
         {{/if}}
         <hr style="margin: 0px;" />
         <div class="row btn-group">
-          {{#if isUserId this.manager}}
+          {{#if currentUserCanManage this}}
             <a class="btn btn-tab" href="{{getManageHref this._id}}">
               經營管理
             </a>
-          {{else}}
-            {{#if currentUser.profile.isAdmin}}
-              <a class="btn btn-tab" href="{{getManageHref this._id}}">
-                經營管理
-              </a>
-            {{/if}}
           {{/if}}
           <button class="btn btn-tab" type="button" data-action="createBuyOrder">
             購入
@@ -272,7 +266,7 @@
       </div>
       {{#if currentUser}}
         <div class="col-12 border-grid">
-          {{#if isUserId this.manager}}
+          {{#if isCurrentUser this.manager}}
             <div class="mb-1">
               您是該公司的經理人。
               <a class="btn btn-primary btn-sm" href="{{getManageHref this._id}}">
@@ -280,7 +274,7 @@
               </a>
             </div>
           {{else}}
-            {{#if currentUser.profile.isAdmin}}
+            {{#if currentUserHasRole 'fscMember'}}
               <div class="mb-1">
                 <a class="btn btn-primary btn-sm" href="{{getManageHref this._id}}">
                   經營管理

--- a/client/company/companyList.js
+++ b/client/company/companyList.js
@@ -9,7 +9,7 @@ import { dbDirectors } from '/db/dbDirectors';
 import { dbOrders } from '/db/dbOrders';
 import { inheritedShowLoadingOnSubscribing } from '../layout/loading';
 import { createBuyOrder, createSellOrder, retrieveOrder, changeChairmanTitle, toggleFavorite } from '../utils/methods';
-import { isUserId, isChairman } from '../utils/helpers';
+import { isCurrentUser, isChairman, currentUserHasRole } from '../utils/helpers';
 import { shouldStopSubscribe } from '../utils/idle';
 import { rCompanyListViewMode } from '../utils/styles';
 
@@ -164,7 +164,7 @@ const companyListHelpers = {
     if (isChairman(companyData._id)) {
       return 'company-card-chairman';
     }
-    if (isUserId(companyData.manager)) {
+    if (isCurrentUser(companyData.manager)) {
       return 'company-card-manager';
     }
     const amount = companyListHelpers.getStockAmount(companyData._id);
@@ -210,6 +210,9 @@ const companyListHelpers = {
     const userId = Meteor.user()._id;
 
     return dbOrders.find({ companyId, userId });
+  },
+  currentUserCanManage(company) {
+    return isCurrentUser(company.manager) || currentUserHasRole('fscMember');
   }
 };
 const companyListEvents = {

--- a/client/foundation/foundationDetail.html
+++ b/client/foundation/foundationDetail.html
@@ -11,7 +11,7 @@
               <button class="btn btn-primary" type="button" data-action="invest">
                 投資
               </button>
-              {{#if currentUser.profile.isAdmin}}
+              {{#if currentUserHasRole 'fscMember'}}
                 <a class="btn btn-warning" href="#" data-action="changeCompanyName">
                   更名
                 </a>

--- a/client/foundation/foundationList.html
+++ b/client/foundation/foundationList.html
@@ -127,7 +127,7 @@
         {{#if currentUser}}
           <hr class="m-0">
           <div class="row btn-group">
-            {{#if currentUser.profile.isAdmin}}
+            {{#if currentUserHasRole 'fscMember'}}
               <a class="btn btn-tab" href="{{getEditHref this._id}}">
                 修改計劃
               </a>
@@ -186,12 +186,12 @@
       </div>
       {{#if currentUser}}
         <div class="col-12 border-grid">
-          {{#if currentUser.profile.isAdmin}}
+          {{#if currentUserHasRole 'fscMember'}}
             <a class="btn btn-warning btn-sm" href="{{getEditHref this._id}}">
               修改計劃
             </a>
           {{/if}}
-          {{#if isUserId this.manager}}
+          {{#if isCurrentUser this.manager}}
             <div class="mb-1">
               您是此創立計劃的發起人。
             </div>

--- a/client/foundation/foundationList.js
+++ b/client/foundation/foundationList.js
@@ -5,7 +5,7 @@ import { Template } from 'meteor/templating';
 import { FlowRouter } from 'meteor/kadira:flow-router';
 import { ReactiveVar } from 'meteor/reactive-var';
 import { dbFoundations } from '/db/dbFoundations';
-import { formatDateText, isUserId } from '../utils/helpers';
+import { formatDateText, isCurrentUser } from '../utils/helpers';
 import { inheritedShowLoadingOnSubscribing } from '../layout/loading';
 import { alertDialog } from '../layout/alertDialog';
 import { shouldStopSubscribe } from '../utils/idle';
@@ -143,7 +143,7 @@ const foundationListHelpers = {
     if (! Meteor.user()) {
       return 'company-card-default';
     }
-    if (isUserId(this.manager)) {
+    if (isCurrentUser(this.manager)) {
       return 'company-card-manager';
     }
     const invest = this.invest;

--- a/client/layout/tutorial.html
+++ b/client/layout/tutorial.html
@@ -119,20 +119,9 @@
               </ol>
               <li>要維持股市市場的健康運作，適當的人工介入是必需的，目前的金管會加入<a href="https://www.ptt.cc/bbs/ACGN_stock/M.1509025008.A.ABF.html" target="_blank">章程</a>在此，制定的規則<a href="https://docs.google.com/document/d/1INBDMg1MFOcEucdJDO57qIkTsFR7iNiZpC2JW2qoYso/edit" target="_blank">在此</a>，成員如下：</li>
               <ol>
-                <li>{{> userLink '2HFha7H4TviS3Pbra'}}</li>
-                <li>{{> userLink 'Kq6PFRE4MBoSrynNy'}}</li>
-                <li>{{> userLink 'XhF3mWuGjmkmtxb26'}}</li>
-                <li>{{> userLink '5twbaLu2q2KauA6n6'}}</li>
-                <li>{{> userLink 'bh7yDRqxmkvxWPox2'}}</li>
-                <li>{{> userLink '5yc4uqEmrauzHKGKH'}}</li>
-                <li>{{> userLink 'b9hfWqHMdEnnZfnmh'}}</li>
-                <li>{{> userLink 'JvTYK97p3K9Ff5DGS'}}</li>
-                <li>{{> userLink '2MnixRrWRWFsYuqa9'}}</li>
-                <li>{{> userLink 'phcAQGMJTXBWYTdBC'}}</li>
-                <li>{{> userLink 'Ep7qv65hM3x7jf3zR'}}</li>
-                <li>{{> userLink 'ysWH2DiKFG7gZWG5S'}}</li>
-                <li>{{> userLink 'RqQivWo4eSnFrKJTX'}}</li>
-                <li>{{> userLink 'LqeYNy7zE5sEAo3DQ'}}</li>
+                {{#each userId in fscMembers}}
+                  <li>{{> userLink userId}}</li>
+                {{/each}}
               </ol>
             </ol>
           </div>

--- a/client/layout/tutorial.js
+++ b/client/layout/tutorial.js
@@ -1,4 +1,5 @@
 import { $ } from 'meteor/jquery';
+import { _ } from 'meteor/underscore';
 import { Meteor } from 'meteor/meteor';
 import { Template } from 'meteor/templating';
 
@@ -8,6 +9,10 @@ import { VIP_LEVEL5_MAX_COUNT } from '/db/dbVips';
 import { importantAccuseLogTypeList } from '/db/dbLog';
 import { stonePowerTable } from '/db/dbCompanyStones';
 
+Template.tutorial.onCreated(function() {
+  this.subscribe('fscMembers');
+});
+
 Template.tutorial.events({
   'click .card-header.pointer'(event) {
     $(event.currentTarget)
@@ -15,6 +20,7 @@ Template.tutorial.events({
       .toggleClass('show');
   }
 });
+
 Template.tutorial.helpers({
   importantAccuseLogTypeList() {
     return importantAccuseLogTypeList;
@@ -107,5 +113,8 @@ Template.tutorial.helpers({
     const { lockTime } = Meteor.settings.public.companyProfitDistribution;
 
     return Math.floor(lockTime / 1000 / 60 / 60);
+  },
+  fscMembers() {
+    return _.pluck(Meteor.users.find({ 'profile.roles': 'fscMember' }, { sort: { createdAt: 1 } }).fetch(), '_id');
   }
 });

--- a/client/product/productCard.html
+++ b/client/product/productCard.html
@@ -45,7 +45,7 @@
           {{product.voteCount}}
         </button>
       </div>
-      {{#if isAdmin}}
+      {{#if currentUserHasRole 'fscMember'}}
         <div class="my-1">
           <button class="btn btn-sm btn-danger" title="修改" data-edit-product="{{product._id}}">修改</button>
           <button class="btn btn-sm btn-danger" title="下架" data-ban-product="{{product._id}}">下架</button>

--- a/client/product/productCard.js
+++ b/client/product/productCard.js
@@ -9,11 +9,6 @@ import { currencyFormat } from '../utils/helpers';
 import { alertDialog } from '../layout/alertDialog';
 
 Template.productCard.helpers({
-  isAdmin() {
-    const user = Meteor.user();
-
-    return user && user.profile.isAdmin;
-  },
   soldAmount() {
     const { product } = Template.currentData();
     const { totalAmount, stockAmount, availableAmount } = product;

--- a/client/productCenter/productCenterByCompany.html
+++ b/client/productCenter/productCenterByCompany.html
@@ -35,7 +35,7 @@
           推薦數
           {{{getSortIcon 'voteCount'}}}
         </th>
-        {{#if currentUser.profile.isAdmin}}
+        {{#if currentUserHasRole 'fscMember'}}
           <th class="text-center" style="width: 120px;" title="管理">
             管理
           </th>
@@ -62,7 +62,7 @@
               <i class="fa fa-ticket" aria-hidden="true"></i>
             </button>
           </td>
-          {{#if currentUser.profile.isAdmin}}
+          {{#if currentUserHasRole 'fscMember'}}
             <td class="text-center" data-title="管理">
               <button class="btn btn-sm btn-danger" title="修改" data-edit-product="{{product._id}}">修改</button>
               <button class="btn btn-sm btn-danger" title="下架" data-ban-product="{{product._id}}">下架</button>

--- a/client/productCenter/productCenterBySeason.html
+++ b/client/productCenter/productCenterBySeason.html
@@ -54,7 +54,7 @@
           得票數
           {{{getSortIcon 'voteCount'}}}
         </th>
-        {{#if currentUser.profile.isAdmin}}
+        {{#if currentUserHasRole 'fscMember'}}
           <th class="text-center" style="width: 140px;" title="管理">
             管理
           </th>
@@ -66,7 +66,7 @@
         {{> productInfoBySeasonTable}}
       {{else}}
         <tr class="default-content">
-          {{#if currentUser.profile.isAdmin}}
+          {{#if currentUserHasRole 'fscMember'}}
             <td class="text-center" colspan="5">當季度沒有任何產品上架！</td>
           {{else}}
             <td class="text-center" colspan="4">當季度沒有任何產品上架！</td>
@@ -103,7 +103,7 @@
         <i class="fa fa-ticket" aria-hidden="true"></i>
       </button>
     </td>
-    {{#if currentUser.profile.isAdmin}}
+    {{#if currentUserHasRole 'fscMember'}}
       <td class="text-center text-nowrap" data-title="管理">
         <button class="btn btn-sm btn-danger" title="修改" data-edit-product="{{this._id}}">修改</button>
         <button class="btn btn-sm btn-danger" title="下架" data-ban-product="{{this._id}}">下架</button>

--- a/client/ruleDiscuss/createRuleAgenda.html
+++ b/client/ruleDiscuss/createRuleAgenda.html
@@ -3,7 +3,7 @@
     <div class="card-block">
       <h1 class="card-title mb-1">建立新議程</h1>
       <hr />
-      {{#if currentUser.profile.isAdmin}}
+      {{#if currentUserHasRole 'planner'}}
         {{#with defaultData}}
           {{> ruleAgendaForm}}
         {{/with}}

--- a/client/ruleDiscuss/ruleAgendaDetail.html
+++ b/client/ruleDiscuss/ruleAgendaDetail.html
@@ -4,7 +4,7 @@
       <div class="card-block">
         <h1 class="card-title text-truncate">
           {{this.title}}
-          {{#if currentUser.profile.isAdmin}}
+          {{#if currentUserHasRole 'planner'}}
             <button class="btn btn-danger float-right" data-action="takeDownRuleAgenda">撤銷</button>
           {{/if}}
           {{#if currentUser}}
@@ -19,7 +19,7 @@
         <h3>
           提案人：
           {{>userLink this.proposer}}
-          {{#if currentUser.profile.isAdmin}}
+          {{#if currentUserHasRole 'planner'}}
             <button class="btn btn-primary btn-sm" data-action="updateAgendaProposer">修改</button>
           {{/if}}
         </h3>

--- a/client/ruleDiscuss/ruleAgendaList.html
+++ b/client/ruleDiscuss/ruleAgendaList.html
@@ -9,7 +9,7 @@
         <div class="text-nowrap text-muted">
           進行中的議程
         </div>
-        {{#if currentUser.profile.isAdmin}}
+        {{#if currentUserHasRole 'planner'}}
           <div class="d-flex flex-wrap justify-content-end ml-auto">
             <a class="btn btn-primary" href="{{getNewAgendaHref}}">
               <i class="fa fa-plus" aria-hidden="true"></i>

--- a/client/utils/helpers.js
+++ b/client/utils/helpers.js
@@ -11,6 +11,8 @@ import { dbCompanies } from '/db/dbCompanies';
 import { dbEmployees } from '/db/dbEmployees';
 import { dbVariables } from '/db/dbVariables';
 import { stoneDisplayName } from '/db/dbCompanyStones';
+import { hasRole, hasAnyRoles, hasAllRoles } from '/db/users';
+
 import '../layout/highcharts-themes';
 
 Meteor.subscribe('variables');
@@ -136,7 +138,7 @@ export function isChairman(companyId) {
 }
 Template.registerHelper('isChairman', isChairman);
 
-export function isUserId(userId) {
+export function isCurrentUser(userId) {
   const user = Meteor.user();
   if (user) {
     return user._id === userId;
@@ -145,7 +147,7 @@ export function isUserId(userId) {
     return false;
   }
 }
-Template.registerHelper('isUserId', isUserId);
+Template.registerHelper('isCurrentUser', isCurrentUser);
 
 export function isFavorite(companyId) {
   const user = Meteor.user();
@@ -293,3 +295,18 @@ export function toPercent(x) {
   return `${Math.round(x * 100)}%`;
 }
 Template.registerHelper('toPercent', toPercent);
+
+export function currentUserHasRole(role) {
+  return hasRole(Meteor.user(), role);
+}
+Template.registerHelper('currentUserHasRole', currentUserHasRole);
+
+export function currentUserHasAnyRoles(...roles) {
+  return hasAnyRoles(Meteor.user(), ...roles);
+}
+Template.registerHelper('currentUserHasAnyRoles', currentUserHasAnyRoles);
+
+export function currentUserHasAllRoles(...roles) {
+  return hasAllRoles(Meteor.user(), ...roles);
+}
+Template.registerHelper('currentUserHasAllRoles', currentUserHasAllRoles);

--- a/common/imports/guards/companyGuard.js
+++ b/common/imports/guards/companyGuard.js
@@ -26,7 +26,7 @@ class CompanyGuard {
   checkIsManagableByUser(user) {
     if (! this.company.manager || this.company.manager === '!none') {
       // 無經理人的狀況下，可由金管會成員代為管理
-      guardUser(user).checkIsAdmin();
+      guardUser(user).checkHasRole('fscMember');
     }
     else {
       // 有經理人的狀況下，只有經理人可以管理

--- a/common/imports/guards/userGuard.js
+++ b/common/imports/guards/userGuard.js
@@ -1,7 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 import { _ } from 'meteor/underscore';
 
-import { banTypeDescription } from '/db/users';
+import { banTypeDescription, hasRole, hasAnyRoles } from '/db/users';
 
 class UserGuard {
   constructor(user) {
@@ -50,9 +50,17 @@ class UserGuard {
     return this;
   }
 
-  checkIsAdmin() {
-    if (! this.user.profile.isAdmin) {
-      throw new Meteor.Error(403, '您並非金融管理會委員，無法進行此操作！');
+  checkHasRole(role) {
+    if (! hasRole(this.user, role)) {
+      throw new Meteor.Error(403, '權限不符，無法進行此操作！');
+    }
+
+    return this;
+  }
+
+  checkHasAnyRoles(...roles) {
+    if (! hasAnyRoles(this.user, ...roles)) {
+      throw new Meteor.Error(403, '權限不符，無法進行此操作！');
     }
 
     return this;

--- a/db/dbAdvertising.js
+++ b/db/dbAdvertising.js
@@ -1,4 +1,4 @@
-'use strict';
+import { Meteor } from 'meteor/meteor';
 import { Mongo } from 'meteor/mongo';
 import SimpleSchema from 'simpl-schema';
 
@@ -33,3 +33,13 @@ const schema = new SimpleSchema({
   }
 });
 dbAdvertising.attachSchema(schema);
+
+dbAdvertising.findByIdOrThrow = function(id, options) {
+  const result = dbAdvertising.findOne(id, options);
+
+  if (! result) {
+    throw new Meteor.Error(404, `找不到識別碼為「${id}」的廣告！`);
+  }
+
+  return result;
+};

--- a/db/dbFoundations.js
+++ b/db/dbFoundations.js
@@ -1,10 +1,9 @@
-'use strict';
+import { Meteor } from 'meteor/meteor';
 import { Mongo } from 'meteor/mongo';
 import SimpleSchema from 'simpl-schema';
 
 // 新創公司資料集
 export const dbFoundations = new Mongo.Collection('foundations');
-export default dbFoundations;
 
 const schema = new SimpleSchema({
   // 公司名稱
@@ -75,3 +74,13 @@ const schema = new SimpleSchema({
   }
 });
 dbFoundations.attachSchema(schema);
+
+dbFoundations.findByIdOrThrow = function(id, options) {
+  const result = dbFoundations.findOne(id, options);
+
+  if (! result) {
+    throw new Meteor.Error(404, `找不到識別碼為「${id}」的新創計劃，該新創計劃可能已經創立成功或失敗！`);
+  }
+
+  return result;
+};

--- a/db/dbRuleAgendas.js
+++ b/db/dbRuleAgendas.js
@@ -1,10 +1,9 @@
-'use strict';
+import { Meteor } from 'meteor/meteor';
 import { Mongo } from 'meteor/mongo';
 import SimpleSchema from 'simpl-schema';
 
 // 議程資料集
 export const dbRuleAgendas = new Mongo.Collection('ruleAgendas');
-export default dbRuleAgendas;
 
 const schema = new SimpleSchema({
   // 議程標題
@@ -59,3 +58,13 @@ const schema = new SimpleSchema({
   }
 });
 dbRuleAgendas.attachSchema(schema);
+
+dbRuleAgendas.findByIdOrThrow = function(id, options) {
+  const result = dbRuleAgendas.findOne(id, options);
+
+  if (! result) {
+    throw new Meteor.Error(404, `找不到識別碼為「${id}」的提案！`);
+  }
+
+  return result;
+};

--- a/db/dbUserArchive.js
+++ b/db/dbUserArchive.js
@@ -3,11 +3,10 @@ import { Mongo } from 'meteor/mongo';
 import { Match } from 'meteor/check';
 import SimpleSchema from 'simpl-schema';
 
-import { banTypeList } from './users';
+import { banTypeList, userRoleMap } from './users';
 
 // 使用者保管庫
 export const dbUserArchive = new Mongo.Collection('userArchive');
-export default dbUserArchive;
 
 const schema = new SimpleSchema({
   // 保管狀態
@@ -29,11 +28,6 @@ const schema = new SimpleSchema({
     type: String,
     optional: true
   },
-  // 是否為金管會委員
-  isAdmin: {
-    type: Boolean,
-    defaultValue: false
-  },
   // 聖晶石數量
   saintStones: {
     type: SimpleSchema.Integer,
@@ -47,6 +41,15 @@ const schema = new SimpleSchema({
   },
   'ban.$': {
     type: new Match.OneOf(...banTypeList)
+  },
+  // 使用者的系統權限組
+  roles: {
+    type: Array,
+    defaultValue: []
+  },
+  'roles.$': {
+    type: String,
+    allowedValues: Object.keys(userRoleMap)
   }
 });
 dbUserArchive.attachSchema(schema);

--- a/db/users.js
+++ b/db/users.js
@@ -29,6 +29,44 @@ export function banTypeDescription(banType) {
   }
 }
 
+export const userRoleMap = {
+  superAdmin: {
+    displayName: '超級管理員'
+  },
+  generalManager: {
+    displayName: '營運總管'
+  },
+  developer: {
+    displayName: '工程部成員'
+  },
+  planner: {
+    displayName: '企劃部成員'
+  },
+  fscMember: {
+    displayName: '金管會成員'
+  }
+};
+
+export function hasRole(user, role) {
+  return user && user.profile && user.profile.roles && user.profile.roles.includes(role);
+}
+
+export function hasAnyRoles(user, ...roles) {
+  return user && user.profile && user.profile.roles && roles.some((role) => {
+    return user.profile.roles.includes(role);
+  });
+}
+
+export function hasAllRoles(user, ...roles) {
+  return user && user.profile && user.profile.roles && roles.every((role) => {
+    return user.profile.roles.includes(role);
+  });
+}
+
+export function roleDisplayName(role) {
+  return (userRoleMap[role] || { displayName: `未知的身份組成員(${role})` }).displayName;
+}
+
 const schema = new SimpleSchema({
   // 使用者PTT帳號名稱
   username: {
@@ -97,11 +135,6 @@ const schema = new SimpleSchema({
           return obj;
         }, {}))
       },
-      // 是否為金管會委員
-      isAdmin: {
-        type: Boolean,
-        defaultValue: false
-      },
       // 是否處於繳稅逾期的狀態
       notPayTax: {
         type: Boolean,
@@ -144,9 +177,19 @@ const schema = new SimpleSchema({
       lastVacationEndDate: {
         type: Date,
         optional: true
+      },
+      // 使用者的系統權限組
+      roles: {
+        type: Array,
+        defaultValue: []
+      },
+      'roles.$': {
+        type: String,
+        allowedValues: Object.keys(userRoleMap)
       }
     })
   },
+  // user-status 的欄位定義
   status: {
     type: new SimpleSchema({
       // 是否為上線狀態

--- a/integration-test/server/methods/product/createProduct.test.js
+++ b/integration-test/server/methods/product/createProduct.test.js
@@ -64,15 +64,15 @@ describe('method createProduct', function() {
     });
 
     it('should success if the user is admin', function() {
-      Meteor.users.update(userId, { $set: { 'profile.isAdmin': true } });
+      Meteor.users.update(userId, { $addToSet: { 'profile.roles': 'fscMember' } });
       const inputProductData = productFactory.build({ companyId });
       createProduct.bind(null, userId, inputProductData).must.not.throw();
     });
 
     it('should fail if the user is not admin', function() {
-      Meteor.users.update(userId, { $set: { 'profile.isAdmin': false } });
+      Meteor.users.update(userId, { $pullAll: { 'profile.roles': 'fscMember' } });
       const inputProductData = productFactory.build({ companyId });
-      createProduct.bind(null, userId, inputProductData).must.throw(Meteor.Error, '您並非金融管理會委員，無法進行此操作！ [403]');
+      createProduct.bind(null, userId, inputProductData).must.throw(Meteor.Error, '權限不符，無法進行此操作！ [403]');
     });
   });
 });

--- a/server/intervalCheck.js
+++ b/server/intervalCheck.js
@@ -209,7 +209,7 @@ export function doRoundWorks(lastRoundData, lastSeasonData) {
             status: 'archived',
             name: userData.profile.name,
             validateType: userData.profile.validateType,
-            isAdmin: userData.profile.isAdmin,
+            roles: userData.profile.roles,
             saintStones: userData.profile.stones.saint,
             ban: userData.profile.ban
           }

--- a/server/methods/accuse/banProduct.js
+++ b/server/methods/accuse/banProduct.js
@@ -22,7 +22,7 @@ function banProduct({ userId, productId, message }) {
   debug.log('banProduct', { userId, productId, message });
 
   const user = Meteor.users.findByIdOrThrow(userId);
-  guardUser(user).checkIsAdmin();
+  guardUser(user).checkHasRole('fscMember');
 
   const { companyId, productName, profit } = dbProducts.findByIdOrThrow(productId);
 

--- a/server/methods/accuse/confiscateStocks.js
+++ b/server/methods/accuse/confiscateStocks.js
@@ -4,6 +4,7 @@ import { check } from 'meteor/check';
 import { dbDirectors } from '/db/dbDirectors';
 import { dbLog } from '/db/dbLog';
 import { debug } from '/server/imports/utils/debug';
+import { guardUser } from '/common/imports/guards';
 
 Meteor.methods({
   confiscateStocks({ userId, message }) {
@@ -17,16 +18,16 @@ Meteor.methods({
 });
 function confiscateStocks(user, { userId, message }) {
   debug.log('confiscateStocks', { user, userId, message });
-  if (! user.profile.isAdmin) {
-    throw new Meteor.Error(403, '您並非金融管理會委員，無法進行此操作！');
-  }
-  if (Meteor.users.find(userId).count() < 1) {
-    throw new Meteor.Error(404, '找不到識別碼為「' + userId + '」的使用者！');
-  }
+
+  guardUser(user).checkHasRole('fscMember');
+
+  Meteor.users.findByIdOrThrow(userId, { fields: { _id: 1 } });
+
   const cursor = dbDirectors.find({ userId });
   if (cursor.count() < 1) {
-    return true;
+    return;
   }
+
   const directorsBulk = dbDirectors.rawCollection().initializeUnorderedBulkOp();
   const logBulk = dbLog.rawCollection().initializeUnorderedBulkOp();
   const createdAt = new Date();
@@ -35,35 +36,29 @@ function confiscateStocks(user, { userId, message }) {
     logBulk.insert({
       logType: '沒收股份',
       userId: [user._id, userId],
-      companyId: companyId,
+      companyId,
       data: {
         reason: message,
         stocks
       },
-      createdAt: createdAt
+      createdAt
     });
     if (dbDirectors.find({ companyId, userId: '!FSC' }).count() > 0) {
       // 由於directors主鍵為Mongo Object ID，在Bulk進行find會有問題，故以companyId+userId進行搜尋更新
       directorsBulk
         .find({ companyId, userId: '!FSC' })
-        .updateOne({
-          $inc: {
-            stocks: stocks
-          }
-        });
+        .updateOne({ $inc: { stocks } });
     }
     else {
       directorsBulk.insert({
-        companyId: companyId,
+        companyId,
         userId: '!FSC',
-        stocks: stocks,
-        createdAt: createdAt
+        stocks,
+        createdAt
       });
     }
   });
   logBulk.execute();
   directorsBulk.execute();
   dbDirectors.remove({ userId });
-
-  return true;
 }

--- a/server/methods/accuse/forfeitUserMoney.js
+++ b/server/methods/accuse/forfeitUserMoney.js
@@ -3,6 +3,7 @@ import { check, Match } from 'meteor/check';
 
 import { dbLog } from '/db/dbLog';
 import { debug } from '/server/imports/utils/debug';
+import { guardUser } from '/common/imports/guards';
 
 Meteor.methods({
   forfeitUserMoney({ userId, reason, amount }) {
@@ -18,17 +19,14 @@ Meteor.methods({
 
 function forfeitUserMoney(user, { userId, reason, amount }) {
   debug.log('forfeitUserMoney', { user, userId, reason, amount });
-  if (! user.profile.isAdmin) {
-    throw new Meteor.Error(403, '您並非金融管理會委員，無法進行此操作！');
-  }
+
+  guardUser(user).checkHasRole('fscMember');
 
   if (amount === 0) {
     throw new Meteor.Error(403, '罰金不得為 0！');
   }
 
-  if (Meteor.users.find(userId).count() < 1) {
-    throw new Meteor.Error(404, `找不到識別碼為「${userId}」的使用者！`);
-  }
+  Meteor.users.findByIdOrThrow(userId, { fields: { _id: 1 } });
 
   dbLog.insert({
     logType: amount > 0 ? '課以罰款' : '退還罰款',

--- a/server/methods/accuse/fscAnnouncement.js
+++ b/server/methods/accuse/fscAnnouncement.js
@@ -3,6 +3,7 @@ import { check, Match } from 'meteor/check';
 
 import { dbLog } from '/db/dbLog';
 import { debug } from '/server/imports/utils/debug';
+import { guardUser } from '/common/imports/guards';
 
 Meteor.methods({
   fscAnnouncement({ userIds, companyId, message }) {
@@ -17,9 +18,8 @@ Meteor.methods({
 });
 function fscAnnouncement(user, { userIds, companyId, message }) {
   debug.log('fscAnnouncement', { user, userIds, message });
-  if (! user.profile.isAdmin) {
-    throw new Meteor.Error(403, '您並非金融管理會委員，無法進行此操作！');
-  }
+
+  guardUser(user).checkHasRole('fscMember');
 
   const nonEmptyUserIds = userIds.filter((id) => {
     return id && id !== '!none';

--- a/server/methods/accuse/unmarkCompanyIllegal.js
+++ b/server/methods/accuse/unmarkCompanyIllegal.js
@@ -5,6 +5,7 @@ import { dbLog } from '/db/dbLog';
 import { dbCompanies } from '/db/dbCompanies';
 import { limitMethod } from '/server/imports/utils/rateLimit';
 import { debug } from '/server/imports/utils/debug';
+import { guardUser } from '/common/imports/guards';
 
 Meteor.methods({
   unmarkCompanyIllegal(companyId) {
@@ -17,13 +18,10 @@ Meteor.methods({
 });
 function unmarkCompanyIllegal(user, companyId) {
   debug.log('unmarkCompanyIllegal', { user, companyId });
-  if (! user.profile.isAdmin) {
-    throw new Meteor.Error(403, '您並非金融管理會委員，無法進行此操作！');
-  }
 
-  if (dbCompanies.find(companyId).count() === 0) {
-    throw new Meteor.Error(404, `找不到識別碼為「${companyId}」的公司！`);
-  }
+  guardUser(user).checkHasRole('fscMember');
+
+  dbCompanies.findByIdOrThrow(companyId, { fields: { _id: 1 } });
 
   dbCompanies.update(companyId, { $unset: { illegalReason: 1 } });
   dbLog.insert({

--- a/server/methods/announcement/editAnnouncement.js
+++ b/server/methods/announcement/editAnnouncement.js
@@ -3,6 +3,7 @@ import { check } from 'meteor/check';
 
 import { dbVariables } from '/db/dbVariables';
 import { debug } from '/server/imports/utils/debug';
+import { guardUser } from '/common/imports/guards';
 
 Meteor.methods({
   editAnnouncement(announcement, announcementDetail) {
@@ -16,9 +17,7 @@ Meteor.methods({
 });
 function editAnnouncement(user, announcement, announcementDetail) {
   debug.log('editAnnouncement', { user, announcement, announcementDetail });
-  if (! user.profile.isAdmin) {
-    throw new Meteor.Error(403, '您並非金融管理會委員，無法進行此操作！');
-  }
+  guardUser(user).checkHasAnyRoles('developer', 'planner', 'fscMember');
   dbVariables.set('announcement', announcement);
   dbVariables.set('announcementDetail', announcementDetail);
 }

--- a/server/methods/company/changeCompanyName.js
+++ b/server/methods/company/changeCompanyName.js
@@ -6,6 +6,7 @@ import { dbCompanyArchive } from '/db/dbCompanyArchive';
 import { dbLog } from '/db/dbLog';
 import { limitMethod } from '/server/imports/utils/rateLimit';
 import { debug } from '/server/imports/utils/debug';
+import { guardUser } from '/common/imports/guards';
 
 Meteor.methods({
   changeCompanyName(companyId, newCompanyName) {
@@ -19,39 +20,19 @@ Meteor.methods({
 });
 function changeCompanyName(user, companyId, newCompanyName) {
   debug.log('changeCompanyName', { user, companyId, newCompanyName });
-  if (! user.profile.isAdmin) {
-    throw new Meteor.Error(403, '您並非金融管理會委員，無法進行此操作！');
-  }
-  const companyData = dbCompanies.findOne(companyId, {
-    fields: {
-      companyName: 1
-    }
-  });
-  if (! companyData) {
-    throw new Meteor.Error(404, '找不到識別碼為「' + companyId + '」的公司！');
-  }
 
-  const oldCompanyName = companyData.companyName;
+  guardUser(user).checkHasRole('fscMember');
+
+  const { companyName: oldCompanyName } = dbCompanies.findByIdOrThrow(companyId, { fields: { companyName: 1 } });
 
   dbLog.insert({
     logType: '公司更名',
     userId: [user._id],
     companyId: companyId,
-    data: {
-      oldCompanyName,
-      newCompanyName
-    },
+    data: { oldCompanyName, newCompanyName },
     createdAt: new Date()
   });
-  dbCompanies.update(companyId, {
-    $set: {
-      companyName: newCompanyName
-    }
-  });
-  dbCompanyArchive.update(companyId, {
-    $set: {
-      name: newCompanyName
-    }
-  });
+  dbCompanies.update(companyId, { $set: { companyName: newCompanyName } });
+  dbCompanyArchive.update(companyId, { $set: { name: newCompanyName } });
 }
 limitMethod('changeCompanyName');

--- a/server/methods/foundation/unmarkFoundationIllegal.js
+++ b/server/methods/foundation/unmarkFoundationIllegal.js
@@ -4,6 +4,7 @@ import { check } from 'meteor/check';
 import { dbFoundations } from '/db/dbFoundations';
 import { limitMethod } from '/server/imports/utils/rateLimit';
 import { debug } from '/server/imports/utils/debug';
+import { guardUser } from '/common/imports/guards';
 
 Meteor.methods({
   unmarkFoundationIllegal(companyId) {
@@ -16,14 +17,8 @@ Meteor.methods({
 });
 function unmarkFoundationIllegal(user, companyId) {
   debug.log('unmarkFoundationIllegal', { user, companyId });
-  if (! user.profile.isAdmin) {
-    throw new Meteor.Error(403, '您並非金融管理會委員，無法進行此操作！');
-  }
-
-  if (dbFoundations.find(companyId).count() === 0) {
-    throw new Meteor.Error(404, '找不到要編輯的新創計劃，該新創計劃可能已經創立成功或失敗！');
-  }
-
+  guardUser(user).checkHasRole('fscMember');
+  dbFoundations.findByIdOrThrow(companyId, { fields: { _id: 1 } });
   dbFoundations.update(companyId, { $unset: { illegalReason: 1 } });
 }
 limitMethod('unmarkFoundationIllegal');

--- a/server/methods/product/adminEditProduct.js
+++ b/server/methods/product/adminEditProduct.js
@@ -29,7 +29,7 @@ export function adminEditProduct({ userId, productId, newData }) {
   debug.log('adminEditProduct', { userId, productId, newData });
 
   const user = Meteor.users.findByIdOrThrow(userId);
-  guardUser(user).checkIsAdmin();
+  guardUser(user).checkHasRole('fscMember');
 
   const { url } = newData;
 

--- a/server/methods/ruleAgenda/createAgenda.js
+++ b/server/methods/ruleAgenda/createAgenda.js
@@ -7,6 +7,7 @@ import { dbRuleIssues } from '/db/dbRuleIssues';
 import { dbRuleIssueOptions } from '/db/dbRuleIssueOptions';
 import { limitMethod } from '/server/imports/utils/rateLimit';
 import { debug } from '/server/imports/utils/debug';
+import { guardUser } from '/common/imports/guards';
 
 Meteor.methods({
   createAgenda(agendaData) {
@@ -33,10 +34,8 @@ Meteor.methods({
 });
 function createAgenda(user, agendaData) {
   debug.log('createAgenda', { user, agendaData });
-  const userId = user._id;
-  if (! user.profile.isAdmin) {
-    throw new Meteor.Error(403, '非金管委員不得建立議程！');
-  }
+
+  guardUser(user).checkHasRole('planner');
 
   const issues = agendaData.issues;
   if (issues.length === 0) {
@@ -55,12 +54,7 @@ function createAgenda(user, agendaData) {
     }
   });
 
-  const proposer = Meteor.users.findOne({
-    _id: agendaData.proposer
-  });
-  if (! proposer) {
-    throw new Meteor.Error(404, '提案人帳號不存在！');
-  }
+  Meteor.users.findByIdOrThrow({ _id: agendaData.proposer });
 
   const issueIds = [];
   issues.forEach((issue, issueIndex) => {
@@ -88,7 +82,7 @@ function createAgenda(user, agendaData) {
     description: agendaData.description,
     discussionUrl: agendaData.discussionUrl,
     proposer: agendaData.proposer,
-    creator: userId,
+    creator: user._id,
     createdAt: createdAt,
     issues: issueIds
   });

--- a/server/publications/accounts/fscMembers.js
+++ b/server/publications/accounts/fscMembers.js
@@ -1,0 +1,16 @@
+import { Meteor } from 'meteor/meteor';
+
+import { limitSubscription } from '/server/imports/utils/rateLimit';
+import { debug } from '/server/imports/utils/debug';
+
+Meteor.publish('fscMembers', function() {
+  debug.log('publish fscMembers');
+
+  return Meteor.users.find({ 'profile.roles': 'fscMember' }, {
+    fields: {
+      'profile.roles': 1,
+      createdAt: 1
+    }
+  });
+});
+limitSubscription('fscMembers');

--- a/server/publications/company/companyDataForEdit.js
+++ b/server/publications/company/companyDataForEdit.js
@@ -2,6 +2,7 @@ import { Meteor } from 'meteor/meteor';
 import { check } from 'meteor/check';
 
 import { dbCompanies } from '/db/dbCompanies';
+import { hasRole } from '/db/users';
 import { dbProducts } from '/db/dbProducts';
 import { limitSubscription } from '/server/imports/utils/rateLimit';
 import { debug } from '/server/imports/utils/debug';
@@ -15,36 +16,35 @@ Meteor.publish('companyDataForEdit', function(companyId) {
     return [];
   }
 
-  const user = Meteor.users.findOne(this.userId, { fields: { 'profile.isAdmin': true } });
+  const user = Meteor.users.findOne(this.userId, { fields: { 'profile.roles': 1 } });
   const companyData = dbCompanies.findOne(companyId, { fields: { manager: 1 } });
 
   if (! companyData) {
     return [];
   }
 
-  if (companyData.manager === this.userId || user.profile.isAdmin) {
-    return [
-      dbCompanies.find(companyId, {
-        fields: {
-          companyName: 1,
-          tags: 1,
-          pictureSmall: 1,
-          pictureBig: 1,
-          description: 1,
-          baseProductionFund: 1,
-          capital: 1, // NOTE 由於目前資本額變動機會較少，不太影響公司資訊編輯，故暫時加入在此
-          productPriceLimit: 1,
-          managerBonusRatePercent: 1,
-          employeeBonusRatePercent: 1,
-          capitalIncreaseRatePercent: 1
-        }
-      }),
-      dbProducts.find({ companyId, state: 'planning' })
-    ];
-  }
-  else {
+  if (companyData.manager !== this.userId && ! hasRole(user, 'fscMember')) {
     return [];
   }
+
+  return [
+    dbCompanies.find(companyId, {
+      fields: {
+        companyName: 1,
+        tags: 1,
+        pictureSmall: 1,
+        pictureBig: 1,
+        description: 1,
+        baseProductionFund: 1,
+        capital: 1, // NOTE 由於目前資本額變動機會較少，不太影響公司資訊編輯，故暫時加入在此
+        productPriceLimit: 1,
+        managerBonusRatePercent: 1,
+        employeeBonusRatePercent: 1,
+        capitalIncreaseRatePercent: 1
+      }
+    }),
+    dbProducts.find({ companyId, state: 'planning' })
+  ];
 });
 // 一分鐘最多10次
 limitSubscription('companyDataForEdit', 10);

--- a/server/startup/accountsOnCreateUserHook.js
+++ b/server/startup/accountsOnCreateUserHook.js
@@ -18,9 +18,9 @@ Accounts.onCreateUser((options, user) => {
     voteTickets: 0,
     vouchers: 0,
     stones: { birth: newUserBirthStones },
-    isAdmin: false,
     ban: [],
-    noLoginDayCount: 0
+    noLoginDayCount: 0,
+    roles: []
   });
 
   if (user.services && user.services.google) {
@@ -37,7 +37,7 @@ Accounts.onCreateUser((options, user) => {
   if (existingArchiveUser) {
     user._id = existingArchiveUser._id;
     user.profile.name = existingArchiveUser.name;
-    user.profile.isAdmin = existingArchiveUser.isAdmin;
+    user.profile.roles = existingArchiveUser.roles;
     user.profile.stones.saint = existingArchiveUser.saintStones;
     user.profile.ban = existingArchiveUser.ban;
     dbUserArchive.update(existingArchiveUser._id, { $set: { status: 'registered' } });
@@ -51,7 +51,7 @@ Accounts.onCreateUser((options, user) => {
       status: 'registered',
       name: user.profile.name,
       validateType: user.profile.validateType,
-      isAdmin: user.profile.isAdmin,
+      roles: user.profile.roles,
       saintStones: user.profile.stones.saint,
       ban: user.profile.ban
     });


### PR DESCRIPTION
1. 改以身份組的方式進行權限的指定 (#287)
  a. 新增 users.profile.roles
  b. 新增身份組：超級管理員、營運總管、工程部成員、企劃部成員、金管會成員
  c. 廢除 users.profile.isAdmin 旗標，並將這些 admin 指定為金管會成員
  d. 規則討論相關操作權在企劃部手上，金管會不再有權限操作這些功能
  e. 系統公告可由企劃部、工程部或金管會修改
  f. 其餘金管會相關權限維持不變
  g. 超級管理員與營運總管目前無特殊功能，未來才會加入
2. isUserId 改名為較有意義的 isCurrentUser
3. 整理部分程式碼