### PR TITLE
加入基礎的身份組管理功能

### DIFF
--- a/client/accountInfo/accountInfo.html
+++ b/client/accountInfo/accountInfo.html
@@ -4,6 +4,13 @@
       {{> accountInfoBasic}}
       <div class="card-block">
         <div class="row border-grid-body">
+          {{#if currentUserHasManageableRoles}}
+            <div class="col-12 border-grid">
+              {{#panelFolder name='manageRole' title='身份組管理' }}
+                {{> accountInfoManageRolePanel}}
+              {{/panelFolder}}
+            </div>
+          {{/if}}
           <div class="col-12 border-grid">
             {{#panelFolder name='tax' title='稅務資訊' }}
               {{> accountInfoTaxList}}
@@ -114,6 +121,9 @@
       <hr />
     {{/if}}
 
+    <div>
+      使用者識別碼：{{this._id}}
+    </div>
     <div>
       帳號驗證方式：
       {{showValidateType}}

--- a/client/accountInfo/accountInfo.js
+++ b/client/accountInfo/accountInfo.js
@@ -9,7 +9,7 @@ import { ReactiveVar } from 'meteor/reactive-var';
 import { dbCompanies } from '/db/dbCompanies';
 import { dbEmployees } from '/db/dbEmployees';
 import { dbVips } from '/db/dbVips';
-import { roleDisplayName } from '/db/users';
+import { roleDisplayName, getManageableRoles } from '/db/users';
 import { inheritedShowLoadingOnSubscribing } from '../layout/loading';
 import { alertDialog } from '../layout/alertDialog';
 import { shouldStopSubscribe } from '../utils/idle';
@@ -46,6 +46,9 @@ Template.accountInfo.helpers({
   ...accountInfoCommonHelpers,
   isDisplayPanel(panelType) {
     return _.contains(rDisplayPanelList.get(), panelType);
+  },
+  currentUserHasManageableRoles() {
+    return getManageableRoles(Meteor.user());
   }
 });
 Template.accountInfo.events({
@@ -65,6 +68,7 @@ Template.accountInfo.events({
 
 Template.accountInfoBasic.helpers({
   ...accountInfoCommonHelpers,
+  roleDisplayName,
   showValidateType() {
     switch (this.profile.validateType) {
       case 'Google': {
@@ -92,9 +96,6 @@ Template.accountInfoBasic.helpers({
   },
   isEndingVacation() {
     return this.profile.isEndingVacation;
-  },
-  roleDisplayName(role) {
-    return roleDisplayName(role);
   }
 });
 

--- a/client/accountInfo/accountInfoManageRolePanel.html
+++ b/client/accountInfo/accountInfoManageRolePanel.html
@@ -1,0 +1,46 @@
+<template name="accountInfoManageRolePanel">
+  <div class="row">
+    <div class="col-12 my-2">
+      <form class="form-inline align-items-center" name="assignRoleForm" action="#">
+        <select class="form-control form-control-sm" name="role">
+          <option value="" class="d-none" hidden>選擇身份組…</option>
+          {{#each role in assignableRoles}}
+            <option value="{{role}}">{{roleDisplayName role}}</option>
+          {{else}}
+            <option value="" disabled>沒有可指派的身份組！</option>
+          {{/each}}
+        </select>
+        <button type="submit" class="btn btn-sm btn-primary">指派身份組</button>
+      </form>
+    </div>
+    <div class="col-12 my-2">
+      <h5>已指派的身份組</h5>
+      <table class="table table-bordered mt-3 w-100 custom-responsive-table-md" style="table-layout: fixed;">
+        <thead>
+          <tr>
+            <th class="text-center text-nowrap">身份組</th>
+            <th class="text-center text-nowrap" style="width: 95px">管理</th>
+          </tr>
+        </thead>
+        <tbody>
+        {{#each role in this.profile.roles}}
+          <tr>
+            <td class="text-center text-truncate text-nowrap px-md-1 py-1" data-title="身份組">
+              {{roleDisplayName role}}
+            </td>
+            <td class="text-center text-truncate text-nowrap px-md-1 py-1" data-title="管理">
+              {{#if isRoleManageable role}}
+                <a href="#" class="btn btn-sm btn-danger" data-unassign-role="{{role}}"><i class="fa fa-times" aria-hidden="true"></i> 解除</a>
+              {{/if}}
+            </td>
+          </tr>
+        {{else}}
+          <tr class="default-content">
+            <td class="text-center text-truncate p-1" colspan="2">查無資料！</td>
+          </tr>
+        {{/each}}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>

--- a/client/accountInfo/accountInfoManageRolePanel.js
+++ b/client/accountInfo/accountInfoManageRolePanel.js
@@ -1,0 +1,72 @@
+import { Meteor } from 'meteor/meteor';
+import { Template } from 'meteor/templating';
+
+import { roleDisplayName, getManageableRoles, isRoleManageable } from '/db/users';
+import { alertDialog } from '../layout/alertDialog';
+import { paramUserId, paramUser } from './helpers';
+
+Template.accountInfoManageRolePanel.helpers({
+  roleDisplayName,
+  manageableRoles() {
+    return getManageableRoles(Meteor.user());
+  },
+  assignableRoles() {
+    const user = paramUser();
+
+    return getManageableRoles(Meteor.user()).filter((role) => {
+      return ! user.profile.roles.includes(role);
+    });
+  },
+  isRoleManageable(role) {
+    return isRoleManageable(Meteor.user(), role);
+  }
+});
+
+Template.accountInfoManageRolePanel.events({
+  'submit form[name="assignRoleForm"]'(event, templateInstance) {
+    event.preventDefault();
+
+    const userId = paramUserId();
+    const user = paramUser();
+    const role = templateInstance.$('select[name="role"]').val();
+
+    if (! role) {
+      return;
+    }
+
+    alertDialog.prompt({
+      title: '指派身份組',
+      message: `請輸入將使用者「${user.profile.name}」<span class="text-success">加入</span>至<span class="text-info">${roleDisplayName(role)}</span>身分組的理由：`,
+      callback: (reason) => {
+        if (! reason) {
+          return;
+        }
+
+        Meteor.customCall('assignUserRole', { userId, role, reason });
+      }
+    });
+  },
+  'click a[data-unassign-role]'(event, templateInstance) {
+    event.preventDefault();
+
+    const userId = paramUserId();
+    const user = paramUser();
+    const role = templateInstance.$(event.currentTarget).attr('data-unassign-role');
+
+    if (! role) {
+      return;
+    }
+
+    alertDialog.prompt({
+      title: '解除身份組',
+      message: `請輸入將使用者「${user.profile.name}」從<span class="text-info">${roleDisplayName(role)}</span>身份組<span class="text-danger">移除</span>的理由：`,
+      callback: (reason) => {
+        if (! reason) {
+          return;
+        }
+
+        Meteor.customCall('unassignUserRole', { userId, role, reason });
+      }
+    });
+  }
+});

--- a/client/utils/displayLog.js
+++ b/client/utils/displayLog.js
@@ -3,6 +3,7 @@ import { _ } from 'meteor/underscore';
 import { Template } from 'meteor/templating';
 import { FlowRouter } from 'meteor/kadira:flow-router';
 
+import { roleDisplayName } from '/db/users';
 import { stoneDisplayName, currencyFormat } from './helpers.js';
 
 Template.displayLog.onRendered(function() {
@@ -73,6 +74,7 @@ Template.displayLog.onRendered(function() {
     });
   });
 });
+
 Template.displayLog.helpers({
   getDescriptionHtml({ logType, userId, companyId, data = {} }) {
     const company = companySpan(companyId);
@@ -415,6 +417,12 @@ Template.displayLog.helpers({
       }
       case '礦機營利': {
         return `【礦機營利】「${company}」公司的挖礦機集結眾人之力努力運轉，使其獲得了$${currencyFormat(data.profit)}的營利額！`;
+      }
+      case '身份指派': {
+        return `【身份指派】${users[0]}以「${_.escape(data.reason)}」的理由將${users[1]}指派了${roleDisplayName(data.role)}的身份！`;
+      }
+      case '身份解除': {
+        return `【身份解除】${users[0]}以「${_.escape(data.reason)}」的理由將${users[1]}解除了${roleDisplayName(data.role)}的身份！`;
       }
     }
   }

--- a/common/imports/guards/companyGuard.js
+++ b/common/imports/guards/companyGuard.js
@@ -23,7 +23,7 @@ class CompanyGuard {
     return this;
   }
 
-  checkIsManagableByUser(user) {
+  checkIsManageableByUser(user) {
     if (! this.company.manager || this.company.manager === '!none') {
       // 無經理人的狀況下，可由金管會成員代為管理
       guardUser(user).checkHasRole('fscMember');

--- a/db/dbLog.js
+++ b/db/dbLog.js
@@ -368,7 +368,17 @@ export const logTypeList = [
   /**
    * 【礦機營利】「companyId」公司的挖礦機集結眾人之力努力運轉，使其獲得了$data.profit的營利額！
    */
-  '礦機營利'
+  '礦機營利',
+
+  /**
+   * 【身份指派】userId0以「data.reason」的理由將userId1指派了data.role的身份！
+   */
+  '身份指派',
+
+  /**
+   * 【身份解除】userId0以「data.reason」的理由將userId1解除了data.role的身份！
+   */
+  '身份解除'
 ];
 
 // 金管會相關紀錄

--- a/db/users.js
+++ b/db/users.js
@@ -37,15 +37,45 @@ export const userRoleMap = {
     displayName: '營運總管'
   },
   developer: {
-    displayName: '工程部成員'
+    displayName: '工程部成員',
+    manageableBy: ['generalManager']
   },
   planner: {
-    displayName: '企劃部成員'
+    displayName: '企劃部成員',
+    manageableBy: ['generalManager']
   },
   fscMember: {
-    displayName: '金管會成員'
+    displayName: '金管會成員',
+    manageableBy: ['generalManager']
   }
 };
+
+export function getManageableRoles(user) {
+  // 超級管理員可管理所有除自身以外的身份組
+  if (hasRole(user, 'superAdmin')) {
+    return Object.keys(userRoleMap).filter((role) => {
+      return role !== 'superAdmin';
+    });
+  }
+
+  // 其餘身份組由 userRoleMap 的設定來決定
+  return Object.entries(userRoleMap)
+    .filter(([, { manageableBy } ]) => {
+      return manageableBy && hasAnyRoles(user, ...manageableBy);
+    })
+    .map(([role]) => {
+      return role;
+    });
+}
+
+export function isRoleManageable(user, role) {
+  // 超級管理員可管理所有除自身以外的身份組
+  if (hasRole(user, 'superAdmin')) {
+    return role !== 'superAdmin';
+  }
+
+  return getManageableRoles(user).includes(role);
+}
 
 export function hasRole(user, role) {
   return user && user.profile && user.profile.roles && user.profile.roles.includes(role);

--- a/integration-test/server/methods/product/createProduct.test.js
+++ b/integration-test/server/methods/product/createProduct.test.js
@@ -70,7 +70,7 @@ describe('method createProduct', function() {
     });
 
     it('should fail if the user is not admin', function() {
-      Meteor.users.update(userId, { $pullAll: { 'profile.roles': 'fscMember' } });
+      Meteor.users.update(userId, { $pull: { 'profile.roles': 'fscMember' } });
       const inputProductData = productFactory.build({ companyId });
       createProduct.bind(null, userId, inputProductData).must.throw(Meteor.Error, '權限不符，無法進行此操作！ [403]');
     });

--- a/server/methods/accounts/assignUserRole.js
+++ b/server/methods/accounts/assignUserRole.js
@@ -1,0 +1,44 @@
+import { Meteor } from 'meteor/meteor';
+import { check, Match } from 'meteor/check';
+
+import { dbLog } from '/db/dbLog';
+import { userRoleMap, roleDisplayName, isRoleManageable } from '/db/users';
+import { debug } from '/server/imports/utils/debug';
+import { limitMethod } from '/server/imports/utils/rateLimit';
+
+Meteor.methods({
+  assignUserRole({ userId, role, reason }) {
+    check(this.userId, String);
+    check(role, new Match.OneOf(...Object.keys(userRoleMap)));
+    check(reason, String);
+    assignUserRole(Meteor.user(), { userId, role, reason });
+
+    return true;
+  }
+});
+
+export function assignUserRole(currentUser, { userId, role, reason }) {
+  debug.log('assignUserRole', { currentUser, userId, role, reason });
+
+  if (! isRoleManageable(currentUser, role)) {
+    throw new Meteor.Error(403, '權限不足，無法進行此操作！');
+  }
+
+  const { _id: currentUserId } = currentUser;
+
+  const user = Meteor.users.findByIdOrThrow(userId, { fields: { 'profile.roles': 1 } });
+
+  if (user.profile.roles.includes(role)) {
+    throw new Meteor.Error(404, `使用者 ${userId} 已經具有 ${roleDisplayName(role)} 的身份！`);
+  }
+
+  Meteor.users.update(userId, { $addToSet: { 'profile.roles': role } });
+  dbLog.insert({
+    logType: '身份指派',
+    userId: [currentUserId, userId],
+    data: { role, reason },
+    createdAt: new Date()
+  });
+}
+
+limitMethod('assignUserRole');

--- a/server/methods/accounts/unassignUserRole.js
+++ b/server/methods/accounts/unassignUserRole.js
@@ -1,0 +1,44 @@
+import { Meteor } from 'meteor/meteor';
+import { check } from 'meteor/check';
+
+import { dbLog } from '/db/dbLog';
+import { roleDisplayName, isRoleManageable } from '/db/users';
+import { debug } from '/server/imports/utils/debug';
+import { limitMethod } from '/server/imports/utils/rateLimit';
+
+Meteor.methods({
+  unassignUserRole({ userId, role, reason }) {
+    check(this.userId, String);
+    check(role, String);
+    check(reason, String);
+    unassignUserRole(Meteor.user(), { userId, role, reason });
+
+    return true;
+  }
+});
+
+export function unassignUserRole(currentUser, { userId, role, reason }) {
+  debug.log('unassignUserRole', { currentUser, userId, role, reason });
+
+  if (! isRoleManageable(currentUser, role)) {
+    throw new Meteor.Error(403, '權限不足，無法進行此操作！');
+  }
+
+  const { _id: currentUserId } = currentUser;
+
+  const user = Meteor.users.findByIdOrThrow(userId, { fields: { 'profile.roles': 1 } });
+
+  if (! user.profile.roles.includes(role)) {
+    throw new Meteor.Error(404, `使用者 ${userId} 並不具有 ${roleDisplayName(role)} 的身份！`);
+  }
+
+  Meteor.users.update(userId, { $pull: { 'profile.roles': role } });
+  dbLog.insert({
+    logType: '身份解除',
+    userId: [currentUserId, userId],
+    data: { role, reason },
+    createdAt: new Date()
+  });
+}
+
+limitMethod('unassignUserRole');

--- a/server/methods/company/editCompany.js
+++ b/server/methods/company/editCompany.js
@@ -37,7 +37,7 @@ function editCompany(user, companyId, newCompanyData) {
   });
 
   guardCompany(companyData)
-    .checkIsManagableByUser(user)
+    .checkIsManageableByUser(user)
     .checkNotSealed();
 
   if (newCompanyData.pictureBig && companyData.pictureBig !== newCompanyData.pictureBig) {

--- a/server/methods/company/updateProfitDistribution.js
+++ b/server/methods/company/updateProfitDistribution.js
@@ -36,7 +36,7 @@ export function updateProfitDistribution({ userId, companyId, distribution }) {
 
   guardCompany(company)
     .checkNotSealed()
-    .checkIsManagableByUser(user);
+    .checkIsManageableByUser(user);
 
   const { min: minManagerBonusRatePercent, max: maxManagerBonusRatePercent } = Meteor.settings.public.companyProfitDistribution.managerBonusRatePercent;
   const { min: minEmployeeBonusRatePercent, max: maxEmployeeBonusRatePercent } = Meteor.settings.public.companyProfitDistribution.employeeBonusRatePercent;

--- a/server/methods/product/createProduct.js
+++ b/server/methods/product/createProduct.js
@@ -44,7 +44,7 @@ export function createProduct(userId, productData) {
   });
 
   guardCompany(companyData)
-    .checkIsManagableByUser(user)
+    .checkIsManageableByUser(user)
     .checkNotSealed();
 
   const { productPriceLimit } = companyData;

--- a/server/methods/product/removeProduct.js
+++ b/server/methods/product/removeProduct.js
@@ -28,7 +28,7 @@ export function removeProduct(user, productId) {
     fields: { companyName: 1, manager: 1, isSeal: 1 }
   });
 
-  guardCompany(company).checkIsManagableByUser(user);
+  guardCompany(company).checkIsManageableByUser(user);
 
   resourceManager.throwErrorIsResourceIsLock(['season']);
   dbProducts.remove(productId);


### PR DESCRIPTION
1. 帳號資訊中加入了身份組管理區塊，在使甩者有權限可以管理時會顯示
    * 超級管理員：可管理所有除自身以外的身份組
    * 營運總管：可管理企劃部成員、工程部成員、金管會成員
2. 加入身份組指派 / 解除時的 log 顯示
3. fix typo: managable -> manageable
4. 帳號資訊中顯示使用者識別碼，方便進行 copy