### PR TITLE
實作新公告系統

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -20,7 +20,6 @@ accounts-base@1.4.0
 accounts-password@1.5.0
 percolate:migrations
 kadira:flow-router
-aldeed:collection2-core
 kadira:dochead
 meteorhacks:aggregate
 mizzao:user-status
@@ -34,3 +33,5 @@ peerlibrary:reactive-publish
 teamgrid:reactive-interval
 reactive-dict
 promise
+aldeed:collection2@3.0.0
+tmeasday:publish-counts

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -2,7 +2,7 @@ accounts-base@1.4.0
 accounts-google@1.3.0
 accounts-oauth@1.1.15
 accounts-password@1.5.0
-aldeed:collection2-core@2.0.1
+aldeed:collection2@3.0.0
 allow-deny@1.1.0
 autoupdate@1.3.12
 babel-compiler@6.24.7
@@ -102,7 +102,8 @@ templating@1.3.2
 templating-compiler@1.3.3
 templating-runtime@1.3.2
 templating-tools@1.1.2
-tmeasday:check-npm-versions@0.3.1
+tmeasday:check-npm-versions@0.3.2
+tmeasday:publish-counts@0.8.0
 tracker@1.1.3
 ui@1.0.13
 underscore@1.0.10

--- a/client/accountInfo/accountInfo.html
+++ b/client/accountInfo/accountInfo.html
@@ -129,10 +129,10 @@
       {{showValidateType}}
     </div>
     <div>
-      帳號啟動日期：{{formatDateText this.createdAt}}
+      帳號啟動日期：{{formatDateTimeText this.createdAt}}
     </div>
     <div>
-      上次登入時間：{{formatDateText this.status.lastLogin.date}}
+      上次登入時間：{{formatDateTimeText this.status.lastLogin.date}}
     </div>
     <div>
       上次登入IP：{{this.status.lastLogin.ipAddr}}

--- a/client/accountInfo/accountInfoTaxList.html
+++ b/client/accountInfo/accountInfoTaxList.html
@@ -16,7 +16,7 @@
     {{#each taxes in taxesList}}
       <tr>
         <td class="text-right text-truncate text-nowrap" data-title="繳稅期限">
-            {{formatDateText taxes.expireDate}}
+            {{formatDateTimeText taxes.expireDate}}
         </td>
         <td class="text-right text-truncate text-nowrap" data-title="財稅額" title="{{taxes.tax}}">
             $ {{currencyFormat taxes.tax}}

--- a/client/advertising/advertising.html
+++ b/client/advertising/advertising.html
@@ -4,11 +4,6 @@
       <h1 class="card-title mb-1">
         廣告中心
       </h1>
-      {{#if inEditAnnouncementMode}}
-        <hr />
-        {{> announcementForm}}
-        <hr />
-      {{/if}}
       {{#if inBuyMode}}
         <hr />
         {{#with defaultAdvertisingData}}

--- a/client/advertising/advertising.js
+++ b/client/advertising/advertising.js
@@ -8,7 +8,7 @@ import { ReactiveVar } from 'meteor/reactive-var';
 import { dbAdvertising } from '/db/dbAdvertising';
 import { inheritedShowLoadingOnSubscribing } from '../layout/loading';
 import { inheritUtilForm, handleInputChange as inheritedHandleInputChange } from '../utils/form';
-import { formatDateText, currencyFormat } from '../utils/helpers';
+import { formatDateTimeText, currencyFormat } from '../utils/helpers';
 import { integerString } from '../utils/regexp';
 import { alertDialog } from '../layout/alertDialog';
 import { shouldStopSubscribe } from '../utils/idle';
@@ -55,7 +55,7 @@ Template.advertising.helpers({
     const createdAtTime = advertisingData.createdAt.getTime();
     const expireTime = new Date(createdAtTime + Meteor.settings.public.advertisingExpireTime);
 
-    return formatDateText(expireTime);
+    return formatDateTimeText(expireTime);
   }
 });
 

--- a/client/announcement/announcementDetail.html
+++ b/client/announcement/announcementDetail.html
@@ -20,7 +20,9 @@
         </p>
         <hr />
         <h3>內文：</h3>
-        {{{markdown announcement.content advanced=true}}}
+        <div class="markdown-container">
+          {{{markdown announcement.content advanced=true}}}
+        </div>
       {{else}}
         讀取中…
       {{/if}}

--- a/client/announcement/announcementDetail.html
+++ b/client/announcement/announcementDetail.html
@@ -4,11 +4,14 @@
       {{#if announcement}}
         <h1 class="card-title d-flex flex-wrap">
           <div>{{categoryDisplayName announcement.category}}公告</div>
-          {{#if canManageAnnouncement}}
-            <div class="ml-auto">
+          <div class="ml-auto">
+            {{#if canRejectAnnoumcenet}}
+              <a class="btn btn-warning" href="{{pathForRejectAnnouncement}}">否決</a>
+            {{/if}}
+            {{#if canManageAnnouncement}}
               <button class="btn btn-danger" data-action="deleteAnnouncement">刪除</button>
-            </div>
-          {{/if}}
+            {{/if}}
+        </div>
         </h1>
         <hr />
         <h3 style="word-break: break-all">主旨：{{announcement.subject}}</h3>
@@ -18,14 +21,6 @@
         <hr />
         <h3>內文：</h3>
         {{{markdown announcement.content advanced=true}}}
-        {{#if announcement.rejectionPetition}}
-          <hr />
-          {{> announcementRejectionPetition}}
-        {{/if}}
-        {{#if announcement.rejectionPoll}}
-          <hr />
-          {{> announcementRejectionPoll}}
-        {{/if}}
       {{else}}
         讀取中…
       {{/if}}

--- a/client/announcement/announcementDetail.html
+++ b/client/announcement/announcementDetail.html
@@ -1,0 +1,34 @@
+<template name="announcementDetail">
+  <div class="card">
+    <div class="card-block">
+      {{#if announcement}}
+        <h1 class="card-title d-flex flex-wrap">
+          <div>{{categoryDisplayName announcement.category}}公告</div>
+          {{#if canManageAnnouncement}}
+            <div class="ml-auto">
+              <button class="btn btn-danger" data-action="deleteAnnouncement">刪除</button>
+            </div>
+          {{/if}}
+        </h1>
+        <hr />
+        <h3 style="word-break: break-all">主旨：{{announcement.subject}}</h3>
+        <p class="text-wrap">
+          於 {{formatDateTimeText announcement.createdAt}} 由 {{>userLink announcement.creator}} 發佈
+        </p>
+        <hr />
+        <h3>內文：</h3>
+        {{{markdown announcement.content advanced=true}}}
+        {{#if announcement.rejectionPetition}}
+          <hr />
+          {{> announcementRejectionPetition}}
+        {{/if}}
+        {{#if announcement.rejectionPoll}}
+          <hr />
+          {{> announcementRejectionPoll}}
+        {{/if}}
+      {{else}}
+        讀取中…
+      {{/if}}
+    </div>
+  </div>
+</template>

--- a/client/announcement/announcementDetail.js
+++ b/client/announcement/announcementDetail.js
@@ -1,0 +1,170 @@
+import { Meteor } from 'meteor/meteor';
+import { Template } from 'meteor/templating';
+import { FlowRouter } from 'meteor/kadira:flow-router';
+
+import { hasAnyRoles } from '/db/users';
+import { categoryDisplayName } from '/db/dbAnnouncements';
+import { alertDialog } from '../layout/alertDialog';
+import { paramAnnouncementId, paramAnnouncement } from './helpers';
+
+Template.announcementDetail.onCreated(function() {
+  this.autorunWithIdleSupport(() => {
+    const announcementId = paramAnnouncementId();
+
+    if (! announcementId) {
+      return;
+    }
+
+    Meteor.subscribe('announcementDetail', paramAnnouncementId());
+  });
+});
+
+Template.announcementDetail.events({
+  'click [data-action="deleteAnnouncement"]'(event) {
+    event.preventDefault();
+
+    const announcementId = paramAnnouncementId();
+
+    if (! announcementId) {
+      return;
+    }
+
+    alertDialog.confirm({
+      title: '刪除公告',
+      message: '刪除後將無法復原，確定要將此公告刪除嗎？',
+      callback(result) {
+        if (! result) {
+          return;
+        }
+
+        Meteor.customCall('deleteAnnouncement', { announcementId }, (error) => {
+          if (! error) {
+            FlowRouter.go('announcementList');
+          }
+        });
+      }
+    });
+  }
+});
+
+Template.announcementDetail.helpers({
+  categoryDisplayName,
+  announcement() {
+    return paramAnnouncement();
+  },
+  canManageAnnouncement() {
+    const currentUser = Meteor.user();
+
+    if (! currentUser) {
+      return false;
+    }
+
+    const { creator } = paramAnnouncement();
+
+    return hasAnyRoles(currentUser, 'generalManager', 'superAdmin') || currentUser._id === creator;
+  }
+});
+
+function computeThreshold({ thresholdPercent, activeUserCount }) {
+  return Math.floor(activeUserCount * thresholdPercent / 100);
+}
+
+function isRejectionPetitionOverdue({ dueAt }) {
+  return Date.now() > dueAt.getTime();
+}
+
+function isRejectionPetitionPassed(rejectionPetition) {
+  const { signers } = rejectionPetition;
+  const threshold = computeThreshold(rejectionPetition);
+
+  return signers.length >= threshold;
+}
+
+Template.announcementRejectionPetition.helpers({
+  petition() {
+    return paramAnnouncement().rejectionPetition;
+  },
+  signerCount() {
+    return paramAnnouncement().rejectionPetition.signers.length;
+  },
+  threshold() {
+    return computeThreshold(paramAnnouncement().rejectionPetition);
+  },
+  isPassed() {
+    return !! paramAnnouncement().rejectionPetition.passedAt;
+  },
+  isOverdue() {
+    return isRejectionPetitionOverdue(paramAnnouncement().rejectionPetition);
+  },
+  canSign() {
+    const { rejectionPetition } = paramAnnouncement();
+    const { signers } = rejectionPetition;
+    const isOverdue = isRejectionPetitionOverdue(rejectionPetition);
+    const isPassed = isRejectionPetitionPassed(rejectionPetition);
+
+    return ! isOverdue && ! isPassed && ! signers.includes(this.userId);
+  }
+});
+
+Template.announcementRejectionPetition.events({
+  'click [data-action="signRejectionPetition"]'(event) {
+    event.preventDefault();
+
+    alertDialog.confirm({
+      title: '參與否決連署',
+      message: '參與連署後將無法取消，確定要參與本次否決連署嗎？',
+      callback(result) {
+        if (! result) {
+          return;
+        }
+
+        const announcementId = paramAnnouncementId();
+
+        Meteor.customCall('signRejectionPetition', { announcementId });
+      }
+    });
+  }
+});
+
+Template.announcementRejectionPoll.helpers({
+  poll() {
+    return paramAnnouncement().rejectionPoll;
+  },
+  threshold() {
+    return computeThreshold(paramAnnouncement().rejectionPoll);
+  },
+  isFinished() {
+    return Date.now() > paramAnnouncement().rejectionPoll.dueAt;
+  },
+  canVote() {
+    const currentUser = Meteor.user();
+    const { currentUserChoice, dueAt } = paramAnnouncement().rejectionPoll;
+
+    const isOverdue = Date.now() > dueAt.getTime();
+    const hasVoted = !! currentUserChoice;
+
+    return currentUser && ! isOverdue && ! hasVoted;
+  },
+  choiceMatches(choice) {
+    const { currentUserChoice } = paramAnnouncement().rejectionPoll;
+
+    return currentUserChoice === choice;
+  },
+  voteCount(choice) {
+    const { yesVotes, noVotes } = paramAnnouncement().rejectionPoll;
+
+    return choice === 'yes' ? yesVotes.length : choice === 'no' ? noVotes.length : 0;
+  },
+  totalVoteCount() {
+    const { yesVotes, noVotes } = paramAnnouncement().rejectionPoll;
+
+    return yesVotes.length + noVotes.length;
+  },
+  isThresholdPassed() {
+    const threshold = computeThreshold(paramAnnouncement().rejectionPoll);
+    const { yesVotes, noVotes } = paramAnnouncement().rejectionPoll;
+    const totalVoteCount = yesVotes.length + noVotes.length;
+
+    return totalVoteCount >= threshold;
+  }
+});

--- a/client/announcement/announcementDetail.js
+++ b/client/announcement/announcementDetail.js
@@ -62,109 +62,11 @@ Template.announcementDetail.helpers({
     const { creator } = paramAnnouncement();
 
     return hasAnyRoles(currentUser, 'generalManager', 'superAdmin') || currentUser._id === creator;
-  }
-});
-
-function computeThreshold({ thresholdPercent, activeUserCount }) {
-  return Math.floor(activeUserCount * thresholdPercent / 100);
-}
-
-function isRejectionPetitionOverdue({ dueAt }) {
-  return Date.now() > dueAt.getTime();
-}
-
-function isRejectionPetitionPassed(rejectionPetition) {
-  const { signers } = rejectionPetition;
-  const threshold = computeThreshold(rejectionPetition);
-
-  return signers.length >= threshold;
-}
-
-Template.announcementRejectionPetition.helpers({
-  petition() {
-    return paramAnnouncement().rejectionPetition;
   },
-  signerCount() {
-    return paramAnnouncement().rejectionPetition.signers.length;
+  canRejectAnnoumcenet() {
+    return Meteor.user() && paramAnnouncement().hasRejectionPetition;
   },
-  threshold() {
-    return computeThreshold(paramAnnouncement().rejectionPetition);
-  },
-  isPassed() {
-    return !! paramAnnouncement().rejectionPetition.passedAt;
-  },
-  isOverdue() {
-    return isRejectionPetitionOverdue(paramAnnouncement().rejectionPetition);
-  },
-  canSign() {
-    const { rejectionPetition } = paramAnnouncement();
-    const { signers } = rejectionPetition;
-    const isOverdue = isRejectionPetitionOverdue(rejectionPetition);
-    const isPassed = isRejectionPetitionPassed(rejectionPetition);
-
-    return ! isOverdue && ! isPassed && ! signers.includes(this.userId);
-  }
-});
-
-Template.announcementRejectionPetition.events({
-  'click [data-action="signRejectionPetition"]'(event) {
-    event.preventDefault();
-
-    alertDialog.confirm({
-      title: '參與否決連署',
-      message: '參與連署後將無法取消，確定要參與本次否決連署嗎？',
-      callback(result) {
-        if (! result) {
-          return;
-        }
-
-        const announcementId = paramAnnouncementId();
-
-        Meteor.customCall('signRejectionPetition', { announcementId });
-      }
-    });
-  }
-});
-
-Template.announcementRejectionPoll.helpers({
-  poll() {
-    return paramAnnouncement().rejectionPoll;
-  },
-  threshold() {
-    return computeThreshold(paramAnnouncement().rejectionPoll);
-  },
-  isFinished() {
-    return Date.now() > paramAnnouncement().rejectionPoll.dueAt;
-  },
-  canVote() {
-    const currentUser = Meteor.user();
-    const { currentUserChoice, dueAt } = paramAnnouncement().rejectionPoll;
-
-    const isOverdue = Date.now() > dueAt.getTime();
-    const hasVoted = !! currentUserChoice;
-
-    return currentUser && ! isOverdue && ! hasVoted;
-  },
-  choiceMatches(choice) {
-    const { currentUserChoice } = paramAnnouncement().rejectionPoll;
-
-    return currentUserChoice === choice;
-  },
-  voteCount(choice) {
-    const { yesVotes, noVotes } = paramAnnouncement().rejectionPoll;
-
-    return choice === 'yes' ? yesVotes.length : choice === 'no' ? noVotes.length : 0;
-  },
-  totalVoteCount() {
-    const { yesVotes, noVotes } = paramAnnouncement().rejectionPoll;
-
-    return yesVotes.length + noVotes.length;
-  },
-  isThresholdPassed() {
-    const threshold = computeThreshold(paramAnnouncement().rejectionPoll);
-    const { yesVotes, noVotes } = paramAnnouncement().rejectionPoll;
-    const totalVoteCount = yesVotes.length + noVotes.length;
-
-    return totalVoteCount >= threshold;
+  pathForRejectAnnouncement() {
+    return FlowRouter.path('rejectAnnouncement', { announcementId: paramAnnouncementId() });
   }
 });

--- a/client/announcement/announcementDetail.js
+++ b/client/announcement/announcementDetail.js
@@ -4,8 +4,11 @@ import { FlowRouter } from 'meteor/kadira:flow-router';
 
 import { hasAnyRoles } from '/db/users';
 import { categoryDisplayName } from '/db/dbAnnouncements';
+import { inheritedShowLoadingOnSubscribing } from '../layout/loading';
 import { alertDialog } from '../layout/alertDialog';
 import { paramAnnouncementId, paramAnnouncement } from './helpers';
+
+inheritedShowLoadingOnSubscribing(Template.announcementDetail);
 
 Template.announcementDetail.onCreated(function() {
   this.autorunWithIdleSupport(() => {

--- a/client/announcement/announcementForm.html
+++ b/client/announcement/announcementForm.html
@@ -45,7 +45,7 @@
     <div class="row" style="margin-top: 15px;">
       <div class="col-12">
         <h3>內文預覽</h3>
-        <div class="announcement-content">{{{contentPreview}}}</div>
+        <div class="markdown-container">{{{contentPreview}}}</div>
       </div>
     </div>
   </div>

--- a/client/announcement/announcementForm.html
+++ b/client/announcement/announcementForm.html
@@ -1,0 +1,52 @@
+<template name="announcementForm">
+  <form>
+    <div class="form-group">
+      <label for="category">公告分類：</label>
+      <select class="form-control" name="category">
+        <option value="" class="d-none" hidden>選擇公告分類…</option>
+        {{#each category in announceableCategories}}
+          <option value="{{category}}">{{categoryDisplayName category}}</option>
+        {{else}}
+          <option value="" disabled>沒有可用的公告分類！</option>
+        {{/each}}
+      </select>
+      {{{errorHtmlOf 'category'}}}
+    </div>
+    <div class="form-group">
+      <label for="subject">公告主旨：</label>
+      <input class="form-control" type="text" name="subject" placeholder="請輸入公告主旨" />
+      {{{errorHtmlOf 'subject'}}}
+    </div>
+    <div class="form-group">
+      <label for="content">公告內文：</label>
+      <textarea class="form-control" name="content" rows="5" placeholder="請輸入公告內容"></textarea>
+      {{{errorHtmlOf 'content'}}}
+    </div>
+    {{#if showRejectionPetitionFields}}
+      <div class="form-group">
+        <label for="rejectionPetitionDurationDays">否決連署天數 ({{rejectionPetitionDurationDays.min}} ~ {{rejectionPetitionDurationDays.max}})：</label>
+        <input
+          class="form-control"
+          type="number"
+          min="{{rejectionPetitionDurationDays.min}}"
+          max="{{rejectionPetitionDurationDays.max}}"
+          name="rejectionPetitionDurationDays"
+          placeholder="請輸入天數" />
+        {{{errorHtmlOf 'rejectionPetitionDurationDays'}}}
+      </div>
+    {{/if}}
+    <div class="text-right">
+      <button class="btn btn-primary" type="submit">送出</button>
+      <a class="btn btn-secondary" href="{{pathFor 'announcementList'}}">取消</a>
+    </div>
+  </form>
+  <hr />
+  <div class="announcement-detail">
+    <div class="row" style="margin-top: 15px;">
+      <div class="col-12">
+        <h3>內文預覽</h3>
+        <div class="announcement-content">{{{contentPreview}}}</div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/client/announcement/announcementForm.js
+++ b/client/announcement/announcementForm.js
@@ -1,0 +1,111 @@
+import { _ } from 'meteor/underscore';
+import { Meteor } from 'meteor/meteor';
+import { Template } from 'meteor/templating';
+import { FlowRouter } from 'meteor/kadira:flow-router';
+
+import { getAnnounceableCategories, categoryDisplayName, dbAnnouncements } from '/db/dbAnnouncements';
+import { inheritUtilForm } from '../utils/form';
+import { alertDialog } from '../layout/alertDialog';
+import { markdown } from '../utils/helpers';
+
+const formModelSchema = dbAnnouncements.simpleSchema().pick('category', 'subject', 'content');
+
+inheritUtilForm(Template.announcementForm);
+Template.announcementForm.onCreated(function() {
+  this.validateModel = (model) => {
+    const error = {};
+
+    const cleanedModel = formModelSchema.clean(model);
+
+    if (! cleanedModel.category) {
+      error.category = '請選擇公告分類！';
+    }
+
+    if (cleanedModel.category === 'plannedRuleChanges') {
+      const { min, max } = Meteor.settings.public.announcement[cleanedModel.category].rejectionPetition.durationDays;
+      const rejectionPetitionDurationDays = parseFloat(model.rejectionPetitionDurationDays);
+
+      if (! model.rejectionPetitionDurationDays) {
+        error.rejectionPetitionDurationDays = '否決連署天數不得為空！';
+      }
+      else if (! Number.isInteger(rejectionPetitionDurationDays)) {
+        error.rejectionPetitionDurationDays = '否決連署天數必須為整數！';
+      }
+      else if (model.rejectionPetitionDurationDays < min || model.rejectionPetitionDurationDays > max) {
+        error.rejectionPetitionDurationDays = `否決連署天數必須介於 ${min} 至 ${max} 天之間！`;
+      }
+    }
+
+    if (! cleanedModel.subject) {
+      error.subject = '公告主旨不得為空！';
+    }
+    else if (cleanedModel.subject.length < formModelSchema.get('subject', 'min')) {
+      error.subject = `公告主旨最短需為${formModelSchema.get('subject', 'min')}字！`;
+    }
+    else if (cleanedModel.subject.length > formModelSchema.get('subject', 'max')) {
+      error.subject = `公告主旨最長不得超過 ${formModelSchema.get('subject', 'max')} 字！`;
+    }
+
+    if (! cleanedModel.content) {
+      error.content = '公告內文不得為空！';
+    }
+    else if (cleanedModel.content.length < formModelSchema.get('content', 'min')) {
+      error.content = `公告內文最短需 ${formModelSchema.get('content', 'min')} 字！`;
+    }
+    else if (cleanedModel.content.length > formModelSchema.get('content', 'max')) {
+      error.content = `公告內文最長不得超過 ${formModelSchema.get('content', 'max')} 字！`;
+    }
+
+    if (_.size(error) > 0) {
+      return error;
+    }
+  };
+
+  this.saveModel = (model) => {
+    const cleanedModel = formModelSchema.clean(model);
+
+    alertDialog.confirm({
+      message: '確定將公告送出嗎？',
+      callback: (result) => {
+        if (! result) {
+          return;
+        }
+
+        const methodArgs = { data: cleanedModel };
+
+        if (cleanedModel.category === 'plannedRuleChanges') {
+          methodArgs.rejectionPetitionDurationDays = parseFloat(model.rejectionPetitionDurationDays);
+        }
+
+        Meteor.customCall('createAnnouncement', methodArgs, (error) => {
+          if (! error) {
+            FlowRouter.go('announcementList');
+          }
+        });
+      }
+    });
+  };
+});
+
+Template.announcementForm.events({
+  'keyup [name="content"]': _.debounce(function(event, templateInstance) {
+    event.preventDefault();
+    templateInstance.handleInputChange(event);
+  }, 250)
+});
+
+Template.announcementForm.helpers({
+  categoryDisplayName,
+  announceableCategories() {
+    return getAnnounceableCategories(Meteor.user());
+  },
+  contentPreview() {
+    return markdown(Template.instance().model.get().content || '', { advanced: true });
+  },
+  showRejectionPetitionFields() {
+    return Template.instance().model.get().category === 'plannedRuleChanges';
+  },
+  rejectionPetitionDurationDays() {
+    return Meteor.settings.public.announcement[Template.instance().model.get().category].rejectionPetition.durationDays;
+  }
+});

--- a/client/announcement/announcementList.html
+++ b/client/announcement/announcementList.html
@@ -26,18 +26,22 @@
               {{/each}}
             </select>
           </div>
-          <button class="btn btn-sm btn-info ml-1" type="button" name="onlyUnread">
-            {{#if onlyUnread}}
-              <i class="fa fa-check-square-o"></i>
-            {{else}}
-              <i class="fa fa-square-o"></i>
-            {{/if}}
-            只顯示未讀
-          </button>
+          {{#if currentUser}}
+            <button class="btn btn-sm btn-info ml-1" type="button" name="onlyUnread">
+              {{#if onlyUnread}}
+                <i class="fa fa-check-square-o"></i>
+              {{else}}
+                <i class="fa fa-square-o"></i>
+              {{/if}}
+              只顯示未讀
+            </button>
+          {{/if}}
         </div>
-        <div class="ml-auto">
-          <a class="btn btn-sm btn-danger" href="#" data-action="markAllAsRead">全部標為已讀</a>
-        </div>
+        {{#if currentUser}}
+          <div class="ml-auto">
+            <a class="btn btn-sm btn-danger" href="#" data-action="markAllAsRead">全部標為已讀</a>
+          </div>
+        {{/if}}
       </div>
       <table class="table-bordered custom-responsive-table-md w-100">
         <thead>

--- a/client/announcement/announcementList.html
+++ b/client/announcement/announcementList.html
@@ -1,0 +1,77 @@
+<template name="announcementList">
+  <div class="card">
+    <div class="card-block">
+      <h1 class="card-title d-flex flex-wrap mb-1">
+        <div class="text-nowrap">系統公告</div>
+        {{#if canCreateAnnouncement}}
+          <div class="ml-auto">
+            <a class="btn btn-primary" href="{{pathFor 'createAnnouncement'}}">
+              <i class="fa fa-plus" aria-hidden="true"></i>
+              建立新公告
+            </a>
+          </div>
+        {{/if}}
+      </h1>
+      <hr />
+      <div class="form-inline my-2">
+        <div class="input-group input-group-sm">
+          <div class="input-group-addon">顯示分類</div>
+          <select class="form-control" name="category">
+            <option value="">全部分類</option>
+            {{#each category in categoryList}}
+              <option value="{{category}}" {{categorySelectedAttr category}}>
+                {{categoryDisplayName category}}
+              </option>
+            {{/each}}
+          </select>
+        </div>
+        <div class="ml-2">
+          <button class="btn btn-sm btn-info" type="button" name="onlyUnread">
+            {{#if onlyUnread}}
+              <i class="fa fa-check-square-o"></i>
+            {{else}}
+              <i class="fa fa-square-o"></i>
+            {{/if}}
+            只顯示未讀
+          </button>
+        </div>
+      </div>
+      <table class="table-bordered custom-responsive-table-md w-100">
+        <thead>
+          <tr>
+            <th class="text-center text-truncate" title="分類">分類</th>
+            <th class="text-center text-truncate w-50" title="主旨">主旨</th>
+            <th class="text-center text-truncate" title="發佈人">發佈人</th>
+            <th class="text-center text-truncate" title="發佈日期">發佈日期</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{#each announcement in announcements}}
+            <tr style="">
+              <td class="text-center text-truncate px-md-2" data-title="分類">
+                {{categoryDisplayName announcement.category}}
+              </td>
+              <td class="text-left text-truncate px-md-2" data-title="主旨">
+                {{#if announcement.isUnread}}
+                  <span class="badge badge-danger">未讀</span>
+                {{/if}}
+                <a href="{{pathForAnnouncementDetail announcement._id}}">{{announcement.subject}}</a>
+              </td>
+              <td class="text-center text-truncate px-md-2" data-title="發佈人">
+                {{>userLink announcement.creator}}
+              </td>
+              <td class="text-center text-truncate px-md-2" data-title="發佈日期">
+                {{formatDateTimeText announcement.createdAt}}
+              </td>
+            </tr>
+          {{else}}
+            <tr class="default-content">
+              <td class="text-center p-1" colspan=4>查無資料！</td>
+            </tr>
+          {{/each}}
+        </tbody>
+      </table>
+      {{> pagination paginationData}}
+    </div>
+  </div>
+</template>

--- a/client/announcement/announcementList.html
+++ b/client/announcement/announcementList.html
@@ -13,20 +13,20 @@
         {{/if}}
       </h1>
       <hr />
-      <div class="form-inline my-2">
-        <div class="input-group input-group-sm">
-          <div class="input-group-addon">顯示分類</div>
-          <select class="form-control" name="category">
-            <option value="">全部分類</option>
-            {{#each category in categoryList}}
-              <option value="{{category}}" {{categorySelectedAttr category}}>
-                {{categoryDisplayName category}}
-              </option>
-            {{/each}}
-          </select>
-        </div>
-        <div class="ml-2">
-          <button class="btn btn-sm btn-info" type="button" name="onlyUnread">
+      <div class="d-flex flex-wrap align-items-center">
+        <div class="form-inline my-2">
+          <div class="input-group input-group-sm">
+            <div class="input-group-addon">顯示分類</div>
+            <select class="form-control" name="category">
+              <option value="">全部分類</option>
+              {{#each category in categoryList}}
+                <option value="{{category}}" {{categorySelectedAttr category}}>
+                  {{categoryDisplayName category}}
+                </option>
+              {{/each}}
+            </select>
+          </div>
+          <button class="btn btn-sm btn-info ml-1" type="button" name="onlyUnread">
             {{#if onlyUnread}}
               <i class="fa fa-check-square-o"></i>
             {{else}}
@@ -34,6 +34,9 @@
             {{/if}}
             只顯示未讀
           </button>
+        </div>
+        <div class="ml-auto">
+          <a class="btn btn-sm btn-danger" href="#" data-action="markAllAsRead">全部標為已讀</a>
         </div>
       </div>
       <table class="table-bordered custom-responsive-table-md w-100">

--- a/client/announcement/announcementList.js
+++ b/client/announcement/announcementList.js
@@ -5,6 +5,7 @@ import { FlowRouter } from 'meteor/kadira:flow-router';
 import { ReactiveVar } from 'meteor/reactive-var';
 
 import { dbAnnouncements, announcementCategoryMap, categoryDisplayName } from '/db/dbAnnouncements';
+import { alertDialog } from '../layout/alertDialog';
 import { canCreateAnnouncement } from './helpers';
 
 Template.announcementList.onCreated(function() {
@@ -29,6 +30,20 @@ Template.announcementList.events({
   'click button[name="onlyUnread"]'(event, templateInstance) {
     event.preventDefault();
     templateInstance.onlyUnread.set(! templateInstance.onlyUnread.get());
+  },
+  'click [data-action="markAllAsRead"]'(event) {
+    event.preventDefault();
+
+    alertDialog.confirm({
+      message: '確定要將所有公告標為已讀嗎？',
+      callback(result) {
+        if (! result) {
+          return;
+        }
+
+        Meteor.customCall('markAllAnnouncementsAsRead');
+      }
+    });
   }
 });
 

--- a/client/announcement/announcementList.js
+++ b/client/announcement/announcementList.js
@@ -1,0 +1,60 @@
+import { _ } from 'meteor/underscore';
+import { Meteor } from 'meteor/meteor';
+import { Template } from 'meteor/templating';
+import { FlowRouter } from 'meteor/kadira:flow-router';
+import { ReactiveVar } from 'meteor/reactive-var';
+
+import { dbAnnouncements, announcementCategoryMap, categoryDisplayName } from '/db/dbAnnouncements';
+import { canCreateAnnouncement } from './helpers';
+
+Template.announcementList.onCreated(function() {
+  this.onlyUnread = new ReactiveVar(false);
+  this.category = new ReactiveVar();
+  this.offset = new ReactiveVar(0);
+
+  this.autorunWithIdleSupport(() => {
+    const onlyUnread = this.onlyUnread.get();
+    const category = this.category.get();
+    const offset = this.offset.get();
+
+    this.subscribe('announcementList', { category, onlyUnread, offset });
+  });
+});
+
+Template.announcementList.events({
+  'change select[name="category"]': _.debounce(function(event, templateInstance) {
+    event.preventDefault();
+    templateInstance.category.set(templateInstance.$(event.currentTarget).val() || undefined);
+  }, 250),
+  'click button[name="onlyUnread"]'(event, templateInstance) {
+    event.preventDefault();
+    templateInstance.onlyUnread.set(! templateInstance.onlyUnread.get());
+  }
+});
+
+Template.announcementList.helpers({
+  canCreateAnnouncement,
+  categoryDisplayName,
+  onlyUnread() {
+    return Template.instance().onlyUnread.get();
+  },
+  categorySelectedAttr(category) {
+    return Template.instance().category.get() === category ? 'selected' : '';
+  },
+  categoryList() {
+    return Object.keys(announcementCategoryMap);
+  },
+  announcements() {
+    return dbAnnouncements.find({}, { sort: { createdAt: -1 } });
+  },
+  pathForAnnouncementDetail(announcementId) {
+    return FlowRouter.path('announcementDetail', { announcementId });
+  },
+  paginationData() {
+    return {
+      counterName: 'announcements',
+      dataNumberPerPage: Meteor.settings.public.dataNumberPerPage.announcements,
+      offset: Template.instance().offset
+    };
+  }
+});

--- a/client/announcement/announcementList.js
+++ b/client/announcement/announcementList.js
@@ -5,8 +5,11 @@ import { FlowRouter } from 'meteor/kadira:flow-router';
 import { ReactiveVar } from 'meteor/reactive-var';
 
 import { dbAnnouncements, announcementCategoryMap, categoryDisplayName } from '/db/dbAnnouncements';
+import { inheritedShowLoadingOnSubscribing } from '../layout/loading';
 import { alertDialog } from '../layout/alertDialog';
 import { canCreateAnnouncement } from './helpers';
+
+inheritedShowLoadingOnSubscribing(Template.announcementList);
 
 Template.announcementList.onCreated(function() {
   this.onlyUnread = new ReactiveVar(false);

--- a/client/announcement/announcementRejectionPetition.html
+++ b/client/announcement/announcementRejectionPetition.html
@@ -20,12 +20,12 @@
       </div>
 
       {{#if canSign}}
-        <button class="btn btn-sm btn-warning my-2" data-action="signRejectionPetition">我要連署</button>
+        <button class="btn btn-sm btn-warning m-1" data-action="signRejectionPetition">連署支持本次否決</button>
       {{/if}}
     </div>
 
     <div class="col-12 col-md-6 my-2">
-      <h4>連署名單</h4>
+      <h4>支持否決名單</h4>
       <ol style="max-height: 300px; overflow-y: auto">
         {{#each userId in petition.signers}}
           <li>{{> userLink userId }}</li>

--- a/client/announcement/announcementRejectionPetition.html
+++ b/client/announcement/announcementRejectionPetition.html
@@ -1,0 +1,38 @@
+<template name="announcementRejectionPetition">
+  <h3>否決連署</h3>
+  <div class="row p-2">
+    <div class="col-12 col-md-6 my-2">
+      <h4>連署資訊</h4>
+      <div class="my-2">
+        {{#if isPassed}}
+          <span class="text-nowrap text-success"><i class="fa fa-check"></i> 連署已通過（於 {{formatDateTimeText petition.passedAt}}）</span>
+        {{else if isOverdue}}
+          <span class="text-nowrap text-danger"><i class="fa fa-times"></i> 已截止，連署未通過</span>
+        {{else}}
+          <span class="text-nowrap text-info"><i class="fa fa-pencil"></i> 連署進行中（尚餘 {{formatLongDurationTimeText remainingTime}}）</span>
+        {{/if}}
+      </div>
+
+      <div class="my-2">
+        截止時間：{{formatDateTimeText petition.dueAt}} <br/>
+        連署門檻：{{threshold}} 人（活躍玩家 {{petition.activeUserCount}} 人中的 {{petition.thresholdPercent}}%） <br/>
+        目前連署人數：{{signerCount}} 人
+      </div>
+
+      {{#if canSign}}
+        <button class="btn btn-sm btn-warning my-2" data-action="signRejectionPetition">我要連署</button>
+      {{/if}}
+    </div>
+
+    <div class="col-12 col-md-6 my-2">
+      <h4>連署名單</h4>
+      <ol style="max-height: 300px; overflow-y: auto">
+        {{#each userId in petition.signers}}
+          <li>{{> userLink userId }}</li>
+        {{else}}
+          <em>裡面什麼都沒有呢…</em>
+        {{/each}}
+      </ol>
+    </div>
+  </div>
+</template>

--- a/client/announcement/announcementRejectionPetition.js
+++ b/client/announcement/announcementRejectionPetition.js
@@ -1,0 +1,68 @@
+import { Meteor } from 'meteor/meteor';
+import { Template } from 'meteor/templating';
+import { reactiveInterval } from 'meteor/teamgrid:reactive-interval';
+
+import { alertDialog } from '../layout/alertDialog';
+import { paramAnnouncementId, paramAnnouncement, computeThreshold } from './helpers';
+
+function isRejectionPetitionOverdue({ dueAt }) {
+  return Date.now() > dueAt.getTime();
+}
+
+function isRejectionPetitionPassed({ passedAt }) {
+  return !! passedAt;
+}
+
+Template.announcementRejectionPetition.helpers({
+  petition() {
+    return paramAnnouncement().rejectionPetition;
+  },
+  signerCount() {
+    return paramAnnouncement().rejectionPetition.signers.length;
+  },
+  threshold() {
+    return computeThreshold(paramAnnouncement().rejectionPetition);
+  },
+  isPassed() {
+    return !! paramAnnouncement().rejectionPetition.passedAt;
+  },
+  isOverdue() {
+    return isRejectionPetitionOverdue(paramAnnouncement().rejectionPetition);
+  },
+  canSign() {
+    const currentUserId = Meteor.userId();
+    const { rejectionPetition } = paramAnnouncement();
+    const { signers } = rejectionPetition;
+    const isOverdue = isRejectionPetitionOverdue(rejectionPetition);
+    const isPassed = isRejectionPetitionPassed(rejectionPetition);
+
+    return currentUserId && ! signers.includes(currentUserId) && ! isOverdue && ! isPassed;
+  },
+  remainingTime() {
+    reactiveInterval(500);
+
+    const { dueAt } = paramAnnouncement().rejectionPetition;
+
+    return Math.max(dueAt.getTime() - Date.now(), 0);
+  }
+});
+
+Template.announcementRejectionPetition.events({
+  'click [data-action="signRejectionPetition"]'(event) {
+    event.preventDefault();
+
+    alertDialog.confirm({
+      title: '參與否決連署',
+      message: '參與連署後將無法取消，確定要參與本次否決連署嗎？',
+      callback(result) {
+        if (! result) {
+          return;
+        }
+
+        const announcementId = paramAnnouncementId();
+
+        Meteor.customCall('signRejectionPetition', { announcementId });
+      }
+    });
+  }
+});

--- a/client/announcement/announcementRejectionPoll.html
+++ b/client/announcement/announcementRejectionPoll.html
@@ -60,7 +60,7 @@
       {{/if}}
     </div>
 
-    {{#if hasVoteLists}}
+    {{#if showVoteLists}}
       <div class="col-12 col-md-6 my-2">
         <h4>贊成名單</h4>
         <ol style="max-height: 300px; overflow-y: auto">

--- a/client/announcement/announcementRejectionPoll.html
+++ b/client/announcement/announcementRejectionPoll.html
@@ -20,16 +20,20 @@
 
       {{#if choiceMatches 'yes'}}
         <div class="my-2">
-          您已經投下了<span class="text-success">贊成</span>票。
+          您已經對本次否決投下了<span class="text-success">贊成</span>票。
         </div>
       {{else if choiceMatches 'no'}}
         <div class="my-2">
-          您已經投下了<span class="text-danger">反對</span>票。
+          您已經對本次否決投下了<span class="text-danger">反對</span>票。
         </div>
       {{else if canVote}}
         <div class="my-2">
-          <button class="btn btn-sm btn-warning" data-vote="yes">贊成</button>
-          <button class="btn btn-sm btn-warning" data-vote="no">反對</button>
+          <button class="btn btn-sm btn-warning" data-vote="yes">
+            <i class="fa fa-check"></i> 贊成本次否決
+          </button>
+          <button class="btn btn-sm btn-warning" data-vote="no">
+            <i class="fa fa-times"></i> 反對本次否決
+          </button>
         </div>
       {{/if}}
     </div>

--- a/client/announcement/announcementRejectionPoll.html
+++ b/client/announcement/announcementRejectionPoll.html
@@ -1,0 +1,83 @@
+
+<template name="announcementRejectionPoll">
+  <h3>否決投票</h3>
+
+  <div class="row p-2">
+    <div class="col-12 col-md-6 my-2">
+      <h4>投票資訊</h4>
+      <div class="my-2">
+        {{#if isFinished}}
+          <span class="text-danger">投票已結束</span>
+        {{else}}
+          <span class="text-info">投票進行中（尚餘 {{formatLongDurationTimeText remainingTime}}）</span>
+        {{/if}}
+      </div>
+
+      <div class="my-2">
+        截止時間：{{formatDateTimeText poll.dueAt}} <br/>
+        投票門檻：{{threshold}} 人（活躍玩家 {{poll.activeUserCount}} 人中的 {{poll.thresholdPercent}}%）
+      </div>
+
+      {{#if choiceMatches 'yes'}}
+        <div class="my-2">
+          您已經投下了<span class="text-success">贊成</span>票。
+        </div>
+      {{else if choiceMatches 'no'}}
+        <div class="my-2">
+          您已經投下了<span class="text-danger">反對</span>票。
+        </div>
+      {{else if canVote}}
+        <div class="my-2">
+          <button class="btn btn-sm btn-warning" data-vote="yes">贊成</button>
+          <button class="btn btn-sm btn-warning" data-vote="no">反對</button>
+        </div>
+      {{/if}}
+    </div>
+
+    <div class="col-12 col-md-6 my-2">
+      <h4>投票結果</h4>
+
+      {{#if isFinished}}
+        <p>
+          <i class="fa fa-check-circle text-success"></i> 贊成：{{voteCount 'yes'}} 人<br/>
+          <i class="fa fa-times-circle text-danger"></i> 反對：{{voteCount 'no'}} 人<br/>
+        </p>
+        <p>
+          <span class="mr-2">總投票人數：{{totalVoteCount}} 人</span>
+
+          {{#if isThresholdPassed}}
+            <span class="text-success"><i class="fa fa-circle-o"></i> 已達投票門檻</span>
+          {{else}}
+            <span class="text-danger"><i class="fa fa-times"></i> 未達投票門檻</span>
+          {{/if}}
+        </p>
+      {{else}}
+        <em>投票截止後再回來看看吧！</em>
+      {{/if}}
+    </div>
+
+    {{#if hasVoteLists}}
+      <div class="col-12 col-md-6 my-2">
+        <h4>贊成名單</h4>
+        <ol style="max-height: 300px; overflow-y: auto">
+          {{#each userId in poll.yesVotes}}
+            <li>{{> userLink userId }}</li>
+          {{else}}
+            <em>一個人都沒有呢！</em>
+          {{/each}}
+        </ol>
+      </div>
+
+      <div class="col-12 col-md-6 my-2">
+        <h4>反對名單</h4>
+        <ol style="max-height: 300px; overflow-y: auto">
+          {{#each userId in poll.noVotes}}
+            <li>{{> userLink userId }}</li>
+          {{else}}
+            <em>一個人都沒有呢！</em>
+          {{/each}}
+        </ol>
+      </div>
+    {{/if}}
+  </div>
+</template>

--- a/client/announcement/announcementRejectionPoll.js
+++ b/client/announcement/announcementRejectionPoll.js
@@ -1,0 +1,93 @@
+import { Meteor } from 'meteor/meteor';
+import { Template } from 'meteor/templating';
+import { reactiveInterval } from 'meteor/teamgrid:reactive-interval';
+
+import { alertDialog } from '../layout/alertDialog';
+import { paramAnnouncementId, paramAnnouncement, computeThreshold } from './helpers';
+
+Template.announcementRejectionPoll.helpers({
+  poll() {
+    return paramAnnouncement().rejectionPoll;
+  },
+  threshold() {
+    return computeThreshold(paramAnnouncement().rejectionPoll);
+  },
+  isFinished() {
+    return Date.now() > paramAnnouncement().rejectionPoll.dueAt;
+  },
+  canVote() {
+    const currentUser = Meteor.user();
+    const { currentUserChoice, dueAt } = paramAnnouncement().rejectionPoll;
+
+    const isOverdue = Date.now() > dueAt.getTime();
+    const hasVoted = !! currentUserChoice;
+
+    return currentUser && ! isOverdue && ! hasVoted;
+  },
+  choiceMatches(choice) {
+    const { currentUserChoice } = paramAnnouncement().rejectionPoll;
+
+    return currentUserChoice === choice;
+  },
+  voteCount(choice) {
+    const { yesVotes, noVotes } = paramAnnouncement().rejectionPoll;
+
+    return choice === 'yes' ? yesVotes.length : choice === 'no' ? noVotes.length : 0;
+  },
+  totalVoteCount() {
+    const { yesVotes, noVotes } = paramAnnouncement().rejectionPoll;
+
+    return yesVotes.length + noVotes.length;
+  },
+  isThresholdPassed() {
+    const threshold = computeThreshold(paramAnnouncement().rejectionPoll);
+    const { yesVotes, noVotes } = paramAnnouncement().rejectionPoll;
+    const totalVoteCount = yesVotes.length + noVotes.length;
+
+    return totalVoteCount >= threshold;
+  },
+  showVoteLists() {
+    const { yesVotes, noVotes, dueAt } = paramAnnouncement().rejectionPoll;
+    const isOverdue = Date.now() > dueAt.getTime();
+
+    return isOverdue && yesVotes && noVotes;
+  },
+  remainingTime() {
+    reactiveInterval(500);
+
+    const { dueAt } = paramAnnouncement().rejectionPetition;
+
+    return Math.max(dueAt.getTime() - Date.now(), 0);
+  }
+});
+
+Template.announcementRejectionPoll.events({
+  'click [data-vote]'(event, templateInstance) {
+    event.preventDefault();
+
+    const choice = templateInstance.$(event.currentTarget).attr('data-vote');
+
+    if (! ['yes', 'no'].includes(choice)) {
+      return;
+    }
+
+    const choiceDisplayMap = {
+      yes: '<span class="text-success">贊成票</span>',
+      no: '<span class="text-danger">反對票</span>'
+    };
+
+    alertDialog.confirm({
+      title: '參與否決投票',
+      message: `參與投票後將無法取消，確定要投下${choiceDisplayMap[choice]}嗎？`,
+      callback(result) {
+        if (! result) {
+          return;
+        }
+
+        const announcementId = paramAnnouncementId();
+
+        Meteor.customCall('voteRejectionPoll', { announcementId, choice });
+      }
+    });
+  }
+});

--- a/client/announcement/announcementRejectionPoll.js
+++ b/client/announcement/announcementRejectionPoll.js
@@ -55,7 +55,7 @@ Template.announcementRejectionPoll.helpers({
   remainingTime() {
     reactiveInterval(500);
 
-    const { dueAt } = paramAnnouncement().rejectionPetition;
+    const { dueAt } = paramAnnouncement().rejectionPoll;
 
     return Math.max(dueAt.getTime() - Date.now(), 0);
   }

--- a/client/announcement/createAnnouncement.html
+++ b/client/announcement/createAnnouncement.html
@@ -1,0 +1,13 @@
+<template name="createAnnouncement">
+  <div class="card">
+    <div class="card-block">
+      <h1 class="card-title mb-1">建立新公告</h1>
+      <hr />
+      {{#if canCreateAnnouncement}}
+        {{> announcementForm}}
+      {{else}}
+        <p><em>你沒有權限建立任何公告，請儘速離開這裡！</em></p>
+      {{/if}}
+    </div>
+  </div>
+</template>

--- a/client/announcement/createAnnouncement.js
+++ b/client/announcement/createAnnouncement.js
@@ -1,0 +1,7 @@
+import { Template } from 'meteor/templating';
+
+import { canCreateAnnouncement } from './helpers';
+
+Template.createAnnouncement.helpers({
+  canCreateAnnouncement
+});

--- a/client/announcement/helpers.js
+++ b/client/announcement/helpers.js
@@ -1,0 +1,23 @@
+import { Meteor } from 'meteor/meteor';
+import { FlowRouter } from 'meteor/kadira:flow-router';
+
+import { getAnnounceableCategories, dbAnnouncements } from '/db/dbAnnouncements';
+
+export function paramAnnouncementId() {
+  return FlowRouter.getParam('announcementId');
+}
+
+export function paramAnnouncement() {
+  const announcementId = paramAnnouncementId();
+
+  return announcementId ? dbAnnouncements.findOne(announcementId) : null;
+}
+
+export function computeThreshold({ thresholdPercent, activeUserCount }) {
+  return Math.floor(activeUserCount * thresholdPercent / 100);
+}
+
+
+export function canCreateAnnouncement() {
+  return getAnnounceableCategories(Meteor.user()).length > 0;
+}

--- a/client/announcement/helpers.js
+++ b/client/announcement/helpers.js
@@ -14,7 +14,7 @@ export function paramAnnouncement() {
 }
 
 export function computeThreshold({ thresholdPercent, activeUserCount }) {
-  return Math.floor(activeUserCount * thresholdPercent / 100);
+  return Math.ceil(activeUserCount * thresholdPercent / 100);
 }
 
 

--- a/client/announcement/rejectAnnouncement.html
+++ b/client/announcement/rejectAnnouncement.html
@@ -1,0 +1,33 @@
+<template name="rejectAnnouncement">
+  <div class="card">
+    <div class="card-block">
+      {{#if announcement}}
+        <h1 class="card-title d-flex flex-wrap">
+          <div>否決{{categoryDisplayName announcement.category}}公告</div>
+        </h1>
+        <hr />
+        <h3 style="word-break: break-all">
+          主旨：
+          <a href="{{pathForAnnouncement}}">{{announcement.subject}}</a>
+        </h3>
+        <hr/>
+
+        {{#if canRejectAnnoumcenet}}
+          {{#if announcement.rejectionPetition}}
+            {{> announcementRejectionPetition}}
+          {{/if}}
+          {{#if announcement.rejectionPoll}}
+            <hr />
+            {{> announcementRejectionPoll}}
+          {{/if}}
+        {{else}}
+          本公告沒有進行否決程序！
+        {{/if}}
+
+      {{else}}
+        讀取中…
+      {{/if}}
+    </div>
+  </div>
+
+</template>

--- a/client/announcement/rejectAnnouncement.js
+++ b/client/announcement/rejectAnnouncement.js
@@ -1,0 +1,35 @@
+import { Meteor } from 'meteor/meteor';
+import { Template } from 'meteor/templating';
+import { FlowRouter } from 'meteor/kadira:flow-router';
+
+import { categoryDisplayName } from '/db/dbAnnouncements';
+import { paramAnnouncementId, paramAnnouncement } from './helpers';
+
+Template.rejectAnnouncement.onCreated(function() {
+  this.autorunWithIdleSupport(() => {
+    const announcementId = paramAnnouncementId();
+
+    if (! announcementId) {
+      return;
+    }
+
+    Meteor.subscribe('announcementRejectionDetail', paramAnnouncementId());
+  });
+});
+
+Template.rejectAnnouncement.events({
+
+});
+
+Template.rejectAnnouncement.helpers({
+  categoryDisplayName,
+  canRejectAnnoumcenet() {
+    return !! paramAnnouncement().rejectionPetition;
+  },
+  announcement() {
+    return paramAnnouncement();
+  },
+  pathForAnnouncement() {
+    return FlowRouter.path('announcementDetail', { announcementId: paramAnnouncementId() });
+  }
+});

--- a/client/announcement/rejectAnnouncement.js
+++ b/client/announcement/rejectAnnouncement.js
@@ -3,7 +3,10 @@ import { Template } from 'meteor/templating';
 import { FlowRouter } from 'meteor/kadira:flow-router';
 
 import { categoryDisplayName } from '/db/dbAnnouncements';
+import { inheritedShowLoadingOnSubscribing } from '../layout/loading';
 import { paramAnnouncementId, paramAnnouncement } from './helpers';
+
+inheritedShowLoadingOnSubscribing(Template.rejectAnnouncement);
 
 Template.rejectAnnouncement.onCreated(function() {
   this.autorunWithIdleSupport(() => {
@@ -15,10 +18,6 @@ Template.rejectAnnouncement.onCreated(function() {
 
     Meteor.subscribe('announcementRejectionDetail', paramAnnouncementId());
   });
-});
-
-Template.rejectAnnouncement.events({
-
 });
 
 Template.rejectAnnouncement.helpers({

--- a/client/arenaInfo/arenaInfo.html
+++ b/client/arenaInfo/arenaInfo.html
@@ -65,8 +65,8 @@
         <span aria-hidden="true">&laquo;</span>
       </a>
       <div>
-        <div class="d-inline-block text-nowrap">{{formatDateText arenaBegin}}～</div>
-        <div class="d-inline-block text-nowrap">{{formatDateText arenaEnd}}</div>
+        <div class="d-inline-block text-nowrap">{{formatDateTimeText arenaBegin}}～</div>
+        <div class="d-inline-block text-nowrap">{{formatDateTimeText arenaEnd}}</div>
       </div>
       <a  {{arenaLinkAttrs 'next'}}>
         <span aria-hidden="true">&raquo;</span>

--- a/client/company/companyDetail.html
+++ b/client/company/companyDetail.html
@@ -176,10 +176,10 @@
           <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/a/ac/No_image_available.svg/300px-No_image_available.svg.png" />
         {{/if}}
       </div>
-      <div class="media-body d-none d-md-block company-description"><h1>角色簡介</h1>{{{markdown this.description}}}</div>
+      <div class="media-body d-none d-md-block company-description markdown-container"><h1>角色簡介</h1>{{{markdown this.description}}}</div>
     </div>
     <div class="row border-grid-body" style="margin-top: 15px;">
-      <div class="col-12 border-grid d-block d-md-none company-description"><h1>角色簡介</h1>{{{markdown this.description}}}</div>
+      <div class="col-12 border-grid d-block d-md-none company-description markdown-container"><h1>角色簡介</h1>{{{markdown this.description}}}</div>
       <div class="col-12 border-grid stock-price-history">
         <a class="d-block h4 my-1" href="#" data-toggle-panel="chart">
           股價趨勢
@@ -257,7 +257,7 @@
         </div>
         <div class="col-8 col-md-4 col-lg-3 border-grid d-flex flex-column align-items-center justify-content-between">
           <span class="text-nowrap">創立時間</span>
-          <span class="text-nowrap">{{formatDateText this.createdAt}}</span>
+          <span class="text-nowrap">{{formatDateTimeText this.createdAt}}</span>
         </div>
       {{/if}}
       <div class="col-12 border-grid">
@@ -630,8 +630,8 @@
             {{>userLink employee.userId}}
           </div>
           <div class="grid-table-hidden-title">報名時間</div>
-          <div class="col-md-3 grid-table-content" title="{{formatDateText employee.registerAt}}">
-            {{formatDateText employee.registerAt}}
+          <div class="col-md-3 grid-table-content" title="{{formatDateTimeText employee.registerAt}}">
+            {{formatDateTimeText employee.registerAt}}
           </div>
           <div class="grid-table-hidden-title">留言</div>
           <div class="col-md-7 grid-table-content" title="{{showMessage employee.message}}" style="word-break: break-all;">
@@ -683,7 +683,7 @@
           </div>
           <div class="grid-table-hidden-title">報名時間</div>
           <div class="col-md-3 grid-table-content">
-            {{formatDateText employee.registerAt}}
+            {{formatDateTimeText employee.registerAt}}
           </div>
           <div class="col-md-7 d-block d-md-none"></div>
         </div>
@@ -701,10 +701,10 @@
     {{#with currentArenaData}}
       <div>
         <a href="{{currentArenaLinkHref}}">本次最萌亂鬥大賽</a>起迄時間為：
-        {{formatDateText currentArenaData.beginDate}}~
-        {{formatDateText currentArenaData.endDate}}
+        {{formatDateTimeText currentArenaData.beginDate}}~
+        {{formatDateTimeText currentArenaData.endDate}}
       </div>
-      <div>報名截止時間為：{{formatDateText currentArenaData.joinEndDate}}</div>
+      <div>報名截止時間為：{{formatDateTimeText currentArenaData.joinEndDate}}</div>
       {{#if this.joinData}}
         <div>
           {{companyData.companyName}}已經報名參加這一屆的最萌亂鬥大賽。

--- a/client/company/companyDetail.js
+++ b/client/company/companyDetail.js
@@ -18,7 +18,7 @@ import { inheritedShowLoadingOnSubscribing } from '../layout/loading';
 import { createBuyOrder, createSellOrder, retrieveOrder, changeChairmanTitle, toggleFavorite } from '../utils/methods';
 import { alertDialog } from '../layout/alertDialog';
 import { shouldStopSubscribe } from '../utils/idle';
-import { currencyFormat, setChartTheme } from '../utils/helpers.js';
+import { currencyFormat, setChartTheme } from '../utils/helpers';
 import { inheritUtilForm, handleInputChange as inheritedHandleInputChange } from '../utils/form';
 import { globalVariable } from '../utils/globalVariable';
 

--- a/client/company/companyEditForm.html
+++ b/client/company/companyEditForm.html
@@ -118,10 +118,10 @@
           <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/a/ac/No_image_available.svg/300px-No_image_available.svg.png" />
         {{/if}}
       </div>
-      <div class="media-body d-none d-md-block company-description"><h1>預覽角色簡介</h1>{{{previewDescription}}}</div>
+      <div class="media-body d-none d-md-block company-description markdown-container"><h1>預覽角色簡介</h1>{{{previewDescription}}}</div>
     </div>
     <div class="row " style="margin-top: 15px;">
-      <div class="col-12 d-md-none company-description"><h1>預覽角色簡介</h1>{{{previewDescription}}}</div>
+      <div class="col-12 d-md-none company-description markdown-container"><h1>預覽角色簡介</h1>{{{previewDescription}}}</div>
     </div>
   </div>
 </template>

--- a/client/company/companyEditForm.js
+++ b/client/company/companyEditForm.js
@@ -9,7 +9,7 @@ import { ReactiveVar } from 'meteor/reactive-var';
 import { inheritUtilForm, handleInputChange as inheritedHandleInputChange } from '../utils/form';
 import { alertDialog } from '../layout/alertDialog';
 import { bigPicturePreviewModal } from '../layout/bigPicturePreviewModal';
-import { markdown } from '../utils/helpers.js';
+import { markdown } from '../utils/helpers';
 
 inheritUtilForm(Template.companyEditForm);
 

--- a/client/company/companyList.html
+++ b/client/company/companyList.html
@@ -77,7 +77,7 @@
   <div class="col-12 col-md-6 col-lg-4 col-xl-3" style="margin-bottom: 25px;">
     <div class="company-card {{cardDisplayClass this}}">
       <div class="row row-info">
-        <small>{{formatDateText this.createdAt}} 創立</small>
+        <small>{{formatDateTimeText this.createdAt}} 創立</small>
         {{#if currentUser}}
           {{#if isFavorite this._id}}
             <i class="fa fa-heart btn-favorite" aria-hidden="true" data-toggle-favorite="{{this._id}}"></i>
@@ -219,8 +219,8 @@
         {{>companyLink this._id}}
       </div>
       <div class="col-4 col-lg-3 text-truncate text-right border-grid row-title">創立日期</div>
-      <div class="col-8 col-lg-3 text-truncate text-right border-grid" title="{{formatDateText this.createdAt}}">
-        {{formatDateText this.createdAt}}
+      <div class="col-8 col-lg-3 text-truncate text-right border-grid" title="{{formatDateTimeText this.createdAt}}">
+        {{formatDateTimeText this.createdAt}}
       </div>
       <div class="col-4 col-lg-3 text-truncate text-right border-grid row-title" title="{{this.chairmanTitle}}">
         {{#if isChairman this._id}}

--- a/client/company/companyMiningMachinePanel.html
+++ b/client/company/companyMiningMachinePanel.html
@@ -70,8 +70,8 @@
               {{stoneDisplayName companyStone.stoneType}}
             </div>
             <div class="grid-table-hidden-title">放置時間</div>
-            <div class="col-md-3 text-md-center grid-table-content" title="{{formatDateText companyStone.placedAt}}">
-              {{formatDateText companyStone.placedAt}}
+            <div class="col-md-3 text-md-center grid-table-content" title="{{formatDateTimeText companyStone.placedAt}}">
+              {{formatDateTimeText companyStone.placedAt}}
             </div>
           </div>
         {{else}}

--- a/client/foundation/editFoundation.html
+++ b/client/foundation/editFoundation.html
@@ -155,10 +155,10 @@
           <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/a/ac/No_image_available.svg/300px-No_image_available.svg.png" />
         {{/if}}
       </div>
-      <div class="media-body d-none d-md-block company-description"><h1>預覽角色簡介</h1>{{{previewDescription}}}</div>
+      <div class="media-body d-none d-md-block company-description markdown-container"><h1>預覽角色簡介</h1>{{{previewDescription}}}</div>
     </div>
     <div class="row " style="margin-top: 15px;">
-      <div class="col-12 d-md-none company-description"><h1>預覽角色簡介</h1>{{{previewDescription}}}</div>
+      <div class="col-12 d-md-none company-description markdown-container"><h1>預覽角色簡介</h1>{{{previewDescription}}}</div>
     </div>
   </div>
 </template>

--- a/client/foundation/editFoundation.js
+++ b/client/foundation/editFoundation.js
@@ -13,7 +13,7 @@ import { inheritedShowLoadingOnSubscribing } from '../layout/loading';
 import { alertDialog } from '../layout/alertDialog';
 import { bigPicturePreviewModal } from '../layout/bigPicturePreviewModal';
 import { shouldStopSubscribe } from '../utils/idle';
-import { currencyFormat, markdown } from '../utils/helpers.js';
+import { currencyFormat, markdown } from '../utils/helpers';
 
 Template.createFoundationPlan.helpers({
   defaultData() {
@@ -214,4 +214,3 @@ function addNewTag(event, templateInstance) {
   templateInstance.model.set(model);
   $input.val('');
 }
-

--- a/client/foundation/foundationDetail.html
+++ b/client/foundation/foundationDetail.html
@@ -73,10 +73,10 @@
           <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/a/ac/No_image_available.svg/300px-No_image_available.svg.png" />
         {{/if}}
       </div>
-      <div class="media-body d-none d-md-block company-description"><h1>角色簡介</h1>{{{markdown this.description}}}</div>
+      <div class="media-body d-none d-md-block company-description markdown-container"><h1>角色簡介</h1>{{{markdown this.description}}}</div>
     </div>
     <div class="row border-grid-body" style="margin-top: 15px;">
-      <div class="col-12 border-grid d-block d-md-none company-description"><h1>角色簡介</h1>{{{markdown this.description}}}</div>
+      <div class="col-12 border-grid d-block d-md-none company-description markdown-container"><h1>角色簡介</h1>{{{markdown this.description}}}</div>
       <div class="col-12 border-grid">
         <a class="d-block h4" href="#" data-toggle-panel="numbers">
           數據資訊
@@ -108,7 +108,7 @@
         </div>
         <div class="col-4 col-md-2 col-lg-2 text-right border-grid px-1">計劃日期</div>
         <div class="col-8 col-md-4 col-lg-2 text-right border-grid">
-          {{formatDateTimeText this.createdAt}}
+          {{formatShortDateTimeText this.createdAt}}
         </div>
         <div class="col-4 col-md-2 col-lg-2 text-right border-grid px-1">截止日期</div>
         <div class="col-8 col-md-4 col-lg-2 text-right border-grid">

--- a/client/foundation/foundationDetail.js
+++ b/client/foundation/foundationDetail.js
@@ -9,7 +9,7 @@ import { FlowRouter } from 'meteor/kadira:flow-router';
 import { dbFoundations } from '/db/dbFoundations';
 import { dbLog } from '/db/dbLog';
 import { inheritedShowLoadingOnSubscribing } from '../layout/loading';
-import { formatDateTimeText } from '../utils/helpers';
+import { formatShortDateTimeText } from '../utils/helpers';
 import { alertDialog } from '../layout/alertDialog';
 import { shouldStopSubscribe } from '../utils/idle';
 import { investFoundCompany } from '../utils/methods';
@@ -177,7 +177,7 @@ Template.foundationDetailTable.helpers({
   getExpireDateText(createdAt) {
     const expireDate = new Date(createdAt.getTime() + Meteor.settings.public.foundExpireTime);
 
-    return formatDateTimeText(expireDate);
+    return formatShortDateTimeText(expireDate);
   },
   getStockPrice(investList) {
     if (investList.length < Meteor.settings.public.foundationNeedUsers) {

--- a/client/foundation/foundationList.html
+++ b/client/foundation/foundationList.html
@@ -167,8 +167,8 @@
         {{>userLink this.manager}}
       </div>
       <div class="col-4 col-lg-3 text-truncate text-right border-grid row-title">計劃日期：</div>
-      <div class="col-8 col-lg-3 text-right text-truncate border-grid" title="{{formatDateText this.createdAt}}">
-        {{formatDateText this.createdAt}}
+      <div class="col-8 col-lg-3 text-right text-truncate border-grid" title="{{formatDateTimeText this.createdAt}}">
+        {{formatDateTimeText this.createdAt}}
       </div>
       <div class="col-4 col-lg-3 text-truncate text-right border-grid row-title">截止日期：</div>
       <div class="col-8 col-lg-3 text-truncate text-right border-grid" title="{{getExpireDateText this.createdAt}}">

--- a/client/foundation/foundationList.js
+++ b/client/foundation/foundationList.js
@@ -5,7 +5,7 @@ import { Template } from 'meteor/templating';
 import { FlowRouter } from 'meteor/kadira:flow-router';
 import { ReactiveVar } from 'meteor/reactive-var';
 import { dbFoundations } from '/db/dbFoundations';
-import { formatDateText, isCurrentUser } from '../utils/helpers';
+import { formatDateTimeText, isCurrentUser } from '../utils/helpers';
 import { inheritedShowLoadingOnSubscribing } from '../layout/loading';
 import { alertDialog } from '../layout/alertDialog';
 import { shouldStopSubscribe } from '../utils/idle';
@@ -121,7 +121,7 @@ const foundationListHelpers = {
   getExpireDateText(createdAt) {
     const expireDate = new Date(createdAt.getTime() + Meteor.settings.public.foundExpireTime);
 
-    return formatDateText(expireDate);
+    return formatDateTimeText(expireDate);
   },
   getEditHref(foundationId) {
     return FlowRouter.path('editFoundationPlan', { foundationId });

--- a/client/layout/footer.html
+++ b/client/layout/footer.html
@@ -3,7 +3,7 @@
     <div class={{containerClass}}>
       <div class="snackbar-container">
         {{> unreadImportantAccuseLogsNotification}}
-        {{> displayAnnouncement}}
+        {{> displayLegacyAnnouncement}}
         {{#each advertisingList}}
           {{> displayAdvertising}}
         {{/each}}
@@ -38,7 +38,7 @@
   {{/if}}
 </template>
 
-<template name="displayAnnouncement">
+<template name="displayLegacyAnnouncement">
   {{#if isDisplay}}
     <div class="media bg-info px-2 py-1 my-2 rounded footer-message-container">
       <div class="media-body footer-message">

--- a/client/layout/footer.html
+++ b/client/layout/footer.html
@@ -2,6 +2,7 @@
   <div class="fixed-bottom">
     <div class={{containerClass}}>
       <div class="snackbar-container">
+        {{> displayAnnouncementUnreadNotification}}
         {{> unreadImportantAccuseLogsNotification}}
         {{> displayLegacyAnnouncement}}
         {{#each advertisingList}}
@@ -47,6 +48,21 @@
       </div>
       <div class="footer-message-close-button">
         <a class="btn btn-danger btn-sm" href="#">
+          <i class="fa fa-times" aria-hidden="true"></i>
+        </a>
+      </div>
+    </div>
+  {{/if}}
+</template>
+
+<template name="displayAnnouncementUnreadNotification">
+  {{#if isDisplay}}
+    <div class="media bg-warning px-2 py-1 my-2 rounded footer-message-container">
+      <div class="media-body footer-message" style="color: white">
+        <strong>【注意】</strong> 您有 {{getPublishedCount 'currentUserUnreadAnnouncements'}} 則未讀的系統公告，請至<a style="color: yellow" href="{{pathFor 'announcementList'}}">系統公告</a>頁面查看！
+      </div>
+      <div class="footer-message-close-button">
+        <a class="btn btn-warning btn-sm" href="#">
           <i class="fa fa-times" aria-hidden="true"></i>
         </a>
       </div>

--- a/client/layout/footer.js
+++ b/client/layout/footer.js
@@ -1,8 +1,9 @@
-'use strict';
 import { _ } from 'meteor/underscore';
 import { Meteor } from 'meteor/meteor';
 import { Template } from 'meteor/templating';
 import { ReactiveVar } from 'meteor/reactive-var';
+import { Counts } from 'meteor/tmeasday:publish-counts';
+
 import { dbAdvertising } from '/db/dbAdvertising';
 import { dbVariables } from '/db/dbVariables';
 import { rMainTheme } from '../utils/styles';
@@ -123,5 +124,35 @@ Template.displayAdvertising.events({
     event.preventDefault();
     const closedAdvertisingIdList = rClosedAdvertisingIdList.get().slice();
     rClosedAdvertisingIdList.set(_.union(closedAdvertisingIdList, templateInstance.data._id));
+  }
+});
+
+Template.displayAnnouncementUnreadNotification.onCreated(function() {
+  this.rIsDisplay = new ReactiveVar(false);
+
+  this.autorunWithIdleSupport(() => {
+    const user = Meteor.user();
+    if (! user) {
+      return;
+    }
+
+    this.subscribe('currentUserUnreadAnnouncementCount');
+  });
+
+  this.autorunWithIdleSupport(() => {
+    this.rIsDisplay.set(Counts.get('currentUserUnreadAnnouncements') > 0);
+  });
+});
+
+Template.displayAnnouncementUnreadNotification.helpers({
+  isDisplay() {
+    return Template.instance().rIsDisplay.get();
+  }
+});
+
+Template.displayAnnouncementUnreadNotification.events({
+  'click .btn'(event, templateInstance) {
+    event.preventDefault();
+    templateInstance.rIsDisplay.set(false);
   }
 });

--- a/client/layout/footer.js
+++ b/client/layout/footer.js
@@ -96,13 +96,13 @@ Template.unreadImportantAccuseLogsNotification.events({
 });
 
 const rIsDisplayAnnouncement = new ReactiveVar(true);
-Template.displayAnnouncement.onCreated(function() {
+Template.displayLegacyAnnouncement.onCreated(function() {
   this.autorun(() => {
     dbVariables.get('announcement');
     rIsDisplayAnnouncement.set(true);
   });
 });
-Template.displayAnnouncement.helpers({
+Template.displayLegacyAnnouncement.helpers({
   isDisplay() {
     return rIsDisplayAnnouncement.get() && dbVariables.get('announcement');
   },
@@ -111,7 +111,7 @@ Template.displayAnnouncement.helpers({
   }
 });
 
-Template.displayAnnouncement.events({
+Template.displayLegacyAnnouncement.events({
   'click .btn'(event) {
     event.preventDefault();
     rIsDisplayAnnouncement.set(false);

--- a/client/layout/nav.html
+++ b/client/layout/nav.html
@@ -68,7 +68,10 @@
     <div class="{{getNavLinkListClassList}}">
       <ul class="navbar-nav">
         <li class="nav-item text-nowrap">
-          <a class="nav-link" href="{{getHref 'announcement'}}">{{getLinkText 'announcement'}}</a>
+          <a class="nav-link" href="{{pathFor 'mainPage'}}">{{getLinkText 'mainPage'}}</a>
+        </li>
+        <li class="nav-item text-nowrap">
+          <a class="nav-link" href="{{pathFor 'announcementList'}}">{{getLinkText 'announcement'}}</a>
         </li>
         {{#navLinkGroup text='交易大廳'}}
           {{> navLink page='instantMessage'}}

--- a/client/mainPage/mainPage.html
+++ b/client/mainPage/mainPage.html
@@ -1,29 +1,9 @@
-<template name="announcement">
+<template name="mainPage">
   <div class="card">
     <div class="card-block">
-      <h1 class="d-flex flex-wrap justify-content-start align-items-center mb-1">
-        <div class="text-nowrap">
-          系統公告
-        </div>
-        {{#if currentUserHasAnyRoles 'developer' 'planner' 'fscMember'}}
-          <div class="d-flex flex-wrap justify-content-end ml-auto">
-            <button class="btn btn-warning btn-sm" type="button" data-action="editAnnouncement">
-              <i class="fa fa-pencil-square-o" aria-hidden="true"></i>
-              修改系統公告
-            </button>
-          </div>
-        {{/if}}
-      </h1>
-      {{#if inEditAnnouncementMode}}
-        <hr />
-        {{> announcementForm}}
-      {{/if}}
+      <h1>{{websiteName}}</h1>
       <hr />
-      <div class="row">
-        <div class="col-12">
-          {{{announcementDetail}}}
-        </div>
-      </div>
+      {{> legacyAnnouncement}}
       <hr />
       {{> systemStatusPanel}}
       <hr />
@@ -36,19 +16,38 @@
   </div>
 </template>
 
-<template name="announcementForm">
+<template name="legacyAnnouncement">
+  {{#if currentUserHasAnyRoles 'developer' 'planner' 'fscMember'}}
+    <button class="btn btn-warning btn-sm" type="button" data-action="legacyEditAnnouncement">
+      <i class="fa fa-pencil-square-o" aria-hidden="true"></i>
+      修改系統通知
+    </button>
+  {{/if}}
+  {{#if inEditAnnouncementMode}}
+    <hr />
+    {{> legacyAnnouncementForm}}
+  {{/if}}
+  <hr />
+  <div class="row">
+    <div class="col-12">
+      {{{announcementDetail}}}
+    </div>
+  </div>
+</template>
+
+<template name="legacyAnnouncementForm">
   <form>
     <h3 class="card-subtitle text-muted">
-      修改系統公告
+      修改系統通知
     </h3>
     <hr />
     <div class="form-group">
       下方快訊內容
-      <textarea class="form-control" id="announcement-short" rows="1">{{getVariable 'announcement'}}</textarea>
+      <textarea class="form-control" id="announcement-short" rows="4">{{getVariable 'announcement'}}</textarea>
     </div>
     <div class="form-group">
-      公告頁面詳細內容
-      <textarea class="form-control" id="announcement-detail" rows="4">{{getVariable 'announcementDetail'}}</textarea>
+      主頁詳細公告內容
+      <textarea class="form-control" id="announcement-detail" rows="8">{{getVariable 'announcementDetail'}}</textarea>
     </div>
     <div class="text-right">
       <button class="btn btn-primary" type="submit">儲存</button>

--- a/client/productCenter/productCenterBySeason.html
+++ b/client/productCenter/productCenterBySeason.html
@@ -16,8 +16,8 @@
       <span aria-hidden="true">&laquo;</span>
     </a>
     <div>
-      <div class="d-inline-block text-nowrap">{{formatDateText seasonBegin}}～</div>
-      <div class="d-inline-block text-nowrap">{{formatDateText seasonEnd}}</div>
+      <div class="d-inline-block text-nowrap">{{formatDateTimeText seasonBegin}}～</div>
+      <div class="d-inline-block text-nowrap">{{formatDateTimeText seasonEnd}}</div>
     </div>
     <a  {{seasonLinkAttrs 'next'}}>
       <span aria-hidden="true">&raquo;</span>

--- a/client/ruleDiscuss/createRuleAgenda.html
+++ b/client/ruleDiscuss/createRuleAgenda.html
@@ -62,7 +62,7 @@
             name="{{getIssueInputName issue.id}}"
             placeholder="請輸入議題名稱(最多100字)"
           />
-          {{{errorHtmlOfIssueInput issue.id}}}
+          {{{errorHtmlOf (getIssueInputName issue.id)}}}
         </div>
         {{#each option in getIssueOptionList issue.id}}
           <div class="form-group">
@@ -73,7 +73,7 @@
               name="{{getIssueOptionInputName issue.id option.id}}"
               placeholder="請輸入選項(最多100字)"
             />
-            {{{errorHtmlOfIssueOptionInput issue.id option.id}}}
+            {{{errorHtmlOf (getIssueOptionInputName issue.id option.id)}}}
           </div>
         {{/each}}
         {{#if showAddOptionButton issue.id}}
@@ -104,7 +104,7 @@
   <div class="agenda-detail">
     <div class="row" style="margin-top: 15px;">
       <div class="col-12">
-        <div class="agenda-description">{{{previewDescription}}}</div>
+        <div class="agenda-description markdown-container">{{{previewDescription}}}</div>
       </div>
     </div>
   </div>

--- a/client/ruleDiscuss/createRuleAgenda.js
+++ b/client/ruleDiscuss/createRuleAgenda.js
@@ -6,9 +6,9 @@ import { Meteor } from 'meteor/meteor';
 import { Template } from 'meteor/templating';
 import { FlowRouter } from 'meteor/kadira:flow-router';
 import { ReactiveVar } from 'meteor/reactive-var';
-import { inheritUtilForm, utilFormHelpers, handleInputChange as inheritedHandleInputChange } from '../utils/form';
+import { inheritUtilForm } from '../utils/form';
 import { alertDialog } from '../layout/alertDialog';
-import { markdown } from '../utils/helpers.js';
+import { markdown } from '../utils/helpers';
 
 const rIssueList = new ReactiveVar();
 const rIssueOptionList = new ReactiveVar();
@@ -25,7 +25,6 @@ Template.createRuleAgenda.helpers({
 inheritUtilForm(Template.ruleAgendaForm);
 Template.ruleAgendaForm.onCreated(function() {
   this.validateModel = validateModel;
-  this.handleInputChange = handleInputChange;
   this.saveModel = saveModel;
   rIssueList.set(defaultIssueList());
   rIssueOptionList.set(defaultIssueOptionList());
@@ -33,9 +32,9 @@ Template.ruleAgendaForm.onCreated(function() {
 
 const description = new ReactiveVar('');
 Template.ruleAgendaForm.helpers({
-  getIssueInputName: getIssueInputName,
-  getIssueInputMultipleName: getIssueInputMultipleName,
-  getIssueOptionInputName: getIssueOptionInputName,
+  getIssueInputName,
+  getIssueInputMultipleName,
+  getIssueOptionInputName,
   getIssueList() {
     return rIssueList.get();
   },
@@ -69,14 +68,8 @@ Template.ruleAgendaForm.helpers({
 
     return list[issueId - 1].length > 2;
   },
-  errorHtmlOfIssueInput(issueId) {
-    return utilFormHelpers.errorHtmlOf(getIssueInputName(issueId));
-  },
-  errorHtmlOfIssueOptionInput(issueId, optionId) {
-    return utilFormHelpers.errorHtmlOf(getIssueOptionInputName(issueId, optionId));
-  },
   previewDescription() {
-    return markdown(description.get(), false);
+    return markdown(description.get(), { advanced: true });
   }
 });
 
@@ -139,15 +132,15 @@ function defaultIssueList() {
 }
 
 function getIssueInputName(issueId) {
-  return 'issue-' + issueId;
+  return `issue-${issueId}`;
 }
 
 function getIssueInputMultipleName(issueId) {
-  return 'issue-multiple-' + issueId;
+  return `issue-multiple-${issueId}`;
 }
 
 function getIssueOptionInputName(issueId, optionId) {
-  return 'option-' + issueId + '-' + optionId;
+  return `option-${issueId}-${optionId}`;
 }
 
 function validateModel(model) {
@@ -202,10 +195,6 @@ function validateModel(model) {
   if (_.size(error) > 0) {
     return error;
   }
-}
-
-function handleInputChange(event) {
-  inheritedHandleInputChange.call(this, event);
 }
 
 function saveModel(model) {

--- a/client/ruleDiscuss/ruleAgendaDetail.html
+++ b/client/ruleDiscuss/ruleAgendaDetail.html
@@ -52,7 +52,7 @@
           </a>
         </div>
 
-        <div class="agenda-description">{{{markdown this.description false}}}</div>
+        <div class="agenda-description markdown-container">{{{markdown this.description advanced=true}}}</div>
       </div>
     </div>
     {{#each issue in getIssueList this.issues}}

--- a/client/ruleDiscuss/ruleAgendaList.js
+++ b/client/ruleDiscuss/ruleAgendaList.js
@@ -3,7 +3,7 @@ import { Template } from 'meteor/templating';
 import { FlowRouter } from 'meteor/kadira:flow-router';
 import { dbRuleAgendas } from '/db/dbRuleAgendas';
 import { inheritedShowLoadingOnSubscribing } from '../layout/loading';
-import { formatDateText } from '../utils/helpers';
+import { formatDateTimeText } from '../utils/helpers';
 import { shouldStopSubscribe } from '../utils/idle';
 
 inheritedShowLoadingOnSubscribing(Template.ruleAgendaList);
@@ -57,6 +57,6 @@ Template.ruleAgendaList.helpers({
   formatExpireDate(agenda) {
     const expireDate = new Date(agenda.createdAt.getTime() + (agenda.duration * 60 * 60 * 1000));
 
-    return formatDateText(expireDate);
+    return formatDateTimeText(expireDate);
   }
 });

--- a/client/ruleDiscuss/ruleAgendaVote.html
+++ b/client/ruleDiscuss/ruleAgendaVote.html
@@ -42,7 +42,7 @@
       </a>
     </div>
 
-    <div class="agenda-description">{{{markdown this.description false}}}</div>
+    <div class="agenda-description markdown-container">{{{markdown this.description advanced=true}}}</div>
     {{#each issue in getIssueList this.issues}}
       {{> ruleIssueVoteList index=@index issue=issue}}
     {{/each}}

--- a/client/seasonalReport/seasonalReport.html
+++ b/client/seasonalReport/seasonalReport.html
@@ -28,8 +28,8 @@
       <span aria-hidden="true">&laquo;</span>
     </a>
     <div>
-      <div class="d-inline-block text-nowrap">{{formatDateText seasonBegin}}～</div>
-      <div class="d-inline-block text-nowrap">{{formatDateText seasonEnd}}</div>
+      <div class="d-inline-block text-nowrap">{{formatDateTimeText seasonBegin}}～</div>
+      <div class="d-inline-block text-nowrap">{{formatDateTimeText seasonEnd}}</div>
     </div>
     <a  {{seasonLinkAttrs 'next'}}>
       <span aria-hidden="true">&raquo;</span>

--- a/client/seasonalReport/seasonalReport.js
+++ b/client/seasonalReport/seasonalReport.js
@@ -13,7 +13,7 @@ import { dbSeason } from '/db/dbSeason';
 import { dbVariables } from '/db/dbVariables';
 import { inheritedShowLoadingOnSubscribing } from '../layout/loading';
 import { shouldStopSubscribe } from '../utils/idle';
-import { currencyFormat, setChartTheme } from '../utils/helpers.js';
+import { currencyFormat, setChartTheme } from '../utils/helpers';
 import { globalVariable } from '../utils/globalVariable';
 
 inheritedShowLoadingOnSubscribing(Template.seasonalReport);

--- a/client/utils/displayLog.html
+++ b/client/utils/displayLog.html
@@ -1,6 +1,6 @@
 <template name="displayLog">
   <div class="logData" style="word-break: break-all;">
-    <span class="text-info">({{formatDateText this.createdAt}})</span>
+    <span class="text-info">({{formatDateTimeText this.createdAt}})</span>
     {{{getDescriptionHtml this}}}
   </div>
 </template>

--- a/client/utils/displayLog.js
+++ b/client/utils/displayLog.js
@@ -4,7 +4,7 @@ import { Template } from 'meteor/templating';
 import { FlowRouter } from 'meteor/kadira:flow-router';
 
 import { roleDisplayName } from '/db/users';
-import { stoneDisplayName, currencyFormat } from './helpers.js';
+import { stoneDisplayName, currencyFormat } from './helpers';
 
 Template.displayLog.onRendered(function() {
   this.$('[data-user-link]').each((_, elem) => {

--- a/client/utils/helpers.js
+++ b/client/utils/helpers.js
@@ -139,7 +139,7 @@ export function formatLongDurationTimeText(time) {
     time >= hourBase ? `${hours} 時` : '',
     time >= minuteBase ? `${minutes} 分` : '',
     time >= secondBase ? `${seconds} 秒` : ''
-  ].join(' ');
+  ].join(' ').trim();
 }
 Template.registerHelper('formatLongDurationTimeText', formatLongDurationTimeText);
 

--- a/client/utils/helpers.js
+++ b/client/utils/helpers.js
@@ -1,4 +1,3 @@
-'use strict';
 import showdown from 'showdown';
 import xssFilter from 'showdown-xss-filter';
 import footnotes from 'showdown-footnotes';
@@ -71,7 +70,7 @@ Template.registerHelper('getCompanyEPS', getCompanyEPS);
 Template.registerHelper('getCompanyPERatio', getCompanyPERatio);
 Template.registerHelper('getCompanyEPRatio', getCompanyEPRatio);
 
-export function formatDateText(date) {
+export function formatDateTimeText(date) {
   if (! date) {
     return '????/??/?? ??:??:??';
   }
@@ -81,27 +80,22 @@ export function formatDateText(date) {
   );
 }
 function padZero(n) {
-  if (n < 10) {
-    return `0${n}`;
-  }
-  else {
-    return `${n}`;
-  }
-}
-Template.registerHelper('formatDateText', formatDateText);
-
-export function formatDateTimeText(date) {
-  if (! date) {
-    return '????/??/?? ??:??:??';
-  }
-
-  return (
-    `${padZero(date.getMonth() + 1)}/${padZero(date.getDate())} ${padZero(date.getHours())}:${padZero(date.getMinutes())}:${padZero(date.getSeconds())}`
-  );
+  return n < 10 ? `0${n}` : `${n}`;
 }
 Template.registerHelper('formatDateTimeText', formatDateTimeText);
 
-export function formatTimeText(time) {
+export function formatShortDateTimeText(date) {
+  if (! date) {
+    return '??/?? ??:??';
+  }
+
+  return (
+    `${padZero(date.getMonth() + 1)}/${padZero(date.getDate())} ${padZero(date.getHours())}:${padZero(date.getMinutes())}`
+  );
+}
+Template.registerHelper('formatShortDateTimeText', formatShortDateTimeText);
+
+export function formatShortDurationTimeText(time) {
   const timeBase = 1000 * 60;
 
   if (! time) {
@@ -114,6 +108,40 @@ export function formatTimeText(time) {
     `${padZero(Math.floor(time / 60))}:${padZero(time % 60)}`
   );
 }
+Template.registerHelper('formatShortDurationTimeText', formatShortDurationTimeText);
+
+export function formatLongDurationTimeText(time) {
+  if (! time) {
+    return '不明';
+  }
+
+  const secondBase = 1000;
+  const minuteBase = 60 * secondBase;
+  const hourBase = 60 * minuteBase;
+  const dayBase = 24 * hourBase;
+
+  let remainingTime = time;
+
+  const days = Math.floor(remainingTime / dayBase);
+  remainingTime -= days * dayBase;
+
+  const hours = Math.floor(remainingTime / hourBase);
+  remainingTime -= hours * hourBase;
+
+  const minutes = Math.floor(remainingTime / minuteBase);
+  remainingTime -= minutes * minuteBase;
+
+  const seconds = Math.floor(remainingTime / secondBase);
+  remainingTime -= seconds * secondBase;
+
+  return [
+    time >= dayBase ? `${days} 天` : '',
+    time >= hourBase ? `${hours} 時` : '',
+    time >= minuteBase ? `${minutes} 分` : '',
+    time >= secondBase ? `${seconds} 秒` : ''
+  ].join(' ');
+}
+Template.registerHelper('formatLongDurationTimeText', formatLongDurationTimeText);
 
 export function currentUserId() {
   return Meteor.userId();
@@ -266,30 +294,37 @@ const codeTagEscapedCharacterTranser = {
   }
 };
 
-// Advance(KaTeX, image)
-export function markdown(content, disableAdvance = true) {
+export function markdown(content, { advanced = false } = {}) {
+  if (! content) {
+    return '';
+  }
+
   const extensionsArray = [xssFilter, footnotes, codeTagEscapedCharacterTranser];
 
   let preprocessContent = content.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
-  if (disableAdvance) {
-    preprocessContent = preprocessContent.replace(/!/g, '&excl;');
-  }
-  else {
+  if (advanced) {
+    // 保留 KaTeX 和圖片
     extensionsArray.push(katexExtension);
     preprocessContent = preprocessContent.replace(/\$\$((.|\r|\n)*?)\$\$/g, function(match, capture) {
-      // \->\\避免showdown吃掉\符號導致KaTeX無法正確處理.
+      // 將 \ 取代為 \\ 避免 showdown 因處理跳脫時吃掉\符號導致 KaTeX 無法正確處理。
       const text = capture.replace(/\\/g, '\\\\');
 
       return `$$${text}$$`;
     });
   }
+  else {
+    preprocessContent = preprocessContent.replace(/!/g, '&excl;');
+  }
+
   const converter = new showdown.Converter({ extensions: extensionsArray });
   converter.setFlavor('github');
   converter.setOption('openLinksInNewWindow', true);
 
   return converter.makeHtml(preprocessContent);
 }
-Template.registerHelper('markdown', markdown);
+Template.registerHelper('markdown', function(content, kw = { hash: {} }) {
+  return markdown(content, kw.hash);
+});
 
 export function toPercent(x) {
   return `${Math.round(x * 100)}%`;
@@ -310,3 +345,10 @@ export function currentUserHasAllRoles(...roles) {
   return hasAllRoles(Meteor.user(), ...roles);
 }
 Template.registerHelper('currentUserHasAllRoles', currentUserHasAllRoles);
+
+export function pathFor(pathDef, kw = { hash: {} }) {
+  const { params, queryParams } = kw;
+
+  return FlowRouter.path(pathDef, params, queryParams);
+}
+Template.registerHelper('pathFor', pathFor);

--- a/client/utils/pagination.js
+++ b/client/utils/pagination.js
@@ -1,18 +1,19 @@
-'use strict';
 import { _ } from 'meteor/underscore';
 import { $ } from 'meteor/jquery';
 import { FlowRouter } from 'meteor/kadira:flow-router';
 import { Template } from 'meteor/templating';
+import { Counts } from 'meteor/tmeasday:publish-counts';
+
 import { dbVariables } from '/db/dbVariables';
 
 Template.pagination.helpers({
   haveData() {
-    const totalCount = dbVariables.get(this.useVariableForTotalCount);
+    const totalCount = Counts.get(this.counterName) || dbVariables.get(this.useVariableForTotalCount);
 
     return totalCount > 0;
   },
   pages() {
-    const totalCount = dbVariables.get(this.useVariableForTotalCount);
+    const totalCount = Counts.get(this.counterName) || dbVariables.get(this.useVariableForTotalCount);
     const totalPages = Math.ceil(totalCount / this.dataNumberPerPage);
     let displayCount = 6;
     displayCount = Math.max(3, displayCount);
@@ -43,7 +44,7 @@ Template.pagination.helpers({
     return (offset / this.dataNumberPerPage) + 1;
   },
   totalPages() {
-    const totalCount = dbVariables.get(this.useVariableForTotalCount);
+    const totalCount = Counts.get(this.counterName) || dbVariables.get(this.useVariableForTotalCount);
     const totalPages = Math.ceil(totalCount / this.dataNumberPerPage);
 
     return totalPages;
@@ -57,7 +58,7 @@ Template.pagination.helpers({
   pageLinkHref(page) {
     const templateInstance = Template.instance();
     const data = templateInstance.data;
-    const totalCount = dbVariables.get(data.useVariableForTotalCount);
+    const totalCount = Counts.get(this.counterName) || dbVariables.get(data.useVariableForTotalCount);
     const totalPages = Math.ceil(totalCount / data.dataNumberPerPage);
 
     if (page === 'end') {

--- a/client/utils/styles.css
+++ b/client/utils/styles.css
@@ -157,60 +157,51 @@ body {
   overflow-y: auto;
 }
 
+.company-description,
 .agenda-description {
   word-break: break-all;
   padding: 5px 15px;
 }
 
 .company-description {
-  word-break: break-all;
-  padding: 5px 15px;
   height: 300px;
   overflow-y: auto;
 }
 
-.company-description h1,
-.agenda-description h1 {
+.markdown-container h1 {
   font-size: 1.5rem;
 }
 
-.company-description h2,
-.agenda-description h2 {
+.markdown-container h2 {
   font-size: 1.3rem;
 }
 
-.company-description h3,
-.agenda-description h3 {
+.markdown-container h3 {
   font-size: 1.15rem;
 }
 
-.company-description h4,
-.company-description h5,
-.company-description h6,
-.agenda-description h4,
-.agenda-description h5,
-.agenda-description h6 {
+.markdown-container h4,
+.markdown-container h5,
+.markdown-container h6 {
   font-size: 1rem;
 }
 
-.company-description blockquote,
-.agenda-description blockquote {
+.markdown-container blockquote {
   font-weight: bold;
   font-style: italic;
-  margin-left: 1rem; 
+  margin-left: 1rem;
   border-left: 2px solid #999;
   padding-left: 1rem;
 }
 
-
-.company-description pre,
-.agenda-description pre {
+.markdown-container pre {
   white-space: pre-wrap;       /* Since CSS 2.1 */
   white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
   white-space: -pre-wrap;      /* Opera 4-6 */
   white-space: -o-pre-wrap;    /* Opera 7 */
   word-wrap: break-word;       /* Internet Explorer 5.5+ */
 }
+
 .company-card {
   padding: 0px;
   max-width: 270px;

--- a/common/imports/guards/userGuard.js
+++ b/common/imports/guards/userGuard.js
@@ -1,7 +1,8 @@
 import { Meteor } from 'meteor/meteor';
 import { _ } from 'meteor/underscore';
 
-import { banTypeDescription, hasRole, hasAnyRoles } from '/db/users';
+import { banTypeList, banTypeDescription, hasRole, hasAnyRoles } from '/db/users';
+import { getCurrentRound } from '/db/dbRound';
 
 class UserGuard {
   constructor(user) {
@@ -27,7 +28,7 @@ class UserGuard {
   checkNotBanned(...banTypes) {
     banTypes.forEach((banType) => {
       if (_.contains(this.user.profile.ban, banType)) {
-        throw new Meteor.Error(403, `您現在被金融管理會禁止了${banTypeDescription(banType)}！`);
+        throw new Meteor.Error(403, `您現在被禁止了${banTypeDescription(banType)}！`);
       }
     });
 
@@ -61,6 +62,28 @@ class UserGuard {
   checkHasAnyRoles(...roles) {
     if (! hasAnyRoles(this.user, ...roles)) {
       throw new Meteor.Error(403, '權限不符，無法進行此操作！');
+    }
+
+    return this;
+  }
+
+  checkCanVote() {
+    this.checkNotBanned(...banTypeList)
+      .checkNoExpiredTaxes();
+
+    if (this.user.profile.money < 0) {
+      throw new Meteor.Error(403, '現金為負數者不可投票！');
+    }
+
+    const now = Date.now();
+    const { voteUserNeedCreatedIn } = Meteor.settings.public;
+    const { beginDate: roundBeginDate } = getCurrentRound();
+
+    if (now - roundBeginDate.getTime() > voteUserNeedCreatedIn * 2) { // XXX: why * 2 ?
+      const userCreatedAt = this.user.createdAt;
+      if (! userCreatedAt || (now - userCreatedAt.getTime() < voteUserNeedCreatedIn)) {
+        throw new Meteor.Error(403, '註冊時間不足，不可投票！');
+      }
     }
 
     return this;

--- a/config.js
+++ b/config.js
@@ -60,7 +60,8 @@ export const config = {
     companyStones: 10,
     userOwnedProducts: 10,
     companyMarketingProducts: 10,
-    companyVips: 10
+    companyVips: 10,
+    announcements: 20
   },
   productFinalSaleTime: 86400000, // 產品最後出清時間 (ms)
   systemProductVotingReward: 4096, // 系統派發的推薦票回饋金
@@ -118,6 +119,31 @@ export const config = {
       default: 3
     }
   },
-  newRoundFoundationRestrictionTime: 3600000 // 新賽季禁止新創的時間 (ms)
+  newRoundFoundationRestrictionTime: 3600000, // 新賽季禁止新創的時間 (ms)
+  announcement: { // 系統公告相關設定
+    plannedRuleChanges: { // 規則更動計劃
+      rejectionPetition: { // 否決連署設定
+        durationDays: { // 持續時間 (天)
+          min: 3,
+          max: 7
+        },
+        thresholdPercent: 10 // 連署門檻 (%)
+      },
+      rejectionPoll: { // 否決投票設定
+        durationDays: 3, // 持續時間 (天)
+        thresholdPercent: 15 // 投票率門檻 (%)
+      }
+    },
+    appliedRuleChanges: { // 規則更動套用
+      rejectionPetition: { // 否決連署設定
+        durationDays: 14, // 持續時間 (天)
+        thresholdPercent: 20 // 連署門檻 (%)
+      },
+      rejectionPoll: { // 否決投票設定
+        durationDays: 3, // 持續時間 (天)
+        thresholdPercent: 30 // 投票率門檻 (%)
+      }
+    }
+  }
 };
 export default config;

--- a/config.json
+++ b/config.json
@@ -58,7 +58,8 @@
       "companyStones": 10,
       "userOwnedProducts": 10,
       "companyMarketingProducts": 10,
-      "companyVips": 10
+      "companyVips": 10,
+      "announcements": 20
     },
     "productFinalSaleTime": 86400000,
     "systemProductVotingReward": 4096,
@@ -117,6 +118,31 @@
         "default": 3
       }
     },
-    "newRoundFoundationRestrictionTime": 3600000
+    "newRoundFoundationRestrictionTime": 3600000,
+    "announcement": {
+      "plannedRuleChanges": {
+        "rejectionPetition": {
+          "durationDays": {
+            "min": 3,
+            "max": 7
+          },
+          "thresholdPercent": 10
+        },
+        "rejectionPoll": {
+          "durationDays": 3,
+          "thresholdPercent": 15
+        }
+      },
+      "appliedRuleChanges": {
+        "rejectionPetition": {
+          "durationDays": 14,
+          "thresholdPercent": 20
+        },
+        "rejectionPoll": {
+          "durationDays": 3,
+          "thresholdPercent": 30
+        }
+      }
+    }
   }
 }

--- a/db/dbAnnouncements.js
+++ b/db/dbAnnouncements.js
@@ -117,8 +117,7 @@ const schema = new SimpleSchema({
         type: String
       }
     }),
-    optional: true,
-    defaultValue: undefined
+    optional: true
   },
   // 否決投票
   rejectionPoll: {
@@ -154,8 +153,7 @@ const schema = new SimpleSchema({
         type: String
       }
     }),
-    optional: true,
-    defaultValue: undefined
+    optional: true
   }
 });
 dbAnnouncements.attachSchema(schema);

--- a/db/dbAnnouncements.js
+++ b/db/dbAnnouncements.js
@@ -1,0 +1,171 @@
+import { Meteor } from 'meteor/meteor';
+import { Mongo } from 'meteor/mongo';
+import SimpleSchema from 'simpl-schema';
+
+import { hasAnyRoles } from './users';
+
+// 系統公告資料集
+export const dbAnnouncements = new Mongo.Collection('announcements');
+
+export const announcementCategoryMap = {
+  maintenance: {
+    displayName: '系統維護',
+    announceableBy: ['superAdmin']
+  },
+  fsc: {
+    displayName: '金管會',
+    announceableBy: ['fscMember']
+  },
+  plannedRuleChanges: {
+    displayName: '規則更動計劃',
+    announceableBy: ['planner']
+  },
+  appliedRuleChanges: {
+    displayName: '規則更動套用',
+    announceableBy: ['planner']
+  },
+  knownProblems: {
+    displayName: '已知問題',
+    announceableBy: ['developer']
+  },
+  miscellaneous: {
+    displayName: '其他雜項',
+    announceableBy: ['superAdmin', 'generalManager']
+  }
+};
+
+export function categoryDisplayName(category) {
+  return (announcementCategoryMap[category] || { displayName: `未知分類(${category})` }).displayName;
+}
+
+export function getAnnounceableCategories(user) {
+  if (! user || ! user.profile || ! user.profile.roles) {
+    return [];
+  }
+
+  return Object.entries(announcementCategoryMap)
+    .filter(([, { announceableBy } ]) => {
+      return ! announceableBy || hasAnyRoles(user, ...announceableBy);
+    })
+    .map(([category]) => {
+      return category;
+    });
+}
+
+const schema = new SimpleSchema({
+  // 公告人 userId
+  creator: {
+    type: String
+  },
+  // 類別
+  category: {
+    type: String,
+    allowedValues: Object.keys(announcementCategoryMap)
+  },
+  // 主旨
+  subject: {
+    type: String,
+    min: 1,
+    max: 100
+  },
+  // 內容
+  content: {
+    type: String,
+    min: 10,
+    max: 3000
+  },
+  // 已讀玩家列表
+  readers: {
+    type: Array,
+    defaultValue: []
+  },
+  'readers.$': {
+    type: String
+  },
+  // 建立日期
+  createdAt: {
+    type: Date
+  },
+  // 否決連署
+  rejectionPetition: {
+    type: new SimpleSchema({
+      // 活躍玩家人數
+      activeUserCount: {
+        type: SimpleSchema.Integer,
+        min: 0
+      },
+      // 連署門檻百分比
+      thresholdPercent: {
+        type: Number,
+        min: 0
+      },
+      // 截止時間
+      dueAt: {
+        type: Date
+      },
+      // 通過時間
+      passedAt: {
+        type: Date,
+        optional: true
+      },
+      // 連署人列表
+      signers: {
+        type: Array,
+        defaultValue: []
+      },
+      'signers.$': {
+        type: String
+      }
+    }),
+    optional: true,
+    defaultValue: undefined
+  },
+  // 否決投票
+  rejectionPoll: {
+    type: new SimpleSchema({
+      // 活躍玩家人數
+      activeUserCount: {
+        type: SimpleSchema.Integer,
+        min: 0
+      },
+      // 投票門檻人數
+      thresholdPercent: {
+        type: Number,
+        min: 0
+      },
+      // 截止時間
+      dueAt: {
+        type: Date
+      },
+      // 贊成列表
+      yesVotes: {
+        type: Array,
+        defaultValue: []
+      },
+      'yesVotes.$': {
+        type: String
+      },
+      // 反對列表
+      noVotes: {
+        type: Array,
+        defaultValue: []
+      },
+      'noVotes.$': {
+        type: String
+      }
+    }),
+    optional: true,
+    defaultValue: undefined
+  }
+});
+dbAnnouncements.attachSchema(schema);
+
+dbAnnouncements.findByIdOrThrow = function(id, options) {
+  const result = dbAnnouncements.findOne(id, options);
+
+  if (! result) {
+    throw new Meteor.Error(404, `找不到識別碼為「${id}」的系統公告！`);
+  }
+
+  return result;
+};

--- a/db/migrate.js
+++ b/db/migrate.js
@@ -6,6 +6,7 @@ import { Migrations } from 'meteor/percolate:migrations';
 import { Promise } from 'meteor/promise';
 
 import { dbAdvertising } from './dbAdvertising';
+import { dbAnnouncements } from './dbAnnouncements';
 import { dbArena } from './dbArena';
 import { dbArenaFighters } from './dbArenaFighters';
 import { dbCompanies } from './dbCompanies';
@@ -1523,6 +1524,18 @@ if (Meteor.isServer) {
 
       // 對權限組設定建立索引
       Promise.await(Meteor.users.rawCollection().createIndex({ roles: 1 }));
+    }
+  });
+
+  Migrations.add({
+    version: 25,
+    name: 'new announcement system',
+    up() {
+      Promise.await(Promise.all([
+        dbAnnouncements.rawCollection().createIndex({ categoty: 1 }),
+        dbAnnouncements.rawCollection().createIndex({ createdAt: -1 }),
+        dbAnnouncements.rawCollection().createIndex({ readers: 1 })
+      ]));
     }
   });
 

--- a/db/users.js
+++ b/db/users.js
@@ -163,7 +163,8 @@ const schema = new SimpleSchema({
           };
 
           return obj;
-        }, {}))
+        }, {})),
+        defaultValue: {}
       },
       // 是否處於繳稅逾期的狀態
       notPayTax: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1150,7 +1150,7 @@
     },
     "capture-stack-trace": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
       "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
       "dev": true
     },
@@ -1366,7 +1366,7 @@
     },
     "create-error-class": {
       "version": "3.0.2",
-      "resolved": "http://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "requires": {
@@ -2131,7 +2131,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
@@ -2969,7 +2969,7 @@
     },
     "is-retry-allowed": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
       "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
       "dev": true
     },
@@ -3199,17 +3199,72 @@
         "lodash.keys": "3.1.2"
       }
     },
+    "lodash._basecallback": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecallback/-/lodash._basecallback-3.3.1.tgz",
+      "integrity": "sha1-t7K7Q9whYEJKIczybFfkQ3cqjic=",
+      "requires": {
+        "lodash._baseisequal": "3.0.7",
+        "lodash._bindcallback": "3.0.1",
+        "lodash.isarray": "3.0.4",
+        "lodash.pairs": "3.0.1"
+      }
+    },
     "lodash._basecopy": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
       "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
       "dev": true
     },
+    "lodash._baseeach": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash._baseeach/-/lodash._baseeach-3.0.4.tgz",
+      "integrity": "sha1-z4cGVyyhROjZ11InyZDamC+TKvM=",
+      "requires": {
+        "lodash.keys": "3.1.2"
+      }
+    },
+    "lodash._basefind": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._basefind/-/lodash._basefind-3.0.0.tgz",
+      "integrity": "sha1-srugXMZF+XLeLPkl+iv2Og9gyK4="
+    },
+    "lodash._basefindindex": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/lodash._basefindindex/-/lodash._basefindindex-3.6.0.tgz",
+      "integrity": "sha1-8IM2ChsCJBjtgbyJm+sxLiHnSk8="
+    },
+    "lodash._baseisequal": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
+      "integrity": "sha1-2AJfdjOdKTQnZ9zIh85cuVpbUfE=",
+      "requires": {
+        "lodash.isarray": "3.0.4",
+        "lodash.istypedarray": "3.0.6",
+        "lodash.keys": "3.1.2"
+      }
+    },
+    "lodash._baseismatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lodash._baseismatch/-/lodash._baseismatch-3.1.3.tgz",
+      "integrity": "sha1-Byj8SO+hFpnT1fLXMEnyqxPED9U=",
+      "requires": {
+        "lodash._baseisequal": "3.0.7"
+      }
+    },
+    "lodash._basematches": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._basematches/-/lodash._basematches-3.2.0.tgz",
+      "integrity": "sha1-9H4D8H7CB4SrCWjQy2y1l+IQEVg=",
+      "requires": {
+        "lodash._baseismatch": "3.1.3",
+        "lodash.pairs": "3.0.1"
+      }
+    },
     "lodash._bindcallback": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
-      "dev": true
+      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
     },
     "lodash._createassigner": {
       "version": "3.1.1",
@@ -3234,8 +3289,7 @@
     "lodash._getnative": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-      "dev": true
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
@@ -3281,11 +3335,39 @@
         "lodash.restparam": "3.6.1"
       }
     },
+    "lodash.every": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.every/-/lodash.every-4.6.0.tgz",
+      "integrity": "sha1-64mYS+vENkJ5uzrvu9HKGb+mxqc="
+    },
     "lodash.find": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
-      "integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=",
-      "dev": true
+      "integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E="
+    },
+    "lodash.findwhere": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.findwhere/-/lodash.findwhere-3.1.0.tgz",
+      "integrity": "sha1-eTfTTz6sgY3sf6lOjKXib9uhz8E=",
+      "requires": {
+        "lodash._basematches": "3.2.0",
+        "lodash.find": "3.2.1"
+      },
+      "dependencies": {
+        "lodash.find": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-3.2.1.tgz",
+          "integrity": "sha1-BG4xnzrOkSrGySRsf2g8XsB7Nq0=",
+          "requires": {
+            "lodash._basecallback": "3.3.1",
+            "lodash._baseeach": "3.0.4",
+            "lodash._basefind": "3.0.0",
+            "lodash._basefindindex": "3.6.0",
+            "lodash.isarray": "3.0.4",
+            "lodash.keys": "3.1.2"
+          }
+        }
+      }
     },
     "lodash.foreach": {
       "version": "4.5.0",
@@ -3298,17 +3380,20 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-      "dev": true
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
     },
     "lodash.isarray": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-      "dev": true
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
     },
     "lodash.isempty": {
       "version": "4.4.0",
@@ -3320,11 +3405,15 @@
       "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
       "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0="
     },
+    "lodash.istypedarray": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
+      "integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I="
+    },
     "lodash.keys": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true,
       "requires": {
         "lodash._getnative": "3.9.1",
         "lodash.isarguments": "3.1.0",
@@ -3341,6 +3430,24 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
       "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU="
+    },
+    "lodash.omit": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
+    },
+    "lodash.pairs": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.pairs/-/lodash.pairs-3.0.1.tgz",
+      "integrity": "sha1-u+CNV4bu6qCaFckevw3LfSvjJqk=",
+      "requires": {
+        "lodash.keys": "3.1.2"
+      }
+    },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
     },
     "lodash.restparam": {
       "version": "3.6.1",
@@ -3364,6 +3471,16 @@
       "requires": {
         "lodash._reinterpolate": "3.0.0"
       }
+    },
+    "lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
     "lodash.without": {
       "version": "4.4.0",
@@ -3443,15 +3560,6 @@
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "requires": {
         "mimic-fn": "1.1.0"
-      }
-    },
-    "message-box": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/message-box/-/message-box-0.1.1.tgz",
-      "integrity": "sha1-d4VlhUzUUn0mc3P8IBJN4Ycpjaw=",
-      "requires": {
-        "lodash.merge": "4.6.0",
-        "lodash.template": "4.4.0"
       }
     },
     "meteor-node-stubs": {
@@ -4098,17 +4206,6 @@
       "dev": true,
       "requires": {
         "caller-id": "0.1.0"
-      }
-    },
-    "mongo-object": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/mongo-object/-/mongo-object-0.0.2.tgz",
-      "integrity": "sha512-FI827BgRJvEZ+Uef+qWIsXu93+8pok26b5LZO2Nc3T6XRg/IrkvV1okxyez+Kz/psfV3n5WqqtR+ySg2Q7mSPg==",
-      "requires": {
-        "lodash.foreach": "4.5.0",
-        "lodash.isempty": "4.4.0",
-        "lodash.isobject": "3.0.2",
-        "lodash.without": "4.4.0"
       }
     },
     "ms": {
@@ -5151,15 +5248,46 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "simpl-schema": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/simpl-schema/-/simpl-schema-0.3.2.tgz",
-      "integrity": "sha1-LHVETpN4UFrFJSGTlN4GPOT28Gg=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/simpl-schema/-/simpl-schema-1.5.0.tgz",
+      "integrity": "sha512-lv9n+1R7Oe3fpm3cWVyrs3mG1C9+DCc8QTCRn6cfLIsPkLfuMhBPLDwpnIsdA8Ch0fRO7BSxKvpVPcYvcYeSxg==",
       "requires": {
         "clone": "2.1.1",
         "extend": "3.0.1",
-        "message-box": "0.1.1",
-        "mongo-object": "0.0.2",
-        "underscore": "1.8.3"
+        "lodash.every": "4.6.0",
+        "lodash.find": "4.6.0",
+        "lodash.findwhere": "3.1.0",
+        "lodash.includes": "4.3.0",
+        "lodash.isempty": "4.4.0",
+        "lodash.isobject": "3.0.2",
+        "lodash.omit": "4.5.0",
+        "lodash.pick": "4.4.0",
+        "lodash.union": "4.6.0",
+        "lodash.uniq": "4.5.0",
+        "message-box": "0.2.0",
+        "mongo-object": "0.1.2"
+      },
+      "dependencies": {
+        "message-box": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/message-box/-/message-box-0.2.0.tgz",
+          "integrity": "sha512-SPLfVDEM2YcAgV2IB0B5vOGjvqXSSw7ZibEeXcff8HYpxyG1Uj+XjgnGUGyR1C0EQCvPI3MBx3p7opt2CIQ2hw==",
+          "requires": {
+            "lodash.merge": "4.6.0",
+            "lodash.template": "4.4.0"
+          }
+        },
+        "mongo-object": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/mongo-object/-/mongo-object-0.1.2.tgz",
+          "integrity": "sha512-xRrnal5HuCz3we8Bzk17iYfgCMfaaSU+cq0OkQ/PP+CYhhFmw4Joqmcc0R9XUAgxbFAybg7uzxbNGUw13kEUxQ==",
+          "requires": {
+            "lodash.foreach": "4.5.0",
+            "lodash.isempty": "4.4.0",
+            "lodash.isobject": "3.0.2",
+            "lodash.without": "4.4.0"
+          }
+        }
       }
     },
     "sinon": {
@@ -5712,11 +5840,6 @@
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-0.0.3.tgz",
       "integrity": "sha1-7Mo6A+VrmvFzhbqsgSrIO5lKli8=",
       "dev": true
-    },
-    "underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
     },
     "unique-string": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0"
+        "acorn": "^3.0.4"
       },
       "dependencies": {
         "acorn": {
@@ -47,10 +47,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
       "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "ajv-keywords": {
@@ -65,7 +65,7 @@
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "dev": true,
       "requires": {
-        "string-width": "2.1.1"
+        "string-width": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -86,8 +86,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -96,7 +96,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -122,8 +122,8 @@
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
-        "micromatch": "2.3.11",
-        "normalize-path": "2.1.1"
+        "micromatch": "^2.1.5",
+        "normalize-path": "^2.0.0"
       }
     },
     "aproba": {
@@ -136,8 +136,8 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.3"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       }
     },
     "argparse": {
@@ -146,7 +146,7 @@
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "aria-query": {
@@ -164,7 +164,7 @@
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0"
+        "arr-flatten": "^1.0.1"
       }
     },
     "arr-flatten": {
@@ -179,8 +179,8 @@
       "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.9.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.7.0"
       }
     },
     "array-union": {
@@ -189,7 +189,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -268,53 +268,36 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       }
     },
     "babel-core": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-      "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+      "version": "6.26.3",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-generator": "6.26.0",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "convert-source-map": "1.5.0",
-        "debug": "2.6.9",
-        "json5": "0.5.1",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.8",
-        "slash": "1.0.0",
-        "source-map": "0.5.7"
-      },
-      "dependencies": {
-        "babel-register": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
-          "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-          "dev": true,
-          "requires": {
-            "babel-core": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "core-js": "2.5.1",
-            "home-or-tmp": "2.0.0",
-            "lodash": "4.17.4",
-            "mkdirp": "0.5.1",
-            "source-map-support": "0.4.18"
-          }
-        }
+        "babel-code-frame": "^6.26.0",
+        "babel-generator": "^6.26.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "convert-source-map": "^1.5.1",
+        "debug": "^2.6.9",
+        "json5": "^0.5.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "path-is-absolute": "^1.0.1",
+        "private": "^0.1.8",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.7"
       }
     },
     "babel-eslint": {
@@ -323,26 +306,26 @@
       "integrity": "sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0"
+        "babel-code-frame": "^6.22.0",
+        "babel-traverse": "^6.23.1",
+        "babel-types": "^6.23.0",
+        "babylon": "^6.17.0"
       }
     },
     "babel-generator": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
-      "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
+      "version": "6.26.1",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "dev": true,
       "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.4",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.7",
+        "trim-right": "^1.0.1"
       },
       "dependencies": {
         "jsesc": {
@@ -359,9 +342,9 @@
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "dev": true,
       "requires": {
-        "babel-helper-explode-assignable-expression": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-explode-assignable-expression": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-call-delegate": {
@@ -370,10 +353,10 @@
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-define-map": {
@@ -382,10 +365,10 @@
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-explode-assignable-expression": {
@@ -394,9 +377,9 @@
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-function-name": {
@@ -405,11 +388,11 @@
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "dev": true,
       "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-get-function-arity": {
@@ -418,8 +401,8 @@
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-hoist-variables": {
@@ -428,8 +411,8 @@
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-optimise-call-expression": {
@@ -438,8 +421,8 @@
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-regex": {
@@ -448,9 +431,9 @@
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -459,11 +442,11 @@
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-replace-supers": {
@@ -472,12 +455,12 @@
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "dev": true,
       "requires": {
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helpers": {
@@ -486,8 +469,8 @@
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-messages": {
@@ -496,7 +479,7 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -505,7 +488,7 @@
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-module-resolver": {
@@ -514,11 +497,11 @@
       "integrity": "sha512-U394VtqR+uGozwV43paA9tUOJ2WYP/OpLMla7u/Qi+/A0chDwuRoYu1hkqkkNTAvoq21ybSIgdCeDV4GVvqfeA==",
       "dev": true,
       "requires": {
-        "find-babel-config": "1.1.0",
-        "glob": "7.1.2",
-        "pkg-up": "2.0.0",
-        "reselect": "3.0.1",
-        "resolve": "1.5.0"
+        "find-babel-config": "^1.1.0",
+        "glob": "^7.1.2",
+        "pkg-up": "^2.0.0",
+        "reselect": "^3.0.1",
+        "resolve": "^1.4.0"
       }
     },
     "babel-plugin-syntax-async-functions": {
@@ -545,9 +528,9 @@
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "dev": true,
       "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-functions": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-functions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -556,7 +539,7 @@
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -565,7 +548,7 @@
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -574,11 +557,11 @@
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -587,15 +570,15 @@
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "dev": true,
       "requires": {
-        "babel-helper-define-map": "6.26.0",
-        "babel-helper-function-name": "6.24.1",
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-define-map": "^6.24.1",
+        "babel-helper-function-name": "^6.24.1",
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -604,8 +587,8 @@
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -614,7 +597,7 @@
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
@@ -623,8 +606,8 @@
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
@@ -633,7 +616,7 @@
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -642,9 +625,9 @@
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-literals": {
@@ -653,7 +636,7 @@
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-modules-amd": {
@@ -662,9 +645,9 @@
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -673,10 +656,10 @@
       "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-plugin-transform-strict-mode": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
@@ -685,9 +668,9 @@
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-umd": {
@@ -696,9 +679,9 @@
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -707,8 +690,8 @@
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "dev": true,
       "requires": {
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.26.0"
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -717,12 +700,12 @@
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "dev": true,
       "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-call-delegate": "^6.24.1",
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -731,8 +714,8 @@
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -741,7 +724,7 @@
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -750,9 +733,9 @@
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -761,7 +744,7 @@
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
@@ -770,7 +753,7 @@
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -779,9 +762,9 @@
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "regexpu-core": "2.0.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "regexpu-core": "^2.0.0"
       }
     },
     "babel-plugin-transform-exponentiation-operator": {
@@ -790,9 +773,9 @@
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "dev": true,
       "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-regenerator": {
@@ -801,7 +784,7 @@
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "dev": true,
       "requires": {
-        "regenerator-transform": "0.10.1"
+        "regenerator-transform": "^0.10.0"
       }
     },
     "babel-plugin-transform-runtime": {
@@ -810,7 +793,7 @@
       "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -819,8 +802,8 @@
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-polyfill": {
@@ -828,9 +811,9 @@
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
       "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.1",
-        "regenerator-runtime": "0.10.5"
+        "babel-runtime": "^6.22.0",
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.10.0"
       },
       "dependencies": {
         "regenerator-runtime": {
@@ -846,51 +829,51 @@
       "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
       "dev": true,
       "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "2.8.0",
-        "invariant": "2.2.2",
-        "semver": "5.4.1"
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-to-generator": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+        "babel-plugin-transform-es2015-classes": "^6.23.0",
+        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+        "babel-plugin-transform-es2015-for-of": "^6.23.0",
+        "babel-plugin-transform-es2015-function-name": "^6.22.0",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+        "babel-plugin-transform-es2015-object-super": "^6.22.0",
+        "babel-plugin-transform-es2015-parameters": "^6.23.0",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+        "babel-plugin-transform-regenerator": "^6.22.0",
+        "browserslist": "^2.1.2",
+        "invariant": "^2.2.2",
+        "semver": "^5.3.0"
       }
     },
     "babel-register": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
-      "integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.1",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18"
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.15"
       }
     },
     "babel-runtime": {
@@ -898,8 +881,8 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "2.5.1",
-        "regenerator-runtime": "0.11.0"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       }
     },
     "babel-template": {
@@ -908,11 +891,11 @@
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.4"
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-traverse": {
@@ -921,15 +904,15 @@
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.2",
-        "lodash": "4.17.4"
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
       }
     },
     "babel-types": {
@@ -938,10 +921,10 @@
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.4",
-        "to-fast-properties": "1.0.3"
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
       }
     },
     "babylon": {
@@ -970,7 +953,7 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "binary-extensions": {
@@ -984,7 +967,7 @@
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "~2.0.0"
       }
     },
     "boolbase": {
@@ -997,7 +980,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.x.x"
       }
     },
     "boxen": {
@@ -1006,13 +989,13 @@
       "integrity": "sha1-Px1AMsMP/qnUsCwyLq8up0HcvOU=",
       "dev": true,
       "requires": {
-        "ansi-align": "2.0.0",
-        "camelcase": "4.1.0",
-        "chalk": "2.3.0",
-        "cli-boxes": "1.0.0",
-        "string-width": "2.1.1",
-        "term-size": "1.2.0",
-        "widest-line": "1.0.0"
+        "ansi-align": "^2.0.0",
+        "camelcase": "^4.0.0",
+        "chalk": "^2.0.1",
+        "cli-boxes": "^1.0.0",
+        "string-width": "^2.0.0",
+        "term-size": "^1.2.0",
+        "widest-line": "^1.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1027,7 +1010,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -1036,9 +1019,9 @@
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -1072,7 +1055,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -1082,7 +1065,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1092,9 +1075,9 @@
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
       }
     },
     "browserslist": {
@@ -1103,8 +1086,8 @@
       "integrity": "sha512-iiWHM1Et6Q4TQpB7Ar6pxuM3TNMXasVJY4Y/oh3q38EwR3Z+IdZ9MyVf7PI4MJFB4xpwMcZgs9bEUnPG2E3TCA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000760",
-        "electron-to-chromium": "1.3.27"
+        "caniuse-lite": "^1.0.30000758",
+        "electron-to-chromium": "^1.3.27"
       }
     },
     "builtin-modules": {
@@ -1119,7 +1102,7 @@
       "integrity": "sha1-Wb2sCJPRLDhxQIJ5Ix+XRYNk8Hs=",
       "dev": true,
       "requires": {
-        "stack-trace": "0.0.10"
+        "stack-trace": "~0.0.7"
       }
     },
     "caller-path": {
@@ -1128,7 +1111,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "0.2.0"
+        "callsites": "^0.2.0"
       }
     },
     "callsites": {
@@ -1164,11 +1147,11 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "cheerio": {
@@ -1176,12 +1159,12 @@
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
       "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
       "requires": {
-        "css-select": "1.2.0",
-        "dom-serializer": "0.1.0",
-        "entities": "1.1.1",
-        "htmlparser2": "3.9.2",
-        "lodash": "4.17.4",
-        "parse5": "3.0.3"
+        "css-select": "~1.2.0",
+        "dom-serializer": "~0.1.0",
+        "entities": "~1.1.1",
+        "htmlparser2": "^3.9.1",
+        "lodash": "^4.15.0",
+        "parse5": "^3.0.1"
       }
     },
     "chokidar": {
@@ -1190,14 +1173,14 @@
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
-        "anymatch": "1.3.2",
-        "async-each": "1.0.1",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
+        "anymatch": "^1.3.0",
+        "async-each": "^1.0.0",
+        "glob-parent": "^2.0.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^2.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0"
       }
     },
     "circular-json": {
@@ -1217,7 +1200,7 @@
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "requires": {
-        "restore-cursor": "2.0.0"
+        "restore-cursor": "^2.0.0"
       }
     },
     "cli-width": {
@@ -1230,9 +1213,9 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
       "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
       "requires": {
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "wrap-ansi": "2.1.0"
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0",
+        "wrap-ansi": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1285,7 +1268,7 @@
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
@@ -1299,7 +1282,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -1318,9 +1301,9 @@
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "typedarray": "0.0.6"
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "configstore": {
@@ -1329,12 +1312,12 @@
       "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
       "dev": true,
       "requires": {
-        "dot-prop": "4.2.0",
-        "graceful-fs": "4.1.11",
-        "make-dir": "1.1.0",
-        "unique-string": "1.0.0",
-        "write-file-atomic": "2.3.0",
-        "xdg-basedir": "3.0.0"
+        "dot-prop": "^4.1.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "unique-string": "^1.0.0",
+        "write-file-atomic": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
       }
     },
     "console-control-strings": {
@@ -1349,9 +1332,9 @@
       "dev": true
     },
     "convert-source-map": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-      "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
       "dev": true
     },
     "core-js": {
@@ -1370,7 +1353,7 @@
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "requires": {
-        "capture-stack-trace": "1.0.0"
+        "capture-stack-trace": "^1.0.0"
       }
     },
     "cross-spawn": {
@@ -1378,9 +1361,9 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "requires": {
-        "lru-cache": "4.1.1",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "cryptiles": {
@@ -1388,7 +1371,7 @@
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "requires": {
-        "boom": "5.2.0"
+        "boom": "5.x.x"
       },
       "dependencies": {
         "boom": {
@@ -1396,7 +1379,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.2.0"
+            "hoek": "4.x.x"
           }
         }
       }
@@ -1417,10 +1400,10 @@
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "requires": {
-        "boolbase": "1.0.0",
-        "css-what": "2.1.0",
+        "boolbase": "~1.0.0",
+        "css-what": "2.1",
         "domutils": "1.5.1",
-        "nth-check": "1.0.1"
+        "nth-check": "~1.0.1"
       }
     },
     "css-what": {
@@ -1439,7 +1422,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.35"
+        "es5-ext": "^0.10.9"
       }
     },
     "damerau-levenshtein": {
@@ -1453,7 +1436,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "debug": {
@@ -1492,8 +1475,8 @@
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
       }
     },
     "defined": {
@@ -1508,13 +1491,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "delayed-stream": {
@@ -1533,7 +1516,7 @@
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "diff": {
@@ -1548,8 +1531,8 @@
       "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2",
-        "isarray": "1.0.0"
+        "esutils": "^2.0.2",
+        "isarray": "^1.0.0"
       }
     },
     "dom-serializer": {
@@ -1557,8 +1540,8 @@
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.1"
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -1578,7 +1561,7 @@
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
       "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
       "requires": {
-        "domelementtype": "1.3.0"
+        "domelementtype": "1"
       }
     },
     "domutils": {
@@ -1586,8 +1569,8 @@
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "requires": {
-        "dom-serializer": "0.1.0",
-        "domelementtype": "1.3.0"
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "dot-prop": {
@@ -1596,7 +1579,7 @@
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "dev": true,
       "requires": {
-        "is-obj": "1.0.1"
+        "is-obj": "^1.0.0"
       }
     },
     "duplexer": {
@@ -1617,7 +1600,7 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "egal": {
@@ -1626,7 +1609,7 @@
       "integrity": "sha1-IKGc+oDOlzP4QTY10AQmQfQpGHs=",
       "dev": true,
       "requires": {
-        "kindof": "2.0.0"
+        "kindof": ">= 2.0.0 < 3"
       }
     },
     "electron-to-chromium": {
@@ -1646,7 +1629,7 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
-        "iconv-lite": "0.4.19"
+        "iconv-lite": "~0.4.13"
       }
     },
     "entities": {
@@ -1660,7 +1643,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
@@ -1669,11 +1652,11 @@
       "integrity": "sha512-kk3IJoKo7A3pWJc0OV8yZ/VEX2oSUytfekrJiqoxBlKJMFAJVJVpGdHClCCTdv+Fn2zHfpDHHIelMFhZVfef3Q==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.1",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
       }
     },
     "es-to-primitive": {
@@ -1682,9 +1665,9 @@
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "dev": true,
       "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
       }
     },
     "es5-ext": {
@@ -1693,8 +1676,8 @@
       "integrity": "sha1-GO6FjOajxFx9eekcFfzKnsVoSU8=",
       "dev": true,
       "requires": {
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
+        "es6-iterator": "~2.0.1",
+        "es6-symbol": "~3.1.1"
       }
     },
     "es6-iterator": {
@@ -1703,9 +1686,9 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.35",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
       }
     },
     "es6-map": {
@@ -1714,12 +1697,12 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.35",
-        "es6-iterator": "2.0.3",
-        "es6-set": "0.1.5",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-promise": {
@@ -1734,11 +1717,11 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.35",
-        "es6-iterator": "2.0.3",
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
         "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-symbol": {
@@ -1747,8 +1730,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.35"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "es6-weak-map": {
@@ -1757,10 +1740,10 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.35",
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
       }
     },
     "escape-string-regexp": {
@@ -1774,10 +1757,10 @@
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
-        "es6-map": "0.1.5",
-        "es6-weak-map": "2.0.2",
-        "esrecurse": "4.2.0",
-        "estraverse": "4.2.0"
+        "es6-map": "^0.1.3",
+        "es6-weak-map": "^2.0.1",
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint": {
@@ -1786,43 +1769,43 @@
       "integrity": "sha512-zEO/Z1ZUxIQ+MhDVKkVTUYpIPDTEJLXGMrkID+5v1NeQHtCz6FZikWuFRgxE1Q/RV2V4zVl1u3xmpPADHhMZ6A==",
       "dev": true,
       "requires": {
-        "ajv": "5.3.0",
-        "babel-code-frame": "6.26.0",
-        "chalk": "2.3.0",
-        "concat-stream": "1.6.0",
-        "cross-spawn": "5.1.0",
-        "debug": "3.1.0",
-        "doctrine": "2.1.0",
-        "eslint-scope": "3.7.1",
-        "eslint-visitor-keys": "1.0.0",
-        "espree": "3.5.2",
-        "esquery": "1.0.0",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "functional-red-black-tree": "1.0.1",
-        "glob": "7.1.2",
-        "globals": "11.1.0",
-        "ignore": "3.3.7",
-        "imurmurhash": "0.1.4",
-        "inquirer": "3.0.6",
-        "is-resolvable": "1.0.0",
-        "js-yaml": "3.10.0",
-        "json-stable-stringify-without-jsonify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "7.0.0",
-        "progress": "2.0.0",
-        "require-uncached": "1.0.3",
-        "semver": "5.4.1",
-        "strip-ansi": "4.0.0",
-        "strip-json-comments": "2.0.1",
-        "table": "4.0.2",
-        "text-table": "0.2.0"
+        "ajv": "^5.3.0",
+        "babel-code-frame": "^6.22.0",
+        "chalk": "^2.1.0",
+        "concat-stream": "^1.6.0",
+        "cross-spawn": "^5.1.0",
+        "debug": "^3.1.0",
+        "doctrine": "^2.0.2",
+        "eslint-scope": "^3.7.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^3.5.2",
+        "esquery": "^1.0.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.0.1",
+        "ignore": "^3.3.3",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^3.0.6",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.9.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.3.0",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "~2.0.1",
+        "table": "^4.0.1",
+        "text-table": "~0.2.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1837,7 +1820,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -1846,9 +1829,9 @@
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "debug": {
@@ -1866,7 +1849,7 @@
           "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
           "dev": true,
           "requires": {
-            "esutils": "2.0.2"
+            "esutils": "^2.0.2"
           }
         },
         "globals": {
@@ -1890,7 +1873,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -1901,7 +1884,7 @@
       "integrity": "sha512-m0q9fiMBzDAIbirlGnpJNWToIhdhJmXXnMG+IFflYzzod9231ZhtmGKegKg8E9T8F1YuVaDSU1FnCm5b9iXVhQ==",
       "dev": true,
       "requires": {
-        "eslint-config-airbnb-base": "11.3.2"
+        "eslint-config-airbnb-base": "^11.3.0"
       }
     },
     "eslint-config-airbnb-base": {
@@ -1910,7 +1893,7 @@
       "integrity": "sha512-/fhjt/VqzBA2SRsx7ErDtv6Ayf+XLw9LIOqmpBuHFCVwyJo2EtzGWMB9fYRFBoWWQLxmNmCpenNiH0RxyeS41w==",
       "dev": true,
       "requires": {
-        "eslint-restricted-globals": "0.1.1"
+        "eslint-restricted-globals": "^0.1.1"
       }
     },
     "eslint-import-resolver-meteor": {
@@ -1919,8 +1902,8 @@
       "integrity": "sha1-yGhjhAghIIz4EzxczlGQnCamFWk=",
       "dev": true,
       "requires": {
-        "object-assign": "4.1.1",
-        "resolve": "1.5.0"
+        "object-assign": "^4.0.1",
+        "resolve": "^1.1.6"
       }
     },
     "eslint-import-resolver-node": {
@@ -1929,8 +1912,8 @@
       "integrity": "sha1-RCJXTN5mqaewmZOO5NUIoZng48w=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "resolve": "1.5.0"
+        "debug": "^2.6.8",
+        "resolve": "^1.2.0"
       }
     },
     "eslint-module-utils": {
@@ -1939,8 +1922,8 @@
       "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "pkg-dir": "1.0.0"
+        "debug": "^2.6.8",
+        "pkg-dir": "^1.0.0"
       }
     },
     "eslint-plugin-import": {
@@ -1949,16 +1932,16 @@
       "integrity": "sha512-Rf7dfKJxZ16QuTgVv1OYNxkZcsu/hULFnC+e+w0Gzi6jMC3guQoWQgxYxc54IDRinlb6/0v5z/PxxIKmVctN+g==",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1",
-        "contains-path": "0.1.0",
-        "debug": "2.6.9",
+        "builtin-modules": "^1.1.1",
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.8",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "0.3.1",
-        "eslint-module-utils": "2.1.1",
-        "has": "1.0.1",
-        "lodash.cond": "4.5.2",
-        "minimatch": "3.0.4",
-        "read-pkg-up": "2.0.0"
+        "eslint-import-resolver-node": "^0.3.1",
+        "eslint-module-utils": "^2.1.1",
+        "has": "^1.0.1",
+        "lodash.cond": "^4.3.0",
+        "minimatch": "^3.0.3",
+        "read-pkg-up": "^2.0.0"
       },
       "dependencies": {
         "doctrine": {
@@ -1979,13 +1962,13 @@
       "integrity": "sha512-5I9SpoP7gT4wBFOtXT8/tXNPYohHBVfyVfO17vkbC7r9kEIxYJF12D3pKqhk8+xnk12rfxKClS3WCFpVckFTPQ==",
       "dev": true,
       "requires": {
-        "aria-query": "0.7.0",
-        "array-includes": "3.0.3",
+        "aria-query": "^0.7.0",
+        "array-includes": "^3.0.3",
         "ast-types-flow": "0.0.7",
-        "axobject-query": "0.1.0",
-        "damerau-levenshtein": "1.0.4",
-        "emoji-regex": "6.5.1",
-        "jsx-ast-utils": "1.4.1"
+        "axobject-query": "^0.1.0",
+        "damerau-levenshtein": "^1.0.0",
+        "emoji-regex": "^6.1.0",
+        "jsx-ast-utils": "^1.4.0"
       }
     },
     "eslint-plugin-meteor": {
@@ -1994,7 +1977,6 @@
       "integrity": "sha1-yl7KHjPPIbxiorYTV8Uv9EvILAM=",
       "dev": true,
       "requires": {
-        "babel-register": "6.24.1",
         "babel-runtime": "6.25.0",
         "escope": "3.6.0",
         "invariant": "2.2.2",
@@ -2009,8 +1991,8 @@
           "integrity": "sha1-M7mOql1IK7AajRqmtDetKwGuxBw=",
           "dev": true,
           "requires": {
-            "core-js": "2.5.1",
-            "regenerator-runtime": "0.10.5"
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.10.0"
           }
         },
         "path-exists": {
@@ -2033,10 +2015,10 @@
       "integrity": "sha512-tvjU9u3VqmW2vVuYnE8Qptq+6ji4JltjOjJ9u7VAOxVYkUkyBZWRvNYKbDv5fN+L6wiA+4we9+qQahZ0m63XEA==",
       "dev": true,
       "requires": {
-        "doctrine": "2.0.0",
-        "has": "1.0.1",
-        "jsx-ast-utils": "2.0.1",
-        "prop-types": "15.6.0"
+        "doctrine": "^2.0.0",
+        "has": "^1.0.1",
+        "jsx-ast-utils": "^2.0.0",
+        "prop-types": "^15.5.10"
       },
       "dependencies": {
         "jsx-ast-utils": {
@@ -2062,8 +2044,8 @@
       "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
       "dev": true,
       "requires": {
-        "esrecurse": "4.2.0",
-        "estraverse": "4.2.0"
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint-visitor-keys": {
@@ -2078,8 +2060,8 @@
       "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.2.1",
-        "acorn-jsx": "3.0.1"
+        "acorn": "^5.2.1",
+        "acorn-jsx": "^3.0.0"
       }
     },
     "esprima": {
@@ -2094,7 +2076,7 @@
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
@@ -2103,8 +2085,8 @@
       "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0",
-        "object-assign": "4.1.1"
+        "estraverse": "^4.1.0",
+        "object-assign": "^4.0.1"
       }
     },
     "estraverse": {
@@ -2125,8 +2107,8 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.35"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "event-stream": {
@@ -2135,13 +2117,13 @@
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
-        "duplexer": "0.1.1",
-        "from": "0.1.7",
-        "map-stream": "0.1.0",
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
         "pause-stream": "0.0.11",
-        "split": "0.3.3",
-        "stream-combiner": "0.0.4",
-        "through": "2.3.8"
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
       }
     },
     "execa": {
@@ -2149,13 +2131,13 @@
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "expand-brackets": {
@@ -2164,7 +2146,7 @@
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "0.1.1"
+        "is-posix-bracket": "^0.1.0"
       }
     },
     "expand-range": {
@@ -2173,7 +2155,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "2.2.3"
+        "fill-range": "^2.1.0"
       }
     },
     "extend": {
@@ -2186,9 +2168,9 @@
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
       "integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
       "requires": {
-        "iconv-lite": "0.4.19",
-        "jschardet": "1.6.0",
-        "tmp": "0.0.33"
+        "iconv-lite": "^0.4.17",
+        "jschardet": "^1.4.2",
+        "tmp": "^0.0.33"
       }
     },
     "extglob": {
@@ -2197,7 +2179,7 @@
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "extsprintf": {
@@ -2232,13 +2214,13 @@
       "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
       "dev": true,
       "requires": {
-        "core-js": "1.2.7",
-        "isomorphic-fetch": "2.2.1",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "promise": "7.3.1",
-        "setimmediate": "1.0.5",
-        "ua-parser-js": "0.7.17"
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.9"
       },
       "dependencies": {
         "core-js": {
@@ -2254,7 +2236,7 @@
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
@@ -2263,8 +2245,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.1"
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "file-type": {
@@ -2284,11 +2266,11 @@
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
       "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^1.1.3",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
       }
     },
     "find-babel-config": {
@@ -2297,8 +2279,8 @@
       "integrity": "sha1-rMAQQ6Z0n+w0Qpvmtk9ULrtdY1U=",
       "dev": true,
       "requires": {
-        "json5": "0.5.1",
-        "path-exists": "3.0.0"
+        "json5": "^0.5.1",
+        "path-exists": "^3.0.0"
       },
       "dependencies": {
         "path-exists": {
@@ -2315,8 +2297,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "flat-cache": {
@@ -2325,10 +2307,10 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
       }
     },
     "for-each": {
@@ -2337,7 +2319,7 @@
       "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
       "dev": true,
       "requires": {
-        "is-function": "1.0.1"
+        "is-function": "~1.0.0"
       }
     },
     "for-in": {
@@ -2352,7 +2334,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "foreach": {
@@ -2371,9 +2353,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
       "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.17"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.12"
       }
     },
     "formatio": {
@@ -2382,7 +2364,7 @@
       "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
       "dev": true,
       "requires": {
-        "samsam": "1.3.0"
+        "samsam": "1.x"
       }
     },
     "from": {
@@ -2401,10 +2383,10 @@
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2"
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
       }
     },
     "fstream-ignore": {
@@ -2412,9 +2394,9 @@
       "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
       "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
       "requires": {
-        "fstream": "1.0.11",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4"
+        "fstream": "^1.0.0",
+        "inherits": "2",
+        "minimatch": "^3.0.0"
       }
     },
     "function-bind": {
@@ -2434,14 +2416,14 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
       }
     },
     "get-caller-file": {
@@ -2459,7 +2441,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
@@ -2467,12 +2449,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-base": {
@@ -2481,8 +2463,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "glob-parent": {
@@ -2491,7 +2473,7 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^2.0.0"
       }
     },
     "global-dirs": {
@@ -2500,7 +2482,7 @@
       "integrity": "sha1-ENNAOeDfBCcuJizyQiT3IJQ0308=",
       "dev": true,
       "requires": {
-        "ini": "1.3.4"
+        "ini": "^1.3.4"
       }
     },
     "globals": {
@@ -2515,12 +2497,12 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "got": {
@@ -2529,17 +2511,17 @@
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "requires": {
-        "create-error-class": "3.0.2",
-        "duplexer3": "0.1.4",
-        "get-stream": "3.0.0",
-        "is-redirect": "1.0.0",
-        "is-retry-allowed": "1.1.0",
-        "is-stream": "1.1.0",
-        "lowercase-keys": "1.0.0",
-        "safe-buffer": "5.1.1",
-        "timed-out": "4.0.1",
-        "unzip-response": "2.0.1",
-        "url-parse-lax": "1.0.0"
+        "create-error-class": "^3.0.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-redirect": "^1.0.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "lowercase-keys": "^1.0.0",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "unzip-response": "^2.0.1",
+        "url-parse-lax": "^1.0.0"
       }
     },
     "graceful-fs": {
@@ -2557,8 +2539,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.3.0",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       }
     },
     "has": {
@@ -2567,7 +2549,7 @@
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.0.2"
       }
     },
     "has-ansi": {
@@ -2575,7 +2557,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -2594,10 +2576,10 @@
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.0",
-        "sntp": "2.1.0"
+        "boom": "4.x.x",
+        "cryptiles": "3.x.x",
+        "hoek": "4.x.x",
+        "sntp": "2.x.x"
       }
     },
     "hoek": {
@@ -2611,8 +2593,8 @@
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
       }
     },
     "hosted-git-info": {
@@ -2626,12 +2608,12 @@
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
       "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
       "requires": {
-        "domelementtype": "1.3.0",
-        "domhandler": "2.4.1",
-        "domutils": "1.5.1",
-        "entities": "1.1.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "domelementtype": "^1.3.0",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "http-signature": {
@@ -2639,9 +2621,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "iconv-lite": {
@@ -2666,7 +2648,7 @@
       "resolved": "https://registry.npmjs.org/image-type/-/image-type-3.0.0.tgz",
       "integrity": "sha1-FQKvMTX5BuEiyHfDHpSve3qRRsU=",
       "requires": {
-        "file-type": "4.4.0"
+        "file-type": "^4.1.0"
       }
     },
     "import-lazy": {
@@ -2686,8 +2668,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -2705,19 +2687,19 @@
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.0.6.tgz",
       "integrity": "sha1-4EqqnQW3o8ubD0B9BDdfBEcZA0c=",
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "chalk": "1.1.3",
-        "cli-cursor": "2.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "2.0.5",
-        "figures": "2.0.0",
-        "lodash": "4.17.4",
+        "ansi-escapes": "^1.1.0",
+        "chalk": "^1.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^2.0.1",
+        "figures": "^2.0.0",
+        "lodash": "^4.3.0",
         "mute-stream": "0.0.7",
-        "run-async": "2.3.0",
-        "rx": "4.1.0",
-        "string-width": "2.1.1",
-        "strip-ansi": "3.0.1",
-        "through": "2.3.8"
+        "run-async": "^2.2.0",
+        "rx": "^4.1.0",
+        "string-width": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "through": "^2.3.6"
       },
       "dependencies": {
         "ansi-regex": {
@@ -2735,8 +2717,8 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "strip-ansi": {
@@ -2744,7 +2726,7 @@
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -2762,7 +2744,7 @@
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
       "dev": true,
       "requires": {
-        "loose-envify": "1.3.1"
+        "loose-envify": "^1.0.0"
       }
     },
     "invert-kv": {
@@ -2782,7 +2764,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.10.0"
+        "binary-extensions": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -2797,7 +2779,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-callable": {
@@ -2824,7 +2806,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -2845,7 +2827,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -2853,7 +2835,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-function": {
@@ -2868,7 +2850,7 @@
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "is-installed-globally": {
@@ -2877,8 +2859,8 @@
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "dev": true,
       "requires": {
-        "global-dirs": "0.1.0",
-        "is-path-inside": "1.0.0"
+        "global-dirs": "^0.1.0",
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-npm": {
@@ -2893,7 +2875,7 @@
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-obj": {
@@ -2914,7 +2896,7 @@
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.0"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -2923,7 +2905,7 @@
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-posix-bracket": {
@@ -2955,7 +2937,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "1.0.1"
+        "has": "^1.0.1"
       }
     },
     "is-resolvable": {
@@ -2964,7 +2946,7 @@
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
       "dev": true,
       "requires": {
-        "tryit": "1.0.3"
+        "tryit": "^1.0.1"
       }
     },
     "is-retry-allowed": {
@@ -3014,8 +2996,8 @@
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "dev": true,
       "requires": {
-        "node-fetch": "1.6.3",
-        "whatwg-fetch": "2.0.3"
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
       }
     },
     "isstream": {
@@ -3035,8 +3017,8 @@
       "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsbn": {
@@ -3111,7 +3093,7 @@
       "resolved": "https://registry.npmjs.org/katex/-/katex-0.9.0.tgz",
       "integrity": "sha512-lp3x90LT1tDZBW2tjLheJ98wmRMRjUHwk4QpaswT9bhqoQZ+XA4cPcjcQBxgOQNwaOSt6ZeL/a6GKQ1of3LFxQ==",
       "requires": {
-        "match-at": "0.1.1"
+        "match-at": "^0.1.1"
       }
     },
     "kind-of": {
@@ -3120,7 +3102,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "kindof": {
@@ -3135,7 +3117,7 @@
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "dev": true,
       "requires": {
-        "package-json": "4.0.1"
+        "package-json": "^4.0.0"
       }
     },
     "lcid": {
@@ -3143,7 +3125,7 @@
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "levn": {
@@ -3152,8 +3134,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "load-json-file": {
@@ -3162,10 +3144,10 @@
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "strip-bom": "3.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "strip-bom": "^3.0.0"
       }
     },
     "locate-path": {
@@ -3173,8 +3155,8 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       },
       "dependencies": {
         "path-exists": {
@@ -3195,8 +3177,8 @@
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._basecallback": {
@@ -3204,10 +3186,10 @@
       "resolved": "https://registry.npmjs.org/lodash._basecallback/-/lodash._basecallback-3.3.1.tgz",
       "integrity": "sha1-t7K7Q9whYEJKIczybFfkQ3cqjic=",
       "requires": {
-        "lodash._baseisequal": "3.0.7",
-        "lodash._bindcallback": "3.0.1",
-        "lodash.isarray": "3.0.4",
-        "lodash.pairs": "3.0.1"
+        "lodash._baseisequal": "^3.0.0",
+        "lodash._bindcallback": "^3.0.0",
+        "lodash.isarray": "^3.0.0",
+        "lodash.pairs": "^3.0.0"
       }
     },
     "lodash._basecopy": {
@@ -3221,7 +3203,7 @@
       "resolved": "https://registry.npmjs.org/lodash._baseeach/-/lodash._baseeach-3.0.4.tgz",
       "integrity": "sha1-z4cGVyyhROjZ11InyZDamC+TKvM=",
       "requires": {
-        "lodash.keys": "3.1.2"
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._basefind": {
@@ -3239,9 +3221,9 @@
       "resolved": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
       "integrity": "sha1-2AJfdjOdKTQnZ9zIh85cuVpbUfE=",
       "requires": {
-        "lodash.isarray": "3.0.4",
-        "lodash.istypedarray": "3.0.6",
-        "lodash.keys": "3.1.2"
+        "lodash.isarray": "^3.0.0",
+        "lodash.istypedarray": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._baseismatch": {
@@ -3249,7 +3231,7 @@
       "resolved": "https://registry.npmjs.org/lodash._baseismatch/-/lodash._baseismatch-3.1.3.tgz",
       "integrity": "sha1-Byj8SO+hFpnT1fLXMEnyqxPED9U=",
       "requires": {
-        "lodash._baseisequal": "3.0.7"
+        "lodash._baseisequal": "^3.0.0"
       }
     },
     "lodash._basematches": {
@@ -3257,8 +3239,8 @@
       "resolved": "https://registry.npmjs.org/lodash._basematches/-/lodash._basematches-3.2.0.tgz",
       "integrity": "sha1-9H4D8H7CB4SrCWjQy2y1l+IQEVg=",
       "requires": {
-        "lodash._baseismatch": "3.1.3",
-        "lodash.pairs": "3.0.1"
+        "lodash._baseismatch": "^3.0.0",
+        "lodash.pairs": "^3.0.0"
       }
     },
     "lodash._bindcallback": {
@@ -3272,9 +3254,9 @@
       "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
       "dev": true,
       "requires": {
-        "lodash._bindcallback": "3.0.1",
-        "lodash._isiterateecall": "3.0.9",
-        "lodash.restparam": "3.6.1"
+        "lodash._bindcallback": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0",
+        "lodash.restparam": "^3.0.0"
       }
     },
     "lodash._createwrapper": {
@@ -3283,7 +3265,7 @@
       "integrity": "sha1-30U+ZkFjIXuJWkVAZa8cR6DqPE0=",
       "dev": true,
       "requires": {
-        "lodash._root": "3.0.1"
+        "lodash._root": "^3.0.0"
       }
     },
     "lodash._getnative": {
@@ -3314,9 +3296,9 @@
       "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
       "dev": true,
       "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._createassigner": "3.1.1",
-        "lodash.keys": "3.1.2"
+        "lodash._baseassign": "^3.0.0",
+        "lodash._createassigner": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash.cond": {
@@ -3331,8 +3313,8 @@
       "integrity": "sha1-xzCLGNv4vJNy1wGnNJPGEZK9Liw=",
       "dev": true,
       "requires": {
-        "lodash.assign": "3.2.0",
-        "lodash.restparam": "3.6.1"
+        "lodash.assign": "^3.0.0",
+        "lodash.restparam": "^3.0.0"
       }
     },
     "lodash.every": {
@@ -3350,8 +3332,8 @@
       "resolved": "https://registry.npmjs.org/lodash.findwhere/-/lodash.findwhere-3.1.0.tgz",
       "integrity": "sha1-eTfTTz6sgY3sf6lOjKXib9uhz8E=",
       "requires": {
-        "lodash._basematches": "3.2.0",
-        "lodash.find": "3.2.1"
+        "lodash._basematches": "^3.0.0",
+        "lodash.find": "^3.0.0"
       },
       "dependencies": {
         "lodash.find": {
@@ -3359,12 +3341,12 @@
           "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-3.2.1.tgz",
           "integrity": "sha1-BG4xnzrOkSrGySRsf2g8XsB7Nq0=",
           "requires": {
-            "lodash._basecallback": "3.3.1",
-            "lodash._baseeach": "3.0.4",
-            "lodash._basefind": "3.0.0",
-            "lodash._basefindindex": "3.6.0",
-            "lodash.isarray": "3.0.4",
-            "lodash.keys": "3.1.2"
+            "lodash._basecallback": "^3.0.0",
+            "lodash._baseeach": "^3.0.0",
+            "lodash._basefind": "^3.0.0",
+            "lodash._basefindindex": "^3.0.0",
+            "lodash.isarray": "^3.0.0",
+            "lodash.keys": "^3.0.0"
           }
         }
       }
@@ -3415,9 +3397,9 @@
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "lodash.memoize": {
@@ -3441,7 +3423,7 @@
       "resolved": "https://registry.npmjs.org/lodash.pairs/-/lodash.pairs-3.0.1.tgz",
       "integrity": "sha1-u+CNV4bu6qCaFckevw3LfSvjJqk=",
       "requires": {
-        "lodash.keys": "3.1.2"
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash.pick": {
@@ -3460,8 +3442,8 @@
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
       "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
       "requires": {
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.templatesettings": "4.1.0"
+        "lodash._reinterpolate": "~3.0.0",
+        "lodash.templatesettings": "^4.0.0"
       }
     },
     "lodash.templatesettings": {
@@ -3469,7 +3451,7 @@
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
       "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
       "requires": {
-        "lodash._reinterpolate": "3.0.0"
+        "lodash._reinterpolate": "~3.0.0"
       }
     },
     "lodash.union": {
@@ -3493,7 +3475,7 @@
       "integrity": "sha1-P82L74Z7LsjCG6xjjYFhgFk/cas=",
       "dev": true,
       "requires": {
-        "lodash._createwrapper": "3.2.0"
+        "lodash._createwrapper": "^3.0.0"
       }
     },
     "lolex": {
@@ -3508,7 +3490,7 @@
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "dev": true,
       "requires": {
-        "js-tokens": "3.0.2"
+        "js-tokens": "^3.0.0"
       }
     },
     "lowercase-keys": {
@@ -3522,8 +3504,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "make-dir": {
@@ -3532,7 +3514,7 @@
       "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
       "dev": true,
       "requires": {
-        "pify": "3.0.0"
+        "pify": "^3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -3559,7 +3541,7 @@
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "requires": {
-        "mimic-fn": "1.1.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "meteor-node-stubs": {
@@ -3567,28 +3549,28 @@
       "resolved": "https://registry.npmjs.org/meteor-node-stubs/-/meteor-node-stubs-0.2.11.tgz",
       "integrity": "sha1-cV5Owc6IgkiylgThbQkiVrDLfjQ=",
       "requires": {
-        "assert": "1.4.1",
-        "browserify-zlib": "0.1.4",
-        "buffer": "4.9.1",
-        "console-browserify": "1.1.0",
-        "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.11.0",
-        "domain-browser": "1.1.7",
-        "events": "1.1.1",
-        "http-browserify": "1.7.0",
+        "assert": "^1.4.1",
+        "browserify-zlib": "^0.1.4",
+        "buffer": "^4.9.1",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.7",
+        "events": "^1.1.1",
+        "http-browserify": "^1.7.0",
         "https-browserify": "0.0.1",
-        "os-browserify": "0.2.1",
+        "os-browserify": "^0.2.1",
         "path-browserify": "0.0.0",
-        "process": "0.11.9",
-        "punycode": "1.4.1",
-        "querystring-es3": "0.2.1",
+        "process": "^0.11.9",
+        "punycode": "^1.4.1",
+        "querystring-es3": "^0.2.1",
         "readable-stream": "git+https://github.com/meteor/readable-stream.git#2e9112d7d31a2af6e0682db0e18679b1e5fd4694",
-        "stream-browserify": "2.0.1",
-        "string_decoder": "1.0.1",
-        "timers-browserify": "1.4.2",
+        "stream-browserify": "^2.0.1",
+        "string_decoder": "^1.0.1",
+        "timers-browserify": "^1.4.2",
         "tty-browserify": "0.0.0",
-        "url": "0.11.0",
-        "util": "0.10.3",
+        "url": "^0.11.0",
+        "util": "^0.10.3",
         "vm-browserify": "0.0.4"
       },
       "dependencies": {
@@ -3602,9 +3584,9 @@
           "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.0.tgz",
           "integrity": "sha1-9xoSQ/PnnUbXsH1/v0gk7nOvBUo=",
           "requires": {
-            "bn.js": "4.11.6",
-            "inherits": "2.0.1",
-            "minimalistic-assert": "1.0.0"
+            "bn.js": "^4.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
           }
         },
         "assert": {
@@ -3635,7 +3617,7 @@
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
           "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
           "requires": {
-            "balanced-match": "0.4.2",
+            "balanced-match": "^0.4.1",
             "concat-map": "0.0.1"
           }
         },
@@ -3649,11 +3631,11 @@
           "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
           "integrity": "sha1-Xncl297x/Vkw1OurSFZ85FHEigo=",
           "requires": {
-            "buffer-xor": "1.0.3",
-            "cipher-base": "1.0.3",
-            "create-hash": "1.1.2",
-            "evp_bytestokey": "1.0.0",
-            "inherits": "2.0.1"
+            "buffer-xor": "^1.0.2",
+            "cipher-base": "^1.0.0",
+            "create-hash": "^1.1.0",
+            "evp_bytestokey": "^1.0.0",
+            "inherits": "^2.0.1"
           }
         },
         "browserify-cipher": {
@@ -3661,9 +3643,9 @@
           "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
           "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
           "requires": {
-            "browserify-aes": "1.0.6",
-            "browserify-des": "1.0.0",
-            "evp_bytestokey": "1.0.0"
+            "browserify-aes": "^1.0.4",
+            "browserify-des": "^1.0.0",
+            "evp_bytestokey": "^1.0.0"
           }
         },
         "browserify-des": {
@@ -3671,9 +3653,9 @@
           "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
           "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
           "requires": {
-            "cipher-base": "1.0.3",
-            "des.js": "1.0.0",
-            "inherits": "2.0.1"
+            "cipher-base": "^1.0.1",
+            "des.js": "^1.0.0",
+            "inherits": "^2.0.1"
           }
         },
         "browserify-rsa": {
@@ -3681,8 +3663,8 @@
           "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
           "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
           "requires": {
-            "bn.js": "4.11.6",
-            "randombytes": "2.0.3"
+            "bn.js": "^4.1.0",
+            "randombytes": "^2.0.1"
           }
         },
         "browserify-sign": {
@@ -3690,13 +3672,13 @@
           "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.0.tgz",
           "integrity": "sha1-EHc5EMPCBtVCCkaq2GlPgguFlo8=",
           "requires": {
-            "bn.js": "4.11.6",
-            "browserify-rsa": "4.0.1",
-            "create-hash": "1.1.2",
-            "create-hmac": "1.1.4",
-            "elliptic": "6.3.2",
-            "inherits": "2.0.1",
-            "parse-asn1": "5.0.0"
+            "bn.js": "^4.1.1",
+            "browserify-rsa": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "create-hmac": "^1.1.2",
+            "elliptic": "^6.0.0",
+            "inherits": "^2.0.1",
+            "parse-asn1": "^5.0.0"
           }
         },
         "browserify-zlib": {
@@ -3704,7 +3686,7 @@
           "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
           "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
           "requires": {
-            "pako": "0.2.9"
+            "pako": "~0.2.0"
           }
         },
         "buffer": {
@@ -3712,9 +3694,9 @@
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
           "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
           "requires": {
-            "base64-js": "1.2.0",
-            "ieee754": "1.1.8",
-            "isarray": "1.0.0"
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
           }
         },
         "buffer-xor": {
@@ -3727,7 +3709,7 @@
           "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz",
           "integrity": "sha1-7qvxlEGc6QDaMBjCB9IS8qbfCgc=",
           "requires": {
-            "inherits": "2.0.1"
+            "inherits": "^2.0.1"
           }
         },
         "concat-map": {
@@ -3740,7 +3722,7 @@
           "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
           "requires": {
-            "date-now": "0.1.4"
+            "date-now": "^0.1.4"
           }
         },
         "constants-browserify": {
@@ -3753,8 +3735,8 @@
           "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
           "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
           "requires": {
-            "bn.js": "4.11.6",
-            "elliptic": "6.3.2"
+            "bn.js": "^4.1.0",
+            "elliptic": "^6.0.0"
           }
         },
         "create-hash": {
@@ -3762,10 +3744,10 @@
           "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz",
           "integrity": "sha1-USEAYte7dHn2xlu0GpIgix1hq60=",
           "requires": {
-            "cipher-base": "1.0.3",
-            "inherits": "2.0.1",
-            "ripemd160": "1.0.1",
-            "sha.js": "2.4.8"
+            "cipher-base": "^1.0.1",
+            "inherits": "^2.0.1",
+            "ripemd160": "^1.0.0",
+            "sha.js": "^2.3.6"
           }
         },
         "create-hmac": {
@@ -3773,8 +3755,8 @@
           "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz",
           "integrity": "sha1-0/tLolPriz9W456i+8uK90e9MXA=",
           "requires": {
-            "create-hash": "1.1.2",
-            "inherits": "2.0.1"
+            "create-hash": "^1.1.0",
+            "inherits": "^2.0.1"
           }
         },
         "crypto-browserify": {
@@ -3782,16 +3764,16 @@
           "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz",
           "integrity": "sha1-NlKgkGq5sqfgw85mpAjpV6JIVSI=",
           "requires": {
-            "browserify-cipher": "1.0.0",
-            "browserify-sign": "4.0.0",
-            "create-ecdh": "4.0.0",
-            "create-hash": "1.1.2",
-            "create-hmac": "1.1.4",
-            "diffie-hellman": "5.0.2",
-            "inherits": "2.0.1",
-            "pbkdf2": "3.0.9",
-            "public-encrypt": "4.0.0",
-            "randombytes": "2.0.3"
+            "browserify-cipher": "^1.0.0",
+            "browserify-sign": "^4.0.0",
+            "create-ecdh": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "create-hmac": "^1.1.0",
+            "diffie-hellman": "^5.0.0",
+            "inherits": "^2.0.1",
+            "pbkdf2": "^3.0.3",
+            "public-encrypt": "^4.0.0",
+            "randombytes": "^2.0.0"
           }
         },
         "date-now": {
@@ -3804,8 +3786,8 @@
           "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
           "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
           "requires": {
-            "inherits": "2.0.1",
-            "minimalistic-assert": "1.0.0"
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
           }
         },
         "diffie-hellman": {
@@ -3813,9 +3795,9 @@
           "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
           "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
           "requires": {
-            "bn.js": "4.11.6",
-            "miller-rabin": "4.0.0",
-            "randombytes": "2.0.3"
+            "bn.js": "^4.1.0",
+            "miller-rabin": "^4.0.0",
+            "randombytes": "^2.0.0"
           }
         },
         "domain-browser": {
@@ -3828,10 +3810,10 @@
           "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.2.tgz",
           "integrity": "sha1-5MgeCCnPCmWrcOmYuCMnI7XBvEg=",
           "requires": {
-            "bn.js": "4.11.6",
-            "brorand": "1.0.6",
-            "hash.js": "1.0.3",
-            "inherits": "2.0.1"
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "inherits": "^2.0.1"
           }
         },
         "events": {
@@ -3844,7 +3826,7 @@
           "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
           "integrity": "sha1-SXtmrZ/vZc18CKYYCCS6FHa2blM=",
           "requires": {
-            "create-hash": "1.1.2"
+            "create-hash": "^1.1.1"
           }
         },
         "fs.realpath": {
@@ -3857,12 +3839,12 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.1",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "hash.js": {
@@ -3870,7 +3852,7 @@
           "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
           "integrity": "sha1-EzL/ABVsCg/92CNgE9B7d6BFFXM=",
           "requires": {
-            "inherits": "2.0.1"
+            "inherits": "^2.0.1"
           }
         },
         "http-browserify": {
@@ -3878,8 +3860,8 @@
           "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
           "integrity": "sha1-M3la3nLfiKz7/TZ3PO/tp2RzWyA=",
           "requires": {
-            "Base64": "0.2.1",
-            "inherits": "2.0.1"
+            "Base64": "~0.2.0",
+            "inherits": "~2.0.1"
           }
         },
         "https-browserify": {
@@ -3902,8 +3884,8 @@
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -3921,8 +3903,8 @@
           "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
           "integrity": "sha1-SmL7HUKTPAVYOYL0xxb2+55sbT0=",
           "requires": {
-            "bn.js": "4.11.6",
-            "brorand": "1.0.6"
+            "bn.js": "^4.0.0",
+            "brorand": "^1.0.1"
           }
         },
         "minimalistic-assert": {
@@ -3935,7 +3917,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "requires": {
-            "brace-expansion": "1.1.7"
+            "brace-expansion": "^1.1.7"
           }
         },
         "once": {
@@ -3943,7 +3925,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-browserify": {
@@ -3961,11 +3943,11 @@
           "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.0.0.tgz",
           "integrity": "sha1-NQYPbVAV03Yox3D04JGgtaJ4vCM=",
           "requires": {
-            "asn1.js": "4.9.0",
-            "browserify-aes": "1.0.6",
-            "create-hash": "1.1.2",
-            "evp_bytestokey": "1.0.0",
-            "pbkdf2": "3.0.9"
+            "asn1.js": "^4.0.0",
+            "browserify-aes": "^1.0.0",
+            "create-hash": "^1.1.0",
+            "evp_bytestokey": "^1.0.0",
+            "pbkdf2": "^3.0.3"
           }
         },
         "path-browserify": {
@@ -3983,7 +3965,7 @@
           "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.9.tgz",
           "integrity": "sha1-8sSyWmAAWLPDdzwIbDfbvuH/5pM=",
           "requires": {
-            "create-hmac": "1.1.4"
+            "create-hmac": "^1.1.2"
           }
         },
         "process": {
@@ -4001,11 +3983,11 @@
           "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
           "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
           "requires": {
-            "bn.js": "4.11.6",
-            "browserify-rsa": "4.0.1",
-            "create-hash": "1.1.2",
-            "parse-asn1": "5.0.0",
-            "randombytes": "2.0.3"
+            "bn.js": "^4.1.0",
+            "browserify-rsa": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "parse-asn1": "^5.0.0",
+            "randombytes": "^2.0.1"
           }
         },
         "punycode": {
@@ -4030,13 +4012,14 @@
         },
         "readable-stream": {
           "version": "git+https://github.com/meteor/readable-stream.git#2e9112d7d31a2af6e0682db0e18679b1e5fd4694",
+          "from": "git+https://github.com/meteor/readable-stream.git",
           "requires": {
-            "inherits": "2.0.1",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.0.1",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "safe-buffer": "^5.0.1",
+            "string_decoder": "~1.0.0",
+            "util-deprecate": "~1.0.1"
           }
         },
         "rimraf": {
@@ -4044,7 +4027,7 @@
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
           "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "ripemd160": {
@@ -4062,7 +4045,7 @@
           "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
           "integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08=",
           "requires": {
-            "inherits": "2.0.1"
+            "inherits": "^2.0.1"
           }
         },
         "stream-browserify": {
@@ -4070,8 +4053,8 @@
           "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
           "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
           "requires": {
-            "inherits": "2.0.1",
-            "readable-stream": "git+https://github.com/meteor/readable-stream.git#2e9112d7d31a2af6e0682db0e18679b1e5fd4694"
+            "inherits": "~2.0.1",
+            "readable-stream": "^2.0.2"
           }
         },
         "string_decoder": {
@@ -4079,7 +4062,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
           "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
           "requires": {
-            "safe-buffer": "5.0.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "timers-browserify": {
@@ -4087,7 +4070,7 @@
           "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
           "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
           "requires": {
-            "process": "0.11.9"
+            "process": "~0.11.0"
           }
         },
         "tty-browserify": {
@@ -4145,19 +4128,19 @@
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
       }
     },
     "mime-db": {
@@ -4170,7 +4153,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
       "requires": {
-        "mime-db": "1.30.0"
+        "mime-db": "~1.30.0"
       }
     },
     "mimic-fn": {
@@ -4183,7 +4166,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -4205,7 +4188,7 @@
       "integrity": "sha1-HqpxqtIwE3c9En3H6Ro/u0g31g0=",
       "dev": true,
       "requires": {
-        "caller-id": "0.1.0"
+        "caller-id": "^0.1.0"
       }
     },
     "ms": {
@@ -4219,11 +4202,11 @@
       "integrity": "sha1-nROJ9FjolLKqBAMr/rekBxT3gXE=",
       "dev": true,
       "requires": {
-        "egal": "1.3.0",
-        "json-stringify-safe": "5.0.1",
-        "kindof": "2.0.0",
-        "lodash.wrap": "3.0.1",
-        "oolong": "1.15.1"
+        "egal": ">= 1.3.0 < 2",
+        "json-stringify-safe": ">= 5 < 6",
+        "kindof": ">= 2.0.0 < 3",
+        "lodash.wrap": ">= 3 < 4",
+        "oolong": ">= 1.11.0 < 2"
       }
     },
     "must-sinon": {
@@ -4232,7 +4215,7 @@
       "integrity": "sha1-YCDtx8WEL5kLWnIyoUQEmli7EwI=",
       "dev": true,
       "requires": {
-        "oolong": "1.15.1"
+        "oolong": "^1.12.0"
       }
     },
     "mute-stream": {
@@ -4257,11 +4240,11 @@
       "integrity": "sha512-q9jXh3UNsMV28KeqI43ILz5+c3l+RiNW8mhurEwCKckuHQbL+hTJIKKTiUlCPKlgQ/OukFvSnKB/Jk3+sFbkGA==",
       "dev": true,
       "requires": {
-        "formatio": "1.2.0",
-        "just-extend": "1.1.27",
-        "lolex": "1.6.0",
-        "path-to-regexp": "1.7.0",
-        "text-encoding": "0.6.4"
+        "formatio": "^1.2.0",
+        "just-extend": "^1.1.26",
+        "lolex": "^1.6.0",
+        "path-to-regexp": "^1.7.0",
+        "text-encoding": "^0.6.4"
       },
       "dependencies": {
         "lolex": {
@@ -4277,8 +4260,8 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
       "integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=",
       "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
       }
     },
     "node-pre-gyp": {
@@ -4286,15 +4269,15 @@
       "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
       "integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y=",
       "requires": {
-        "mkdirp": "0.5.1",
-        "nopt": "4.0.1",
-        "npmlog": "4.1.2",
-        "rc": "1.2.2",
-        "request": "2.83.0",
-        "rimraf": "2.6.2",
-        "semver": "5.4.1",
-        "tar": "2.2.1",
-        "tar-pack": "3.4.1"
+        "mkdirp": "^0.5.1",
+        "nopt": "^4.0.1",
+        "npmlog": "^4.0.2",
+        "rc": "^1.1.7",
+        "request": "^2.81.0",
+        "rimraf": "^2.6.1",
+        "semver": "^5.3.0",
+        "tar": "^2.2.1",
+        "tar-pack": "^3.4.0"
       }
     },
     "nodemon": {
@@ -4303,16 +4286,16 @@
       "integrity": "sha1-mWpW3EnZ8Wu/G3ik3gjxNjSzh40=",
       "dev": true,
       "requires": {
-        "chokidar": "1.7.0",
-        "debug": "2.6.9",
-        "es6-promise": "3.3.1",
-        "ignore-by-default": "1.0.1",
-        "lodash.defaults": "3.1.2",
-        "minimatch": "3.0.4",
-        "ps-tree": "1.1.0",
-        "touch": "3.1.0",
+        "chokidar": "^1.7.0",
+        "debug": "^2.6.8",
+        "es6-promise": "^3.3.1",
+        "ignore-by-default": "^1.0.1",
+        "lodash.defaults": "^3.1.2",
+        "minimatch": "^3.0.4",
+        "ps-tree": "^1.1.0",
+        "touch": "^3.1.0",
         "undefsafe": "0.0.3",
-        "update-notifier": "2.3.0"
+        "update-notifier": "^2.2.0"
       }
     },
     "nopt": {
@@ -4320,8 +4303,8 @@
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
       "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
       "requires": {
-        "abbrev": "1.1.1",
-        "osenv": "0.1.4"
+        "abbrev": "1",
+        "osenv": "^0.1.4"
       }
     },
     "normalize-package-data": {
@@ -4330,10 +4313,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
-        "validate-npm-package-license": "3.0.1"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -4342,7 +4325,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "npm-run-path": {
@@ -4350,7 +4333,7 @@
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "npm-watch": {
@@ -4359,8 +4342,8 @@
       "integrity": "sha512-w/czxbmI2B/L7eotpo8wfE5u92X6Oguy+L3ECgfUUaERNSAtIHR0djYqzGVD7BakCH+HE3hHoDxV798rug/A6g==",
       "dev": true,
       "requires": {
-        "nodemon": "1.12.1",
-        "through2": "2.0.3"
+        "nodemon": "^1.12.1",
+        "through2": "^2.0.0"
       }
     },
     "npmlog": {
@@ -4368,10 +4351,10 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "requires": {
-        "are-we-there-yet": "1.1.4",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "nth-check": {
@@ -4379,7 +4362,7 @@
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
       "requires": {
-        "boolbase": "1.0.0"
+        "boolbase": "~1.0.0"
       }
     },
     "number-is-nan": {
@@ -4415,8 +4398,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "once": {
@@ -4424,7 +4407,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -4432,7 +4415,7 @@
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "requires": {
-        "mimic-fn": "1.1.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "oolong": {
@@ -4466,8 +4449,8 @@
       "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
       "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
       "requires": {
-        "object-assign": "4.1.1",
-        "pinkie-promise": "2.0.1"
+        "object-assign": "^4.0.1",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "optionator": {
@@ -4476,12 +4459,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "os-homedir": {
@@ -4494,9 +4477,9 @@
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "requires": {
-        "execa": "0.7.0",
-        "lcid": "1.0.0",
-        "mem": "1.1.0"
+        "execa": "^0.7.0",
+        "lcid": "^1.0.0",
+        "mem": "^1.1.0"
       }
     },
     "os-tmpdir": {
@@ -4509,8 +4492,8 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
       "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
       }
     },
     "p-finally": {
@@ -4528,7 +4511,7 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "requires": {
-        "p-limit": "1.1.0"
+        "p-limit": "^1.1.0"
       }
     },
     "package-json": {
@@ -4537,10 +4520,10 @@
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "dev": true,
       "requires": {
-        "got": "6.7.1",
-        "registry-auth-token": "3.3.1",
-        "registry-url": "3.1.0",
-        "semver": "5.4.1"
+        "got": "^6.7.1",
+        "registry-auth-token": "^3.0.1",
+        "registry-url": "^3.0.3",
+        "semver": "^5.1.0"
       }
     },
     "parse-glob": {
@@ -4549,10 +4532,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "parse-json": {
@@ -4561,7 +4544,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "^1.2.0"
       }
     },
     "parse-ms": {
@@ -4575,7 +4558,7 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
       "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
       "requires": {
-        "@types/node": "8.0.51"
+        "@types/node": "*"
       }
     },
     "path-exists": {
@@ -4584,7 +4567,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "2.0.1"
+        "pinkie-promise": "^2.0.0"
       }
     },
     "path-is-absolute": {
@@ -4631,7 +4614,7 @@
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "dev": true,
       "requires": {
-        "pify": "2.3.0"
+        "pify": "^2.0.0"
       }
     },
     "pause-stream": {
@@ -4640,7 +4623,7 @@
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "dev": true,
       "requires": {
-        "through": "2.3.8"
+        "through": "~2.3"
       }
     },
     "performance-now": {
@@ -4664,7 +4647,7 @@
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-dir": {
@@ -4673,7 +4656,7 @@
       "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2"
+        "find-up": "^1.0.0"
       }
     },
     "pkg-up": {
@@ -4682,7 +4665,7 @@
       "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0"
+        "find-up": "^2.1.0"
       },
       "dependencies": {
         "find-up": {
@@ -4691,7 +4674,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         }
       }
@@ -4732,9 +4715,9 @@
       "integrity": "sha1-QlfCVt8/sLRR1q/6qwIYhBJpgdw=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2",
-        "parse-ms": "1.0.1",
-        "plur": "1.0.0"
+        "is-finite": "^1.0.1",
+        "parse-ms": "^1.0.0",
+        "plur": "^1.0.0"
       }
     },
     "private": {
@@ -4768,7 +4751,7 @@
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "dev": true,
       "requires": {
-        "asap": "2.0.6"
+        "asap": "~2.0.3"
       }
     },
     "prop-types": {
@@ -4777,9 +4760,9 @@
       "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
       "dev": true,
       "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
       }
     },
     "ps-tree": {
@@ -4788,7 +4771,7 @@
       "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
       "dev": true,
       "requires": {
-        "event-stream": "3.3.4"
+        "event-stream": "~3.3.0"
       }
     },
     "pseudomap": {
@@ -4812,8 +4795,8 @@
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -4822,7 +4805,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -4831,7 +4814,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -4842,7 +4825,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -4852,10 +4835,10 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
       "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
       "requires": {
-        "deep-extend": "0.4.2",
-        "ini": "1.3.4",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "~0.4.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
         "minimist": {
@@ -4877,9 +4860,9 @@
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "dev": true,
       "requires": {
-        "load-json-file": "2.0.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "2.0.0"
+        "load-json-file": "^2.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^2.0.0"
       }
     },
     "read-pkg-up": {
@@ -4888,8 +4871,8 @@
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0",
-        "read-pkg": "2.0.0"
+        "find-up": "^2.0.0",
+        "read-pkg": "^2.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -4898,7 +4881,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         }
       }
@@ -4908,13 +4891,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readdirp": {
@@ -4923,10 +4906,10 @@
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.3",
-        "set-immediate-shim": "1.0.1"
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "readable-stream": "^2.0.2",
+        "set-immediate-shim": "^1.0.1"
       }
     },
     "rechoir": {
@@ -4934,7 +4917,7 @@
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "requires": {
-        "resolve": "1.5.0"
+        "resolve": "^1.1.6"
       }
     },
     "regenerate": {
@@ -4954,9 +4937,9 @@
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "private": "0.1.8"
+        "babel-runtime": "^6.18.0",
+        "babel-types": "^6.19.0",
+        "private": "^0.1.6"
       }
     },
     "regex-cache": {
@@ -4965,7 +4948,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "0.1.3"
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "regexpu-core": {
@@ -4974,9 +4957,9 @@
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
-        "regenerate": "1.3.3",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
       }
     },
     "registry-auth-token": {
@@ -4985,8 +4968,8 @@
       "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
       "dev": true,
       "requires": {
-        "rc": "1.2.2",
-        "safe-buffer": "5.1.1"
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
       }
     },
     "registry-url": {
@@ -4995,7 +4978,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "1.2.2"
+        "rc": "^1.0.1"
       }
     },
     "regjsgen": {
@@ -5010,7 +4993,7 @@
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
-        "jsesc": "0.5.0"
+        "jsesc": "~0.5.0"
       }
     },
     "remove-trailing-separator": {
@@ -5037,7 +5020,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "request": {
@@ -5045,28 +5028,28 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
       "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.1",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.17",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "hawk": "~6.0.2",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "stringstream": "~0.0.5",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       }
     },
     "require-directory": {
@@ -5085,8 +5068,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
       }
     },
     "reselect": {
@@ -5100,7 +5083,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
       "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-from": {
@@ -5114,8 +5097,8 @@
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "resumer": {
@@ -5124,7 +5107,7 @@
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
       "dev": true,
       "requires": {
-        "through": "2.3.8"
+        "through": "~2.3.4"
       }
     },
     "rimraf": {
@@ -5132,7 +5115,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "rosie": {
@@ -5145,7 +5128,7 @@
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "requires": {
-        "is-promise": "2.1.0"
+        "is-promise": "^2.1.0"
       }
     },
     "rx": {
@@ -5175,7 +5158,7 @@
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true,
       "requires": {
-        "semver": "5.4.1"
+        "semver": "^5.0.3"
       }
     },
     "set-blocking": {
@@ -5200,7 +5183,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -5213,9 +5196,9 @@
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
       "requires": {
-        "glob": "7.1.2",
-        "interpret": "1.1.0",
-        "rechoir": "0.6.2"
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
       }
     },
     "showdown": {
@@ -5223,7 +5206,7 @@
       "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.8.6.tgz",
       "integrity": "sha1-kepO47elRIqspoIKTifmkMatdxw=",
       "requires": {
-        "yargs": "10.1.2"
+        "yargs": "^10.0.3"
       }
     },
     "showdown-footnotes": {
@@ -5231,7 +5214,7 @@
       "resolved": "https://registry.npmjs.org/showdown-footnotes/-/showdown-footnotes-2.1.2.tgz",
       "integrity": "sha1-3SGZSk4v+rwk6yZqls33dFlQeVw=",
       "requires": {
-        "showdown": "1.8.6"
+        "showdown": "^1.4.1"
       }
     },
     "showdown-xss-filter": {
@@ -5239,7 +5222,7 @@
       "resolved": "https://registry.npmjs.org/showdown-xss-filter/-/showdown-xss-filter-0.2.0.tgz",
       "integrity": "sha1-OYV7rlbWGEl58mh2sYe7h+n08Ew=",
       "requires": {
-        "xss": "0.2.18"
+        "xss": "0.2.x"
       }
     },
     "signal-exit": {
@@ -5252,20 +5235,20 @@
       "resolved": "https://registry.npmjs.org/simpl-schema/-/simpl-schema-1.5.0.tgz",
       "integrity": "sha512-lv9n+1R7Oe3fpm3cWVyrs3mG1C9+DCc8QTCRn6cfLIsPkLfuMhBPLDwpnIsdA8Ch0fRO7BSxKvpVPcYvcYeSxg==",
       "requires": {
-        "clone": "2.1.1",
-        "extend": "3.0.1",
-        "lodash.every": "4.6.0",
-        "lodash.find": "4.6.0",
-        "lodash.findwhere": "3.1.0",
-        "lodash.includes": "4.3.0",
-        "lodash.isempty": "4.4.0",
-        "lodash.isobject": "3.0.2",
-        "lodash.omit": "4.5.0",
-        "lodash.pick": "4.4.0",
-        "lodash.union": "4.6.0",
-        "lodash.uniq": "4.5.0",
-        "message-box": "0.2.0",
-        "mongo-object": "0.1.2"
+        "clone": "^2.1.1",
+        "extend": "^3.0.1",
+        "lodash.every": "^4.6.0",
+        "lodash.find": "^4.6.0",
+        "lodash.findwhere": "^3.1.0",
+        "lodash.includes": "^4.3.0",
+        "lodash.isempty": "^4.4.0",
+        "lodash.isobject": "^3.0.2",
+        "lodash.omit": "^4.5.0",
+        "lodash.pick": "^4.4.0",
+        "lodash.union": "^4.6.0",
+        "lodash.uniq": "^4.5.0",
+        "message-box": "^0.2.0",
+        "mongo-object": "^0.1.2"
       },
       "dependencies": {
         "message-box": {
@@ -5273,8 +5256,8 @@
           "resolved": "https://registry.npmjs.org/message-box/-/message-box-0.2.0.tgz",
           "integrity": "sha512-SPLfVDEM2YcAgV2IB0B5vOGjvqXSSw7ZibEeXcff8HYpxyG1Uj+XjgnGUGyR1C0EQCvPI3MBx3p7opt2CIQ2hw==",
           "requires": {
-            "lodash.merge": "4.6.0",
-            "lodash.template": "4.4.0"
+            "lodash.merge": "^4.6.0",
+            "lodash.template": "^4.4.0"
           }
         },
         "mongo-object": {
@@ -5282,10 +5265,10 @@
           "resolved": "https://registry.npmjs.org/mongo-object/-/mongo-object-0.1.2.tgz",
           "integrity": "sha512-xRrnal5HuCz3we8Bzk17iYfgCMfaaSU+cq0OkQ/PP+CYhhFmw4Joqmcc0R9XUAgxbFAybg7uzxbNGUw13kEUxQ==",
           "requires": {
-            "lodash.foreach": "4.5.0",
-            "lodash.isempty": "4.4.0",
-            "lodash.isobject": "3.0.2",
-            "lodash.without": "4.4.0"
+            "lodash.foreach": "^4.5.0",
+            "lodash.isempty": "^4.4.0",
+            "lodash.isobject": "^3.0.2",
+            "lodash.without": "^4.4.0"
           }
         }
       }
@@ -5296,13 +5279,13 @@
       "integrity": "sha512-5uLBZPdCWl59Lpbf45ygKj7Z0LVol+ftBe7RDIXOQV/sF58pcFmbK8raA7bt6eljNuGnvBP+/ZxlicVn0emDjA==",
       "dev": true,
       "requires": {
-        "diff": "3.4.0",
+        "diff": "^3.1.0",
         "formatio": "1.2.0",
-        "lodash.get": "4.4.2",
-        "lolex": "2.3.0",
-        "nise": "1.2.0",
-        "supports-color": "4.5.0",
-        "type-detect": "4.0.5"
+        "lodash.get": "^4.4.2",
+        "lolex": "^2.2.0",
+        "nise": "^1.2.0",
+        "supports-color": "^4.4.0",
+        "type-detect": "^4.0.0"
       },
       "dependencies": {
         "supports-color": {
@@ -5311,7 +5294,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -5328,7 +5311,7 @@
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0"
+        "is-fullwidth-code-point": "^2.0.0"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -5344,7 +5327,7 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.x.x"
       }
     },
     "source-map": {
@@ -5359,7 +5342,7 @@
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "^0.5.6"
       }
     },
     "spdx-correct": {
@@ -5368,7 +5351,7 @@
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-license-ids": "^1.0.2"
       }
     },
     "spdx-expression-parse": {
@@ -5389,7 +5372,7 @@
       "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
       "dev": true,
       "requires": {
-        "through": "2.3.8"
+        "through": "2"
       }
     },
     "sprintf-js": {
@@ -5403,14 +5386,14 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
       }
     },
     "stack-trace": {
@@ -5425,7 +5408,7 @@
       "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
       "dev": true,
       "requires": {
-        "duplexer": "0.1.1"
+        "duplexer": "~0.1.1"
       }
     },
     "string-width": {
@@ -5433,9 +5416,9 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string.prototype.trim": {
@@ -5444,9 +5427,9 @@
       "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.9.0",
-        "function-bind": "1.1.1"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.0",
+        "function-bind": "^1.0.2"
       }
     },
     "string_decoder": {
@@ -5454,7 +5437,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "stringstream": {
@@ -5467,7 +5450,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -5497,12 +5480,12 @@
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "5.3.0",
-        "ajv-keywords": "2.1.1",
-        "chalk": "2.3.0",
-        "lodash": "4.17.4",
+        "ajv": "^5.2.3",
+        "ajv-keywords": "^2.1.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
         "slice-ansi": "1.0.0",
-        "string-width": "2.1.1"
+        "string-width": "^2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -5517,7 +5500,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -5526,9 +5509,9 @@
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -5543,8 +5526,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -5553,7 +5536,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
@@ -5562,7 +5545,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -5573,9 +5556,9 @@
       "integrity": "sha1-yQfsG/lAURHQiCY+kvVgi4jLs3o=",
       "dev": true,
       "requires": {
-        "re-emitter": "1.1.3",
-        "readable-stream": "2.3.3",
-        "split": "1.0.1",
+        "re-emitter": "^1.0.0",
+        "readable-stream": "^2.0.0",
+        "split": "^1.0.0",
         "trim": "0.0.1"
       },
       "dependencies": {
@@ -5585,7 +5568,7 @@
           "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
           "dev": true,
           "requires": {
-            "through": "2.3.8"
+            "through": "2"
           }
         }
       }
@@ -5596,14 +5579,14 @@
       "integrity": "sha1-4unyb1IIIysfViKIyXYk1YqI8Fo=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "duplexer": "0.1.1",
-        "figures": "1.7.0",
-        "lodash": "3.10.1",
-        "pretty-ms": "2.1.0",
-        "repeat-string": "1.6.1",
-        "tap-out": "1.4.2",
-        "through2": "2.0.3"
+        "chalk": "^1.0.0",
+        "duplexer": "^0.1.1",
+        "figures": "^1.4.0",
+        "lodash": "^3.6.0",
+        "pretty-ms": "^2.1.0",
+        "repeat-string": "^1.5.2",
+        "tap-out": "^1.4.1",
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "figures": {
@@ -5612,8 +5595,8 @@
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
           }
         },
         "lodash": {
@@ -5630,19 +5613,19 @@
       "integrity": "sha512-TWILfEnvO7I8mFe35d98F6T5fbLaEtbFTG/lxWvid8qDfFTxt19EBijWmB4j3+Hoh5TfHE2faWs73ua+EphuBA==",
       "dev": true,
       "requires": {
-        "deep-equal": "1.0.1",
-        "defined": "1.0.0",
-        "for-each": "0.3.2",
-        "function-bind": "1.1.1",
-        "glob": "7.1.2",
-        "has": "1.0.1",
-        "inherits": "2.0.3",
-        "minimist": "1.2.0",
-        "object-inspect": "1.3.0",
-        "resolve": "1.4.0",
-        "resumer": "0.0.0",
-        "string.prototype.trim": "1.1.2",
-        "through": "2.3.8"
+        "deep-equal": "~1.0.1",
+        "defined": "~1.0.0",
+        "for-each": "~0.3.2",
+        "function-bind": "~1.1.0",
+        "glob": "~7.1.2",
+        "has": "~1.0.1",
+        "inherits": "~2.0.3",
+        "minimist": "~1.2.0",
+        "object-inspect": "~1.3.0",
+        "resolve": "~1.4.0",
+        "resumer": "~0.0.0",
+        "string.prototype.trim": "~1.1.2",
+        "through": "~2.3.8"
       },
       "dependencies": {
         "minimist": {
@@ -5657,7 +5640,7 @@
           "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
           "dev": true,
           "requires": {
-            "path-parse": "1.0.5"
+            "path-parse": "^1.0.5"
           }
         }
       }
@@ -5667,9 +5650,9 @@
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "requires": {
-        "block-stream": "0.0.9",
-        "fstream": "1.0.11",
-        "inherits": "2.0.3"
+        "block-stream": "*",
+        "fstream": "^1.0.2",
+        "inherits": "2"
       }
     },
     "tar-pack": {
@@ -5677,14 +5660,14 @@
       "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.1.tgz",
       "integrity": "sha512-PPRybI9+jM5tjtCbN2cxmmRU7YmqT3Zv/UDy48tAh2XRkLa9bAORtSWLkVc13+GJF+cdTh1yEnHEk3cpTaL5Kg==",
       "requires": {
-        "debug": "2.6.9",
-        "fstream": "1.0.11",
-        "fstream-ignore": "1.0.5",
-        "once": "1.4.0",
-        "readable-stream": "2.3.3",
-        "rimraf": "2.6.2",
-        "tar": "2.2.1",
-        "uid-number": "0.0.6"
+        "debug": "^2.2.0",
+        "fstream": "^1.0.10",
+        "fstream-ignore": "^1.0.5",
+        "once": "^1.3.3",
+        "readable-stream": "^2.1.4",
+        "rimraf": "^2.5.1",
+        "tar": "^2.2.1",
+        "uid-number": "^0.0.6"
       }
     },
     "term-size": {
@@ -5693,7 +5676,7 @@
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "dev": true,
       "requires": {
-        "execa": "0.7.0"
+        "execa": "^0.7.0"
       }
     },
     "text-encoding": {
@@ -5719,8 +5702,8 @@
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3",
-        "xtend": "4.0.1"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       }
     },
     "timed-out": {
@@ -5734,7 +5717,7 @@
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "to-fast-properties": {
@@ -5749,7 +5732,7 @@
       "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
       "dev": true,
       "requires": {
-        "nopt": "1.0.10"
+        "nopt": "~1.0.10"
       },
       "dependencies": {
         "nopt": {
@@ -5758,7 +5741,7 @@
           "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
           "dev": true,
           "requires": {
-            "abbrev": "1.1.1"
+            "abbrev": "1"
           }
         }
       }
@@ -5768,7 +5751,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
       "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "trim": {
@@ -5794,7 +5777,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -5809,7 +5792,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-detect": {
@@ -5847,7 +5830,7 @@
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "dev": true,
       "requires": {
-        "crypto-random-string": "1.0.0"
+        "crypto-random-string": "^1.0.0"
       }
     },
     "unzip-response": {
@@ -5862,15 +5845,15 @@
       "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
       "dev": true,
       "requires": {
-        "boxen": "1.2.2",
-        "chalk": "2.3.0",
-        "configstore": "3.1.1",
-        "import-lazy": "2.1.0",
-        "is-installed-globally": "0.1.0",
-        "is-npm": "1.0.0",
-        "latest-version": "3.1.0",
-        "semver-diff": "2.1.0",
-        "xdg-basedir": "3.0.0"
+        "boxen": "^1.2.1",
+        "chalk": "^2.0.1",
+        "configstore": "^3.0.0",
+        "import-lazy": "^2.1.0",
+        "is-installed-globally": "^0.1.0",
+        "is-npm": "^1.0.0",
+        "latest-version": "^3.0.0",
+        "semver-diff": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5879,7 +5862,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -5888,9 +5871,9 @@
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "supports-color": {
@@ -5899,7 +5882,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -5910,7 +5893,7 @@
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "dev": true,
       "requires": {
-        "prepend-http": "1.0.4"
+        "prepend-http": "^1.0.1"
       }
     },
     "util-deprecate": {
@@ -5929,8 +5912,8 @@
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "dev": true,
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "~1.0.0",
+        "spdx-expression-parse": "~1.0.0"
       }
     },
     "verror": {
@@ -5938,9 +5921,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "whatwg-fetch": {
@@ -5954,7 +5937,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -5967,7 +5950,7 @@
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.2"
       }
     },
     "widest-line": {
@@ -5976,7 +5959,7 @@
       "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.1"
       }
     },
     "wordwrap": {
@@ -5990,8 +5973,8 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       }
     },
     "wrappy": {
@@ -6005,7 +5988,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     },
     "write-file-atomic": {
@@ -6014,9 +5997,9 @@
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "signal-exit": "3.0.2"
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
       }
     },
     "xdg-basedir": {
@@ -6030,8 +6013,8 @@
       "resolved": "https://registry.npmjs.org/xss/-/xss-0.2.18.tgz",
       "integrity": "sha1-bfX7XKKL3FHnhiT/Y/GeE+vXO6s=",
       "requires": {
-        "commander": "2.14.1",
-        "cssfilter": "0.0.8"
+        "commander": "^2.9.0",
+        "cssfilter": "^0.0.8"
       }
     },
     "xtend": {
@@ -6055,18 +6038,18 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
       "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
       "requires": {
-        "cliui": "4.0.0",
-        "decamelize": "1.2.0",
-        "find-up": "2.1.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "2.1.0",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "2.1.1",
-        "which-module": "2.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "8.1.0"
+        "cliui": "^4.0.0",
+        "decamelize": "^1.1.1",
+        "find-up": "^2.1.0",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^2.0.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^2.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^8.1.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6079,7 +6062,7 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -6092,8 +6075,8 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -6101,7 +6084,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -6111,7 +6094,7 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
       "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
       "requires": {
-        "camelcase": "4.1.0"
+        "camelcase": "^4.1.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.1",
+    "babel-register": "^6.26.0",
     "eslint": "^4.15.0",
     "eslint-config-airbnb": "^15.0.2",
     "eslint-import-resolver-meteor": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "showdown": "^1.8.6",
     "showdown-footnotes": "^2.1.2",
     "showdown-xss-filter": "^0.2.0",
-    "simpl-schema": "0.3.2"
+    "simpl-schema": "1.5.0"
   },
   "devDependencies": {
     "@meteorjs/eslint-config-meteor": "^1.0.5",

--- a/routes.js
+++ b/routes.js
@@ -4,15 +4,9 @@ import { FlowRouter } from 'meteor/kadira:flow-router';
 import { DocHead } from 'meteor/kadira:dochead';
 import { dbCompanyArchive } from '/db/dbCompanyArchive';
 
-// default route
-FlowRouter.route('/', {
-  name: 'announcement',
-  action() {
-    DocHead.setTitle(Meteor.settings.public.websiteName + ' - 系統公告');
-  }
-});
 
 export const pageNameHash = {
+  mainPage: '首頁',
   announcement: '系統公告',
   tutorial: '遊戲規則',
   instantMessage: '即時訊息',
@@ -28,6 +22,37 @@ export const pageNameHash = {
   accuseRecord: '舉報違規紀錄',
   fscStock: '金管會持股'
 };
+
+// default route
+FlowRouter.route('/', {
+  name: 'mainPage',
+  action() {
+    DocHead.setTitle(Meteor.settings.public.websiteName);
+  }
+});
+
+const announcementRoute = FlowRouter.group({
+  prefix: '/announcement',
+  name: 'announcementRoute'
+});
+announcementRoute.route('/', {
+  name: 'announcementList',
+  action() {
+    DocHead.setTitle(`${Meteor.settings.public.websiteName} - 系統公告`);
+  }
+});
+announcementRoute.route('/view/:announcementId', {
+  name: 'announcementDetail',
+  action() {
+    DocHead.setTitle(`${Meteor.settings.public.websiteName} - 系統公告內容`);
+  }
+});
+announcementRoute.route('/new', {
+  name: 'createAnnouncement',
+  action() {
+    DocHead.setTitle(`${Meteor.settings.public.websiteName} - 新增系統公告`);
+  }
+});
 
 FlowRouter.route('/fscStock', {
   name: 'fscStock',

--- a/routes.js
+++ b/routes.js
@@ -53,6 +53,12 @@ announcementRoute.route('/new', {
     DocHead.setTitle(`${Meteor.settings.public.websiteName} - 新增系統公告`);
   }
 });
+announcementRoute.route('/reject/:announcementId', {
+  name: 'rejectAnnouncement',
+  action() {
+    DocHead.setTitle(`${Meteor.settings.public.websiteName} - 系統公告否決`);
+  }
+});
 
 FlowRouter.route('/fscStock', {
   name: 'fscStock',

--- a/server/imports/utils/computeActiveUserCount.js
+++ b/server/imports/utils/computeActiveUserCount.js
@@ -1,0 +1,42 @@
+import { _ } from 'meteor/underscore';
+
+import { dbLog } from '/db/dbLog';
+import { dbEmployees } from '/db/dbEmployees';
+
+/*
+ * 計算系統中的活躍玩家數量
+ *
+ * 目前的活躍玩家定義：於七天內有參與投資、購買下單、販賣下單、推薦產品與報名員工等任一紀錄之玩家。
+ */
+export function computeActiveUserCount() {
+  // 往回統計的時間
+  const lookbackDate = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+
+  // 有紀錄的玩家
+  const activeUsersByLog = _.pluck(
+    dbLog.aggregate([ {
+      $match: {
+        logType: { $in: ['參與投資', '購買下單', '販賣下單', '推薦產品'] },
+        createdAt: { $gte: lookbackDate }
+      }
+    }, {
+      $group: { _id: { $arrayElemAt: ['$userId', 0] } }
+    } ]),
+    '_id'
+  );
+
+  // 有報名員工的玩家
+  const activeUsersByEmployee = _.pluck(
+    dbEmployees.aggregate([ {
+      $match: { registerAt: { $gte: lookbackDate } }
+    }, {
+      $group: { _id: '$userId' }
+    } ]),
+    '_id'
+  );
+
+  // 以上所有條件的聯集
+  const activeUsers = [...new Set([...activeUsersByLog, ...activeUsersByEmployee])];
+
+  return activeUsers.length;
+}

--- a/server/methods/announcement/createAnnouncement.js
+++ b/server/methods/announcement/createAnnouncement.js
@@ -1,0 +1,74 @@
+import { Meteor } from 'meteor/meteor';
+import { check, Match } from 'meteor/check';
+
+import { dbAnnouncements, getAnnounceableCategories, announcementCategoryMap } from '/db/dbAnnouncements';
+import { computeActiveUserCount } from '/server/imports/utils/computeActiveUserCount';
+import { debug } from '/server/imports/utils/debug';
+
+Meteor.methods({
+  createAnnouncement({ data, rejectionPetitionDurationDays }) {
+    check(this.userId, String);
+    check(data, {
+      category: Match.OneOf(...Object.keys(announcementCategoryMap)),
+      subject: String,
+      content: String
+    });
+
+    if (data.category === 'plannedRuleChanges') {
+      check(rejectionPetitionDurationDays, Match.Integer);
+    }
+
+    createAnnouncement(Meteor.user(), { data, rejectionPetitionDurationDays });
+
+    return true;
+  }
+});
+
+export function createAnnouncement(currentUser, { data, rejectionPetitionDurationDays }) {
+  debug.log('createAnnouncement', { currentUser, data, rejectionPetitionDurationDays });
+
+  const { category } = data;
+
+  if (! getAnnounceableCategories(currentUser).includes(category)) {
+    throw new Meteor.Error(403, '您沒有權限發佈此類型的公告！');
+  }
+
+  const extraData = {};
+
+  const nowDate = new Date();
+  const oneDayTime = 24 * 60 * 60 * 1000;
+
+  if (['plannedRuleChanges', 'appliedRuleChanges'].includes(category)) {
+    const { durationDays, thresholdPercent } = Meteor.settings.public.announcement[category].rejectionPetition;
+
+    let rejectionPetitionDurationTime;
+
+    if (category === 'plannedRuleChanges') {
+      if (rejectionPetitionDurationDays < durationDays.min || rejectionPetitionDurationDays > durationDays.max) {
+        throw new Meteor.Error('不合法的否決連署持續時間！');
+      }
+      rejectionPetitionDurationTime = rejectionPetitionDurationDays * oneDayTime;
+    }
+    else if (category === 'appliedRuleChanges') {
+      rejectionPetitionDurationTime = durationDays * oneDayTime;
+    }
+
+    const activeUserCount = computeActiveUserCount();
+    const dueAt = new Date(nowDate.getTime() + rejectionPetitionDurationTime);
+
+    Object.assign(extraData, {
+      rejectionPetition: {
+        activeUserCount,
+        thresholdPercent,
+        dueAt
+      }
+    });
+  }
+
+  dbAnnouncements.insert({
+    ...data,
+    ...extraData,
+    creator: currentUser._id,
+    createdAt: nowDate
+  });
+}

--- a/server/methods/announcement/deleteAnnouncement.js
+++ b/server/methods/announcement/deleteAnnouncement.js
@@ -1,0 +1,35 @@
+import { Meteor } from 'meteor/meteor';
+import { check } from 'meteor/check';
+
+import { dbAnnouncements } from '/db/dbAnnouncements';
+import { limitMethod } from '/server/imports/utils/rateLimit';
+import { debug } from '/server/imports/utils/debug';
+import { guardUser } from '/common/imports/guards';
+
+Meteor.methods({
+  deleteAnnouncement({ announcementId }) {
+    check(this.userId, String);
+    check(announcementId, String);
+    deleteAnnouncement(Meteor.user(), { announcementId });
+
+    return true;
+  }
+});
+
+export function deleteAnnouncement(currentUser, args, resourceLocked = false) {
+  debug.log('deleteAnnouncement', { currentUser, args, resourceLocked });
+
+  const { announcementId } = args;
+  const { creator } = dbAnnouncements.findByIdOrThrow(announcementId, { fields: { creator: 1 } });
+
+  const { _id: currentUserId } = currentUser;
+
+  // 若是非公告發佈人，需要符合身份組才能刪除
+  if (currentUserId !== creator) {
+    guardUser(currentUser).checkHasAnyRoles('superAdmin', 'generalManager');
+  }
+
+  dbAnnouncements.remove(announcementId);
+}
+// 一分鐘鐘最多兩次
+limitMethod('deleteAnnouncement', 2, 60000);

--- a/server/methods/announcement/legacyEditAnnouncement.js
+++ b/server/methods/announcement/legacyEditAnnouncement.js
@@ -6,17 +6,17 @@ import { debug } from '/server/imports/utils/debug';
 import { guardUser } from '/common/imports/guards';
 
 Meteor.methods({
-  editAnnouncement(announcement, announcementDetail) {
+  legacyEditAnnouncement(announcement, announcementDetail) {
     check(this.userId, String);
     check(announcement, String);
     check(announcementDetail, String);
-    editAnnouncement(Meteor.user(), announcement, announcementDetail);
+    legacyEditAnnouncement(Meteor.user(), announcement, announcementDetail);
 
     return true;
   }
 });
-function editAnnouncement(user, announcement, announcementDetail) {
-  debug.log('editAnnouncement', { user, announcement, announcementDetail });
+function legacyEditAnnouncement(user, announcement, announcementDetail) {
+  debug.log('legacyEditAnnouncement', { user, announcement, announcementDetail });
   guardUser(user).checkHasAnyRoles('developer', 'planner', 'fscMember');
   dbVariables.set('announcement', announcement);
   dbVariables.set('announcementDetail', announcementDetail);

--- a/server/methods/announcement/markAllAnnouncementAsRead.js
+++ b/server/methods/announcement/markAllAnnouncementAsRead.js
@@ -1,0 +1,22 @@
+import { Meteor } from 'meteor/meteor';
+import { check } from 'meteor/check';
+
+import { dbAnnouncements } from '/db/dbAnnouncements';
+import { limitMethod } from '/server/imports/utils/rateLimit';
+import { debug } from '/server/imports/utils/debug';
+
+Meteor.methods({
+  markAllAnnouncementsAsRead() {
+    check(this.userId, String);
+    markAllAnnouncementsAsRead(Meteor.user());
+
+    return true;
+  }
+});
+
+export function markAllAnnouncementsAsRead(currentUser) {
+  debug.log('markAllAnnouncementsAsRead', { currentUser });
+  dbAnnouncements.update({ }, { $addToSet: { readers: currentUser._id } }, { multi: true });
+}
+// 一分鐘最多一次
+limitMethod('markAllAnnouncementsAsRead', 1, 60000);

--- a/server/methods/announcement/signRejectionPetition.js
+++ b/server/methods/announcement/signRejectionPetition.js
@@ -1,0 +1,82 @@
+import { Meteor } from 'meteor/meteor';
+import { check } from 'meteor/check';
+
+import { resourceManager } from '/server/imports/threading/resourceManager';
+import { dbAnnouncements } from '/db/dbAnnouncements';
+import { limitMethod } from '/server/imports/utils/rateLimit';
+import { debug } from '/server/imports/utils/debug';
+import { computeActiveUserCount } from '/server/imports/utils/computeActiveUserCount';
+import { guardUser } from '/common/imports/guards';
+
+Meteor.methods({
+  signRejectionPetition({ announcementId }) {
+    check(this.userId, String);
+    check(announcementId, String);
+    signRejectionPetition(Meteor.user(), { announcementId });
+
+    return true;
+  }
+});
+
+export function signRejectionPetition(currentUser, args, resourceLocked = false) {
+  debug.log('signRejectionPetition', { currentUser, args, resourceLocked });
+
+  const nowDate = new Date();
+  const { _id: currentUserId } = currentUser;
+  const { announcementId } = args;
+
+  guardUser(currentUser).checkCanVote();
+
+  const { rejectionPetition: petition, category } = dbAnnouncements.findByIdOrThrow(announcementId, {
+    fields: { rejectionPetition: 1, category: 1 }
+  });
+
+  if (! petition) {
+    throw new Meteor.Error(403, '此公告並無進行否決連署！');
+  }
+
+  const { dueAt, signers, thresholdPercent, activeUserCount } = petition;
+  const threshold = Math.floor(activeUserCount * thresholdPercent / 100);
+
+  if (nowDate.getTime() > dueAt.getTime()) {
+    throw new Meteor.Error(403, '連署時間已過！');
+  }
+
+  if (signers.includes(currentUserId)) {
+    throw new Meteor.Error(403, '您已經連署過了！');
+  }
+
+  if (signers.length > 0 && signers.length >= threshold) {
+    throw new Meteor.Error(403, '連署人數已達門檻！');
+  }
+
+  if (! resourceLocked) {
+    resourceManager.throwErrorIsResourceIsLock(['signRejectionPetition', `announcement_${announcementId}`]);
+
+    // 先鎖定資源，再重新跑一次 function 進行運算
+    resourceManager.request('signRejectionPetition', [`announcement_${announcementId}`], (release) => {
+      signRejectionPetition(Meteor.users.findByIdOrThrow(currentUserId), args, true);
+      release();
+    });
+
+    return;
+  }
+
+  dbAnnouncements.update(announcementId, { $addToSet: { 'rejectionPetition.signers': currentUserId } });
+  signers.push(currentUserId);
+
+  // 若連署達到門檻，啟動否決投票
+  if (signers.length >= threshold) {
+    dbAnnouncements.update(announcementId, { $set: { 'rejectionPetition.passedAt': nowDate } });
+
+    const { durationDays, thresholdPercent } = Meteor.settings.public.announcement[category].rejectionPoll;
+    const oneDayTime = 24 * 60 * 60 * 1000;
+
+    const activeUserCount = computeActiveUserCount();
+    const dueAt = new Date(nowDate.getTime() + durationDays * oneDayTime);
+
+    dbAnnouncements.update(announcementId, { $set: { rejectionPoll: { activeUserCount, thresholdPercent, dueAt } } });
+  }
+}
+// 一分鐘鐘最多兩次
+limitMethod('signRejectionPetition', 2, 60000);

--- a/server/methods/announcement/signRejectionPetition.js
+++ b/server/methods/announcement/signRejectionPetition.js
@@ -36,7 +36,7 @@ export function signRejectionPetition(currentUser, args, resourceLocked = false)
   }
 
   const { dueAt, signers, thresholdPercent, activeUserCount } = petition;
-  const threshold = Math.floor(activeUserCount * thresholdPercent / 100);
+  const threshold = Math.ceil(activeUserCount * thresholdPercent / 100);
 
   if (nowDate.getTime() > dueAt.getTime()) {
     throw new Meteor.Error(403, '連署時間已過！');

--- a/server/methods/announcement/voteRejectionPoll.js
+++ b/server/methods/announcement/voteRejectionPoll.js
@@ -1,0 +1,67 @@
+import { Meteor } from 'meteor/meteor';
+import { check, Match } from 'meteor/check';
+
+import { resourceManager } from '/server/imports/threading/resourceManager';
+import { dbAnnouncements } from '/db/dbAnnouncements';
+import { limitMethod } from '/server/imports/utils/rateLimit';
+import { debug } from '/server/imports/utils/debug';
+import { guardUser } from '/common/imports/guards';
+
+const validPollChoices = ['yes', 'no'];
+
+Meteor.methods({
+  voteRejectionPoll({ announcementId, choice }) {
+    check(this.userId, String);
+    check(announcementId, String);
+    check(choice, Match.OneOf(...validPollChoices));
+    voteRejectionPoll(Meteor.user(), { announcementId, choice });
+
+    return true;
+  }
+});
+
+export function voteRejectionPoll(currentUser, args, resourceLocked = false) {
+  debug.log('voteRejectionPoll', { currentUser, args, resourceLocked });
+
+  const nowDate = new Date();
+  const { _id: currentUserId } = currentUser;
+  const { announcementId, choice } = args;
+
+  guardUser(currentUser).checkCanVote();
+
+  const { rejectionPoll: poll } = dbAnnouncements.findByIdOrThrow(announcementId, { fields: { rejectionPoll: 1 } });
+
+  if (! poll) {
+    throw new Meteor.Error(403, '此公告並無進行否決投票！');
+  }
+
+  const { dueAt, yesVotes, noVotes } = poll;
+
+  if (nowDate.getTime() > dueAt.getTime()) {
+    throw new Meteor.Error(403, '投票時間已過！');
+  }
+
+  if (yesVotes.includes(currentUserId) || noVotes.includes(currentUserId)) {
+    throw new Meteor.Error(403, '您已經投票過了！');
+  }
+
+  if (! validPollChoices.includes(choice)) {
+    throw new Meteor.Error(403, '不合法的投票選項！');
+  }
+
+  if (! resourceLocked) {
+    resourceManager.throwErrorIsResourceIsLock(['voteRejectionPoll', `announcement_${announcementId}`]);
+
+    // 先鎖定資源，再重新跑一次 function 進行運算
+    resourceManager.request('voteRejectionPoll', [`announcement_${announcementId}`], (release) => {
+      voteRejectionPoll(Meteor.users.findByIdOrThrow(currentUserId), args, true);
+      release();
+    });
+
+    return;
+  }
+
+  dbAnnouncements.update(announcementId, { $addToSet: { [`rejectionPoll.${choice}Votes`]: currentUserId } });
+}
+// 一分鐘鐘最多兩次
+limitMethod('voteRejectionPoll', 2, 60000);

--- a/server/publications/announcement/announcementDetail.js
+++ b/server/publications/announcement/announcementDetail.js
@@ -16,26 +16,14 @@ Meteor.publish('announcementDetail', function(announcementId) {
   }
 
   const transformFields = (fields) => {
-    const result = { ...fields };
+    const result = { ..._.omit(fields, 'rejectionPetition', 'rejectionPoll') };
+
+    if (fields.rejectionPetition) {
+      result.hasRejectionPetition = !! fields.rejectionPetition;
+    }
 
     if (fields.rejectionPoll) {
-      const { dueAt, yesVotes, noVotes } = fields.rejectionPoll;
-
-      // 標記目前使用者的投票選項
-      if (this.userId) {
-        const hasVotedYes = yesVotes.includes(this.userId);
-        const hasVotedNo = noVotes.includes(this.userId);
-
-        Object.assign(result.rejectionPoll, {
-          currentUserChoice: hasVotedYes ? 'yes' : hasVotedNo ? 'no' : undefined
-        });
-      }
-
-      // 在尚未截止時隱藏投票名單
-      // NOTE: 由於此處判斷的方式，投票結束後，一般需要重新訂閱（i.e., 重新進入頁面），以正確拿到投票名單
-      if (Date.now() < dueAt.getTime()) {
-        result.rejectionPoll = _.omit(result.rejectionPoll, 'yesVotes', 'noVotes');
-      }
+      result.hasRejectionPoll = !! fields.rejectionPoll;
     }
 
     return result;

--- a/server/publications/announcement/announcementDetail.js
+++ b/server/publications/announcement/announcementDetail.js
@@ -1,13 +1,59 @@
 import { Meteor } from 'meteor/meteor';
+import { _ } from 'meteor/underscore';
+import { check } from 'meteor/check';
 
-import { dbVariables } from '/db/dbVariables';
+import { dbAnnouncements } from '/db/dbAnnouncements';
 import { limitSubscription } from '/server/imports/utils/rateLimit';
 import { debug } from '/server/imports/utils/debug';
 
-Meteor.publish('announcementDetail', function() {
+Meteor.publish('announcementDetail', function(announcementId) {
   debug.log('publish announcementDetail');
+  check(announcementId, String);
 
-  return dbVariables.find({ _id: 'announcementDetail' }, { disableOplog: true });
+  // 已讀標記
+  if (this.userId) {
+    dbAnnouncements.update(announcementId, { $addToSet: { readers: this.userId } });
+  }
+
+  const transformFields = (fields) => {
+    const result = { ...fields };
+
+    if (fields.rejectionPoll) {
+      const { dueAt, yesVotes, noVotes } = fields.rejectionPoll;
+
+      // 標記目前使用者的投票選項
+      if (this.userId) {
+        const hasVotedYes = yesVotes.includes(this.userId);
+        const hasVotedNo = noVotes.includes(this.userId);
+
+        Object.assign(result.rejectionPoll, {
+          currentUserChoice: hasVotedYes ? 'yes' : hasVotedNo ? 'no' : undefined
+        });
+      }
+
+      // 在尚未截止時隱藏投票名單
+      // NOTE: 由於此處判斷的方式，投票結束後，一般需要重新訂閱（i.e., 重新進入頁面），以正確拿到投票名單
+      if (Date.now() < dueAt.getTime()) {
+        result.rejectionPoll = _.omit(result.rejectionPoll, 'yesVotes', 'noVotes');
+      }
+    }
+
+    return result;
+  };
+
+  dbAnnouncements
+    .find(announcementId, { fields: { readers: 0 } })
+    .observeChanges({
+      added: (id, fields) => {
+        this.added('announcements', id, transformFields(fields));
+      },
+      changed: (id, fields) => {
+        this.changed('announcements', id, transformFields(fields));
+      },
+      removed: (id) => {
+        this.removed('announcements', id);
+      }
+    });
 });
-// 一分鐘最多重複訂閱5次
-limitSubscription('announcementDetail', 5);
+// 一分鐘最多20次
+limitSubscription('announcementDetail', 20);

--- a/server/publications/announcement/announcementList.js
+++ b/server/publications/announcement/announcementList.js
@@ -1,0 +1,69 @@
+import { _ } from 'meteor/underscore';
+import { check, Match } from 'meteor/check';
+import { Meteor } from 'meteor/meteor';
+import { Counts } from 'meteor/tmeasday:publish-counts';
+
+import { dbAnnouncements, announcementCategoryMap } from '/db/dbAnnouncements';
+import { limitSubscription } from '/server/imports/utils/rateLimit';
+import { debug } from '/server/imports/utils/debug';
+
+Meteor.publish('announcementList', function({ category, onlyUnread, offset }) {
+  debug.log('publish announcementList', { category, onlyUnread, offset });
+
+  check(category, Match.Optional(Match.OneOf(...Object.keys(announcementCategoryMap))));
+  check(onlyUnread, Match.Optional(Boolean));
+  check(offset, Match.Integer);
+
+  const filter = {};
+
+  if (category) {
+    Object.assign(filter, { category });
+  }
+
+  if (this.userId && onlyUnread) {
+    Object.assign(filter, { readers: { $ne: this.userId } });
+  }
+
+  Counts.publish(this, 'announcements', dbAnnouncements.find(filter, { fields: { _id: 1 } }), { noReady: true });
+
+  const transformFields = (fields) => {
+    const result = { ..._.omit(fields, 'readers') };
+
+    if (this.userId && fields.readers) {
+      result.isUnread = ! fields.readers.includes(this.userId);
+    }
+
+    return result;
+  };
+
+  const { announcements: dataNumberPerPage } = Meteor.settings.public.dataNumberPerPage;
+
+  dbAnnouncements
+    .find(filter, {
+      fields: {
+        creator: 1,
+        category: 1,
+        subject: 1,
+        createdAt: 1,
+        readers: 1
+      },
+      sort: { createdAt: -1 },
+      skip: offset,
+      limit: dataNumberPerPage
+    })
+    .observeChanges({
+      added: (id, fields) => {
+        this.added('announcements', id, transformFields(fields));
+      },
+      changed: (id, fields) => {
+        this.changed('announcements', id, transformFields(fields));
+      },
+      removed: (id) => {
+        this.removed('announcements', id);
+      }
+    });
+
+  this.ready();
+});
+// 一分鐘最多20次
+limitSubscription('announcementList');

--- a/server/publications/announcement/announcementRejectionDetail.js
+++ b/server/publications/announcement/announcementRejectionDetail.js
@@ -1,0 +1,59 @@
+import { Meteor } from 'meteor/meteor';
+import { _ } from 'meteor/underscore';
+import { check } from 'meteor/check';
+
+import { dbAnnouncements } from '/db/dbAnnouncements';
+import { limitSubscription } from '/server/imports/utils/rateLimit';
+import { debug } from '/server/imports/utils/debug';
+
+Meteor.publish('announcementRejectionDetail', function(announcementId) {
+  debug.log('publish announcementRejectionDetail');
+  check(announcementId, String);
+
+  const transformFields = (fields) => {
+    const result = { ...fields };
+
+    if (fields.rejectionPoll) {
+      const { dueAt, yesVotes, noVotes } = fields.rejectionPoll;
+
+      // 標記目前使用者的投票選項
+      if (this.userId) {
+        const hasVotedYes = yesVotes.includes(this.userId);
+        const hasVotedNo = noVotes.includes(this.userId);
+
+        Object.assign(result.rejectionPoll, {
+          currentUserChoice: hasVotedYes ? 'yes' : hasVotedNo ? 'no' : undefined
+        });
+      }
+
+      // 在尚未截止時隱藏投票名單
+      // NOTE: 由於此處判斷的方式，投票結束後，一般需要重新訂閱（i.e., 重新進入頁面），以正確拿到投票名單
+      if (Date.now() < dueAt.getTime()) {
+        result.rejectionPoll = _.omit(result.rejectionPoll, 'yesVotes', 'noVotes');
+      }
+    }
+
+    return result;
+  };
+
+  dbAnnouncements
+    .find(announcementId, { fields: {
+      subject: 1,
+      category: 1,
+      rejectionPetition: 1,
+      rejectionPoll: 1
+    } })
+    .observeChanges({
+      added: (id, fields) => {
+        this.added('announcements', id, transformFields(fields));
+      },
+      changed: (id, fields) => {
+        this.changed('announcements', id, transformFields(fields));
+      },
+      removed: (id) => {
+        this.removed('announcements', id);
+      }
+    });
+});
+// 一分鐘最多20次
+limitSubscription('announcementRejectionDetail', 20);

--- a/server/publications/announcement/currentUserUnreadAnnouncementCount.js
+++ b/server/publications/announcement/currentUserUnreadAnnouncementCount.js
@@ -1,0 +1,18 @@
+import { Meteor } from 'meteor/meteor';
+import { Counts } from 'meteor/tmeasday:publish-counts';
+
+import { dbAnnouncements } from '/db/dbAnnouncements';
+import { limitSubscription } from '/server/imports/utils/rateLimit';
+import { debug } from '/server/imports/utils/debug';
+
+Meteor.publish('currentUserUnreadAnnouncementCount', function() {
+  debug.log('publish currentUserUnreadAnnouncementCount');
+
+  if (! this.userId) {
+    return [];
+  }
+
+  Counts.publish(this, 'currentUserUnreadAnnouncements', dbAnnouncements.find({ readers: { $ne: this.userId } }, { fields: { _id: 1 } }));
+});
+// 一分鐘最多20次
+limitSubscription('currentUserUnreadAnnouncementCount', 20);

--- a/server/publications/announcement/legacyAnnouncementDetail.js
+++ b/server/publications/announcement/legacyAnnouncementDetail.js
@@ -1,0 +1,13 @@
+import { Meteor } from 'meteor/meteor';
+
+import { dbVariables } from '/db/dbVariables';
+import { limitSubscription } from '/server/imports/utils/rateLimit';
+import { debug } from '/server/imports/utils/debug';
+
+Meteor.publish('legacyAnnouncementDetail', function() {
+  debug.log('publish legacyAnnouncementDetail');
+
+  return dbVariables.find({ _id: 'announcementDetail' }, { disableOplog: true });
+});
+// 一分鐘最多重複訂閱5次
+limitSubscription('legacyAnnouncementDetail', 5);

--- a/server/startup/initializeEventSchedules.js
+++ b/server/startup/initializeEventSchedules.js
@@ -1,5 +1,5 @@
 import { Meteor } from 'meteor/meteor';
-import { _ } from 'underscore';
+import { _ } from 'meteor/underscore';
 
 import { checkChairman } from '/server/functions/company/checkChairman';
 import { recordListPrice, updateRecordListPricePeriod } from '/server/functions/company/recordListPrice';


### PR DESCRIPTION
1. 增加系統公告頁面
2. 增加以下公告分類
    a. 系統維護公告：可由超級管理員發佈，可於更新維護前發佈通知
    b. 金管會公告：可由金管會成員發佈
    c. 已知問題公告：可由工程部發佈，告知目前已知問題
    d. 其他雜項公告：可由超級管理員或營運總管發佈
    e. 系統更新{計劃,套用}公告：可由企劃部成員發佈，並可根據新章程規定進行否決程序
3. 舊有系統公告頁另立為首頁，並修改相關名稱，以和新公告系統區別
4. 更新部分套件
    a. simpl-schema 更新至 1.5.0
    b. aldeed:collection-core 移除，改為 aldeed:collection

其他修改

1. 移除廣告中心 template 裡無用的區塊
2. 重構部分與 markdown 相關的程式碼及 css 樣式
3. 修正部分引用路徑
4. 整理 form 相關的程式碼
    a. 在 template 不帶 data 時以空物件當作預設的 model 資料，減少不必要的空物件傳遞
    b. 移除 errorHtmlOf 的 side-effect，減少誤解
    ~~c. handleInputChange 增加參數 templateInstance，使其與 Blaze 的 helper 形式一致~~ 後來沒弄成這樣了，commit message 沒改到
    d. 移除使用 form 時部分不需要的 handleInputChange 覆寫實作
5. 整理與時間格式相關的 helpers
    a. 原 formatDateText 重新命名為 formatDateTimeText
    b. 原 formatDateTimeText 重新命名為 formatShortDateTimeText，以正確區別減少誤解
    c. formatShortDateTimeText 移除秒數顯示，並移除無資料時的年份與秒數之 ? 顯示
    d. formatTimeText 重新命名為 formatShortDurationTimeText 以減少與前述 function
       的混淆，並補上 regiterHelpers 的設定
    e. 新增 formatLongDurationTimeText 以中文顯示時間天數與時分秒，方便倒數之用
6. 加入 publish-counts 套件並與目前的分頁機制整合，未來將以此套件取代掉 publishTotalCounts
   與 dbVariables 的 `totalCountOf*` 總數記錄機制