### PR TITLE
新增營運送禮功能

### DIFF
--- a/client/controlCenter/controlCenterNavLinkGroup.html
+++ b/client/controlCenter/controlCenterNavLinkGroup.html
@@ -1,0 +1,11 @@
+<template name="controlCenterNavLinkGroup">
+  {{#navLinkGroup text="控制中心"}}
+    {{#each pageKey in getAccessibleControlCenterPageKeys}}
+      <li class="nav-item">
+        <a href="{{pathForControlCenterPage pageKey}}" class="nav-link">
+          {{controlCenterPageDisplayName pageKey}}
+        </a>
+      </li>
+    {{/each}}
+  {{/navLinkGroup}}
+</template>

--- a/client/controlCenter/controlCenterNavLinkGroup.js
+++ b/client/controlCenter/controlCenterNavLinkGroup.js
@@ -1,0 +1,13 @@
+import { Template } from 'meteor/templating';
+
+import {
+  controlCenterPageDisplayName,
+  getAccessibleControlCenterPageKeys,
+  pathForControlCenterPage
+} from '/client/controlCenter/helpers';
+
+Template.controlCenterNavLinkGroup.helpers({
+  getAccessibleControlCenterPageKeys,
+  controlCenterPageDisplayName,
+  pathForControlCenterPage
+});

--- a/client/controlCenter/controlCenterSendGift.html
+++ b/client/controlCenter/controlCenterSendGift.html
@@ -1,0 +1,9 @@
+<template name="controlCenterSendGift">
+  <div class="card">
+    <div class="card-block">
+      <h1 class="card-title mb-1">發送禮物</h1>
+      <hr/>
+      {{> controlCenterSendGiftForm}}
+    </div>
+  </div>
+</template>

--- a/client/controlCenter/controlCenterSendGiftForm.html
+++ b/client/controlCenter/controlCenterSendGiftForm.html
@@ -1,0 +1,82 @@
+<template name="controlCenterSendGiftForm">
+  <form class="form">
+    <div class="form-group">
+      <label for="userType">{{schema.label 'userType'}}：</label>
+      <select class="form-control" name="userType">
+        <option value="" class="d-none">選擇類型…</option>
+        {{#each userType in schema.getAllowedValuesForKey 'userType'}}
+          <option value="{{userType}}">{{userTypeDisplayName userType}}</option>
+        {{/each}}
+      </select>
+      {{{errorHtmlOf 'userType'}}}
+    </div>
+
+    {{#if userTypeMatches 'recentlyLoggedIn'}}
+      <div class="form-group">
+        <label for="days">{{schema.label 'days'}}：</label>
+        <input class="form-control" type="number" name="days"
+          min="{{schema.get 'days' 'min'}}"
+          placeholder="請輸入天數" value="{{valueOf 'days'}}">
+        {{{errorHtmlOf 'days'}}}
+      </div>
+    {{/if}}
+
+    {{#if userTypeMatches 'specified'}}
+      <div class="form-group">
+        {{schema.label 'users'}}：
+        <ol name='users'>
+          {{#each userId in valueOf 'users'}}
+            <li>
+              玩家 {{> userLink userId}} ({{userId}})
+              <a href="#" class="badge badge-danger" data-action="removeUser" data-user-id="{{userId}}">
+                <i class="fa fa-times"></i> 移除
+              </a>
+            </li>
+          {{else}}
+            <em>一個人都沒有！</em>
+          {{/each}}
+        </ol>
+        <div class="form-inline">
+          <div class="input-group input-group-sm">
+            <span class="input-group-addon">玩家識別碼</span>
+            <input type="text" class="form-control form-control-sm" name="userId" placeholder="請輸入識別碼">
+          </div>
+          <button type="button" data-action="addUser" class="btn btn-sm btn-primary">
+            <i class="fa fa-plus"></i> 加入列表
+          </button>
+        </div>
+        {{{errorHtmlOf 'users'}}}
+      </div>
+    {{/if}}
+
+    <div class="form-group">
+      <label for="giftType">{{schema.label 'giftType'}}：</label>
+      <select class="form-control" name="giftType">
+        <option value="" class="d-none">選擇類型…</option>
+        {{#each giftType in schema.getAllowedValuesForKey 'giftType'}}
+          <option value="{{giftType}}">{{giftTypeDisplayName giftType}}</option>
+        {{/each}}
+      </select>
+      {{{errorHtmlOf 'giftType'}}}
+    </div>
+
+    <div class="form-group">
+      <label for="amount">{{schema.label 'amount'}}：</label>
+      <input class="form-control" type="number" name="amount"
+        min="{{schema.get 'amount' 'min'}}"
+        placeholder="請輸入數量" value="{{valueOf 'amount'}}">
+      {{{errorHtmlOf 'amount'}}}
+    </div>
+
+    <div class="form-group">
+      <label for="reason">{{schema.label 'reason'}}：</label>
+      <input class="form-control" type="text" name="reason" placeholder="請輸入數量" value="{{valueOf 'reason'}}">
+      {{{errorHtmlOf 'reason'}}}
+    </div>
+
+    <div class="text-right">
+      <button class="btn btn-primary" type="submit">送出</button>
+      <button class="btn btn-secondary" type="reset">重設</button>
+    </div>
+  </form>
+</template>

--- a/client/controlCenter/controlCenterSendGiftForm.js
+++ b/client/controlCenter/controlCenterSendGiftForm.js
@@ -1,0 +1,188 @@
+import { _ } from 'meteor/underscore';
+import { Meteor } from 'meteor/meteor';
+import { Template } from 'meteor/templating';
+import SimpleSchema from 'simpl-schema';
+
+import { translatedMessages } from '/common/imports/utils/schemaHelpers';
+import { inheritUtilForm } from '../utils/form';
+import { alertDialog } from '../layout/alertDialog';
+
+// TODO 將 server 端的定義一同合併
+export const userTypeDisplayNameMap = {
+  all: '全體玩家',
+  active: '活躍玩家',
+  recentlyLoggedIn: '近日內有登入的玩家',
+  specified: '指定玩家'
+};
+
+// TODO 將 server 端的定義一同合併
+export const giftTypeDisplayNameMap = {
+  saintStone: '聖晶石',
+  rainbowStone: '彩虹石',
+  rainbowStoneFragment: '彩紅石碎片',
+  questStone: '任務石',
+  money: '金錢',
+  voucher: '消費券',
+  voteTicket: '推薦票'
+};
+
+const baseFormModelSchema = new SimpleSchema({
+  userType: {
+    label: '玩家類型',
+    type: String,
+    allowedValues: Object.keys(userTypeDisplayNameMap)
+  },
+
+  giftType: {
+    label: '禮物類型',
+    type: String,
+    allowedValues: Object.keys(giftTypeDisplayNameMap)
+  },
+
+  amount: {
+    label: '數量',
+    type: SimpleSchema.Integer,
+    min: 1
+  },
+
+  reason: {
+    label: '送禮原因',
+    type: String,
+    min: 1,
+    max: 200
+  }
+});
+baseFormModelSchema.messageBox.setLanguage('zh-tw');
+baseFormModelSchema.messageBox.messages(translatedMessages);
+
+export const userTypeFormModelSchemaMap = {
+  all: baseFormModelSchema,
+  active: baseFormModelSchema,
+  recentlyLoggedIn: baseFormModelSchema.clone().extend({
+    days: {
+      label: '天數',
+      type: Number,
+      min: 1
+    }
+  }),
+  specified: baseFormModelSchema.clone().extend({
+    users: {
+      label: '玩家列表',
+      type: Array,
+      minCount: 1,
+      defaultValue: []
+    },
+    'users.$': String
+  })
+};
+
+inheritUtilForm(Template.controlCenterSendGiftForm);
+Template.controlCenterSendGiftForm.onCreated(function() {
+  this.getFormModelSchema = () => {
+    return userTypeFormModelSchemaMap[this.model.get().userType] || baseFormModelSchema;
+  };
+
+  this.validateModel = (model) => {
+    const error = {};
+
+    const formModelSchema = this.getFormModelSchema();
+    const cleanedModel = formModelSchema.clean(model);
+
+    try {
+      formModelSchema.validate(cleanedModel);
+    }
+    catch (e) {
+      if (e.error === 'validation-error') {
+        e.details.forEach(({ name, message }) => {
+          error[name] = message;
+        });
+      }
+      else throw e;
+    }
+
+    if (_.size(error) > 0) {
+      return error;
+    }
+  };
+
+  this.saveModel = (model) => {
+    const formModelSchema = this.getFormModelSchema();
+    const cleanedModel = formModelSchema.clean(model);
+
+    alertDialog.confirm({
+      message: '確定送出禮物嗎？',
+      callback: (result) => {
+        if (! result) {
+          return;
+        }
+
+        Meteor.customCall('adminSendGift', cleanedModel, (err) => {
+          if (! err) {
+            alertDialog.alert('禮物送出成功！');
+          }
+        });
+      }
+    });
+  };
+
+  this.onAddUser = () => {
+    const userId = this.$('[name="userId"]').val();
+
+    if (! userId) {
+      return;
+    }
+
+    const model = this.model.get();
+    if (! model.users) {
+      model.users = [];
+    }
+
+    if (model.users.includes(userId)) {
+      return;
+    }
+
+    model.users.push(userId);
+    this.model.set(model);
+    this.$('[name="userId"]').val('');
+  };
+});
+
+Template.controlCenterSendGiftForm.events({
+  'click [data-action="addUser"]'(event, templateInstance) {
+    event.preventDefault();
+    templateInstance.onAddUser();
+  },
+  'click [data-action="removeUser"]'(event, templateInstance) {
+    event.preventDefault();
+    const userId = templateInstance.$(event.currentTarget).attr('data-user-id');
+    const model = templateInstance.model.get();
+
+    if (! model.users) {
+      return;
+    }
+
+    model.users = _.without(model.users, userId);
+    templateInstance.model.set(model);
+  },
+  'keydown input[name="userId"]'(event, templateInstance) {
+    if (event.which === 13) { // return
+      event.preventDefault();
+      templateInstance.onAddUser();
+    }
+  }
+});
+
+Template.controlCenterSendGiftForm.helpers({
+  schema() {
+    return Template.instance().getFormModelSchema();
+  },
+  userTypeDisplayName(userType) {
+    return userTypeDisplayNameMap[userType];
+  },
+  userTypeMatches(userType) {
+    return Template.instance().model.get().userType === userType;
+  },
+  giftTypeDisplayName(giftType) {
+    return giftTypeDisplayNameMap[giftType];
+  }
+});

--- a/client/controlCenter/controlCenterSendGiftForm.js
+++ b/client/controlCenter/controlCenterSendGiftForm.js
@@ -1,3 +1,4 @@
+import { $ } from 'meteor/jquery';
 import { _ } from 'meteor/underscore';
 import { Meteor } from 'meteor/meteor';
 import { Template } from 'meteor/templating';
@@ -148,6 +149,14 @@ Template.controlCenterSendGiftForm.onCreated(function() {
 });
 
 Template.controlCenterSendGiftForm.events({
+  reset(event, templateInstance) {
+    event.preventDefault();
+    const model = templateInstance.model.get();
+    templateInstance.$('select[name]').each((i, e) => {
+      const name = $(e).attr('name');
+      $(e).val(model[name] || '');
+    });
+  },
   'click [data-action="addUser"]'(event, templateInstance) {
     event.preventDefault();
     templateInstance.onAddUser();

--- a/client/controlCenter/helpers.js
+++ b/client/controlCenter/helpers.js
@@ -1,0 +1,37 @@
+import { FlowRouter } from 'meteor/kadira:flow-router';
+import { _ } from 'meteor/underscore';
+import { Meteor } from 'meteor/meteor';
+
+import { hasAnyRoles } from '/db/users';
+
+export const controlCenterPageMap = {
+  sendGift: {
+    routerName: 'controlCenterSendGift',
+    displayName: '發送禮物',
+    allowedRoles: ['superAdmin', 'planner']
+  }
+};
+
+export function controlCenterPageDisplayName(key) {
+  return controlCenterPageMap[key].displayName;
+}
+
+export function canAccessControlCenterPage(key) {
+  return hasAnyRoles(Meteor.user(), ...controlCenterPageMap[key].allowedRoles);
+}
+
+export function pathForControlCenterPage(key) {
+  return FlowRouter.path(controlCenterPageMap[key].routerName);
+}
+
+export function getAccessibleControlCenterPageKeys() {
+  const currentUser = Meteor.user();
+
+  if (! currentUser) {
+    return [];
+  }
+
+  return _.pluck(Object.entries(controlCenterPageMap).filter(([, { allowedRoles } ]) => {
+    return allowedRoles && hasAnyRoles(currentUser, ...allowedRoles);
+  }), 0);
+}

--- a/client/layout/nav.html
+++ b/client/layout/nav.html
@@ -67,12 +67,8 @@
     </button>
     <div class="{{getNavLinkListClassList}}">
       <ul class="navbar-nav">
-        <li class="nav-item text-nowrap">
-          <a class="nav-link" href="{{pathFor 'mainPage'}}">{{getLinkText 'mainPage'}}</a>
-        </li>
-        <li class="nav-item text-nowrap">
-          <a class="nav-link" href="{{pathFor 'announcementList'}}">{{getLinkText 'announcement'}}</a>
-        </li>
+        {{> navLink page='mainPage'}}
+        {{> navLink page='announcementList'}}
         {{#navLinkGroup text='交易大廳'}}
           {{> navLink page='instantMessage'}}
           {{> navLink page='companyList' params=page1}}
@@ -100,6 +96,9 @@
           {{> navLink page='violationCaseList'}}
           {{> navLink page='fscStock'}}
         {{/navLinkGroup}}
+        {{#if shouldShowControlCenter}}
+          {{> controlCenterNavLinkGroup}}
+        {{/if}}
         {{#navLinkGroup text='主題配置'}}
           <li class="nav-item">
             <a class="nav-link" href="#" data-theme="light" data-action="switch-theme">亮色</a>
@@ -120,7 +119,7 @@
   <div class="note">
     <li class="nav-item dropdown text-nowrap">
       <a class="nav-link dropdown-toggle" href="#" data-toggle="dropdown">
-        {{{this.text}}}
+        {{{text}}}
       </a>
       <div class="dropdown-menu px-3 nav-dropdown-menu" style="{{style}}" aria-labelledby="navbarDropdownMenuLink">
         {{> Template.contentBlock}}

--- a/client/layout/nav.js
+++ b/client/layout/nav.js
@@ -7,6 +7,10 @@ import { FlowRouter } from 'meteor/kadira:flow-router';
 import { dbArena } from '/db/dbArena';
 import { dbSeason } from '/db/dbSeason';
 import { stoneTypeList } from '/db/dbCompanyStones';
+import {
+  getAccessibleControlCenterPageKeys,
+  pathForControlCenterPage
+} from '/client/controlCenter/helpers';
 import { pageNameHash } from '/routes';
 import { rMainTheme } from '../utils/styles';
 import { shouldStopSubscribe } from '../utils/idle';
@@ -151,7 +155,12 @@ Template.nav.helpers({
   },
   userStoneCount(user, stoneType) {
     return user.profile.stones[stoneType];
-  }
+  },
+  shouldShowControlCenter() {
+    return getAccessibleControlCenterPageKeys().length > 0;
+  },
+  getAccessibleControlCenterPageKeys,
+  pathForControlCenterPage
 });
 Template.nav.events({
   'click [data-login]'(event) {

--- a/client/utils/displayLog.js
+++ b/client/utils/displayLog.js
@@ -87,9 +87,6 @@ Template.displayLog.helpers({
       case '登入紀錄': {
         return `${users[0]}從${data.ipAddr}登入了系統！`;
       }
-      case '免費得石': {
-        return `【免費得石】因為「${_.escape(data.reason)}」的理由獲得了${data.stones}顆聖晶石！`;
-      }
       case '購買得石': {
         return `【購買得石】${users[0]}花費$${currencyFormat(data.cost)}購買了${data.amount}個${stoneDisplayName(data.stoneType)}！`;
       }
@@ -423,6 +420,52 @@ Template.displayLog.helpers({
       }
       case '身份解除': {
         return `【身份解除】${users[0]}以「${_.escape(data.reason)}」的理由將${users[1]}解除了${roleDisplayName(data.role)}的身份！`;
+      }
+      case '營運送禮': {
+        let result = `【營運送禮】${users[0]}以「${_.escape(data.reason)}」的理由發給了`;
+
+        switch (data.userType) {
+          case 'all':
+            result += '所有玩家';
+            break;
+          case 'active':
+            result += '所有活躍玩家';
+            break;
+          case 'recentlyLoggedIn':
+            result += `最近 ${data.days} 日內有登入的玩家`;
+            break;
+          case 'specified':
+            result += users.slice(1).join('、');
+            break;
+        }
+
+        switch (data.giftType) {
+          case 'saintStone':
+            result += ` ${data.amount} 個聖晶石`;
+            break;
+          case 'rainbowStone':
+            result += ` ${data.amount} 個彩紅石`;
+            break;
+          case 'rainbowStoneFragment':
+            result += ` ${data.amount} 個彩虹石碎片`;
+            break;
+          case 'questStone':
+            result += ` ${data.amount} 個任務石`;
+            break;
+          case 'money':
+            result += ` $${currencyFormat(data.amount)} 的現金`;
+            break;
+          case 'voucher':
+            result += ` ${data.amount} 張消費券`;
+            break;
+          case 'voteTicket':
+            result += ` ${data.amount} 張推薦票`;
+            break;
+        }
+
+        result += '！';
+
+        return result;
       }
     }
   }

--- a/common/imports/utils/schemaHelpers.js
+++ b/common/imports/utils/schemaHelpers.js
@@ -1,0 +1,13 @@
+export const translatedMessages = {
+  'zh-tw': {
+    required: '必須填寫{{label}}！',
+    minString: '{{label}}不得少於 {{min}} 字！',
+    maxString: '{{label}}不得超過 {{max}} 字！',
+    minNumber: '{{label}}不得小於 {{min}}！',
+    maxNumber: '{{label}}不得大於 {{max}}！',
+    minCount: '{{label}}總數量不得少於 {{minCount}} 個！',
+    maxCount: '{{label}}總數量不得超過 {{maxCount}} 個！',
+    noDecimal: '{{label}}必須為整數！',
+    notAllowed: '{{value}}並非被允許的值！'
+  }
+};

--- a/db/dbLog.js
+++ b/db/dbLog.js
@@ -17,11 +17,6 @@ export const logTypeList = [
   '登入紀錄',
 
   /**
-   * 因為「data.reason」的理由獲得了data.stones顆聖晶石！
-   */
-  '免費得石',
-
-  /**
    * 【購買得石】userId0花費$data.cost購買了data.amount個data.stoneType！
    */
   '購買得石',
@@ -375,7 +370,15 @@ export const logTypeList = [
   /**
    * 【身份解除】userId0以「data.reason」的理由將userId1解除了data.role的身份！
    */
-  '身份解除'
+  '身份解除',
+
+  /**
+   * 【營運送禮】userId0以「data.reason」的理由發給了所有玩家data.amount數量的data.giftType！
+   * 【營運送禮】userId0以「data.reason」的理由發給了所有活躍玩家data.amount數量的data.giftType！
+   * 【營運送禮】userId0以「data.reason」的理由發給了所有data.days天內有登入的玩家data.amount數量的data.giftType！
+   * 【營運送禮】userId0以「data.reason」的理由發給了玩家userId...data.amount數量的data.giftType！
+   */
+  '營運送禮'
 ];
 
 // log 的分組，方便以群組方式 filtering 之用
@@ -389,7 +392,6 @@ export const logTypeGroupMap = {
   miningMachines: {
     displayName: '挖礦機與石頭相關',
     logTypes: [
-      '免費得石',
       '購買得石',
       '礦機營利'
     ]
@@ -517,6 +519,7 @@ export const logTypeGroupMap = {
     logTypes: [
       '驗證通過',
       '發薪紀錄',
+      '營運送禮',
       '公司復活'
     ]
   }

--- a/db/migrate.js
+++ b/db/migrate.js
@@ -1579,6 +1579,23 @@ if (Meteor.isServer) {
     }
   });
 
+  Migrations.add({
+    version: 28,
+    name: 'admin gift system',
+    up() {
+      // 將舊有的「免費得石」紀錄轉換成新的「營運送禮」格式
+      Promise.await(dbLog.rawCollection().update({ logType: '免費得石' }, {
+        $rename: { 'data.stones': 'data.amount' },
+        $set: {
+          logType: '營運送禮',
+          userId: ['!system', '!all'],
+          'data.userType': 'all',
+          'data.giftType': 'saintStone'
+        }
+      }, { multi: true }));
+    }
+  });
+
   Meteor.startup(() => {
     Migrations.migrateTo('latest');
   });

--- a/routes.js
+++ b/routes.js
@@ -6,7 +6,7 @@ import { dbCompanyArchive } from '/db/dbCompanyArchive';
 
 export const pageNameHash = {
   mainPage: '首頁',
-  announcement: '系統公告',
+  announcementList: '系統公告',
   tutorial: '遊戲規則',
   instantMessage: '即時訊息',
   companyList: '股市總覽',
@@ -341,5 +341,17 @@ ruleDiscussRoute.route('/vote/:agendaId', {
   name: 'ruleAgendaVote',
   action() {
     DocHead.setTitle(Meteor.settings.public.websiteName + ' - 議程投票');
+  }
+});
+
+// 控制中心
+const controlCenterRoute = FlowRouter.group({
+  prefix: '/controlCenter',
+  name: 'controlCenterRoute'
+});
+controlCenterRoute.route('/sendGift', {
+  name: 'controlCenterSendGift',
+  action() {
+    DocHead.setTitle(`${Meteor.settings.public.websiteName} - 控制中心 - 發送禮物`);
   }
 });

--- a/server/imports/utils/computeActiveUserCount.js
+++ b/server/imports/utils/computeActiveUserCount.js
@@ -1,42 +1,5 @@
-import { _ } from 'meteor/underscore';
+import { computeActiveUserIds } from './computeActiveUserIds';
 
-import { dbLog } from '/db/dbLog';
-import { dbEmployees } from '/db/dbEmployees';
-
-/*
- * 計算系統中的活躍玩家數量
- *
- * 目前的活躍玩家定義：於七天內有參與投資、購買下單、販賣下單、推薦產品與報名員工等任一紀錄之玩家。
- */
 export function computeActiveUserCount() {
-  // 往回統計的時間
-  const lookbackDate = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-
-  // 有紀錄的玩家
-  const activeUsersByLog = _.pluck(
-    dbLog.aggregate([ {
-      $match: {
-        logType: { $in: ['參與投資', '購買下單', '販賣下單', '推薦產品'] },
-        createdAt: { $gte: lookbackDate }
-      }
-    }, {
-      $group: { _id: { $arrayElemAt: ['$userId', 0] } }
-    } ]),
-    '_id'
-  );
-
-  // 有報名員工的玩家
-  const activeUsersByEmployee = _.pluck(
-    dbEmployees.aggregate([ {
-      $match: { registerAt: { $gte: lookbackDate } }
-    }, {
-      $group: { _id: '$userId' }
-    } ]),
-    '_id'
-  );
-
-  // 以上所有條件的聯集
-  const activeUsers = [...new Set([...activeUsersByLog, ...activeUsersByEmployee])];
-
-  return activeUsers.length;
+  return computeActiveUserIds().length;
 }

--- a/server/imports/utils/computeActiveUserIds.js
+++ b/server/imports/utils/computeActiveUserIds.js
@@ -1,0 +1,40 @@
+import { _ } from 'meteor/underscore';
+
+import { dbLog } from '/db/dbLog';
+import { dbEmployees } from '/db/dbEmployees';
+
+/*
+ * 計算系統中的活躍玩家數量
+ *
+ * 目前的活躍玩家定義：於七天內有參與投資、購買下單、販賣下單、推薦產品與報名員工等任一紀錄之玩家。
+ */
+export function computeActiveUserIds() {
+  // 往回統計的時間
+  const lookbackDate = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+
+  // 有紀錄的玩家
+  const activeUsersByLog = _.pluck(
+    dbLog.aggregate([ {
+      $match: {
+        logType: { $in: ['參與投資', '購買下單', '販賣下單', '推薦產品'] },
+        createdAt: { $gte: lookbackDate }
+      }
+    }, {
+      $group: { _id: { $arrayElemAt: ['$userId', 0] } }
+    } ]),
+    '_id'
+  );
+
+  // 有報名員工的玩家
+  const activeUsersByEmployee = _.pluck(
+    dbEmployees.aggregate([ {
+      $match: { registerAt: { $gte: lookbackDate } }
+    }, {
+      $group: { _id: '$userId' }
+    } ]),
+    '_id'
+  );
+
+  // 以上所有條件的聯集
+  return [...new Set([...activeUsersByLog, ...activeUsersByEmployee])];
+}

--- a/server/methods/admin/adminSendGift.js
+++ b/server/methods/admin/adminSendGift.js
@@ -1,0 +1,144 @@
+import { Meteor } from 'meteor/meteor';
+import { check, Match } from 'meteor/check';
+
+import { computeActiveUserIds } from '/server/imports/utils/computeActiveUserIds';
+import { dbLog } from '/db/dbLog';
+import { debug } from '/server/imports/utils/debug';
+import { guardUser } from '/common/imports/guards';
+
+// TODO 將 client 端的定義一同合併
+const userTypeDisplayNameMap = {
+  all: '全體玩家',
+  active: '活躍玩家',
+  recentlyLoggedIn: '近日內有登入的玩家',
+  specified: '指定玩家'
+};
+
+// TODO 將 client 端的定義一同合併
+const giftTypeDisplayNameMap = {
+  saintStone: '聖晶石',
+  rainbowStone: '彩虹石',
+  rainbowStoneFragment: '彩紅石碎片',
+  questStone: '任務石',
+  money: '金錢',
+  voucher: '消費券',
+  voteTicket: '推薦票'
+};
+
+Meteor.methods({
+  adminSendGift({ userType, giftType, amount, reason, days, users }) {
+    check(this.userId, String);
+    check(userType, Match.OneOf(...Object.keys(userTypeDisplayNameMap)));
+    check(giftType, Match.OneOf(...Object.keys(giftTypeDisplayNameMap)));
+    check(amount, Match.Integer);
+    check(reason, String);
+
+    if (userType === 'specified') {
+      check(users, [String]);
+    }
+
+    if (userType === 'recentlyLoggedIn') {
+      check(days, Match.Integer);
+    }
+
+    adminSendGift(Meteor.user(), { userType, giftType, amount, reason, days, users });
+
+    return true;
+  }
+});
+function adminSendGift(currentUser, { userType, giftType, amount, reason, days, users }) {
+  debug.log('adminSendGift', { currentUser, userType, giftType, amount, reason, days, users });
+
+  guardUser(currentUser).checkHasAnyRoles('superAdmin', 'planner');
+
+  if (amount < 1) {
+    throw new Meteor.Error(403, '數量需至少為 1！');
+  }
+
+  if (reason.length < 1) {
+    throw new Meteor.Error(403, '送禮原因必須大於 1 字！');
+  }
+
+  if (reason.length > 200) {
+    throw new Meteor.Error(403, '送禮原因必須在 200 字以內！');
+  }
+
+  if (userType === 'specified' && users.length < 1) {
+    throw new Meteor.Error(403, `玩家列表至少需有一人！`);
+  }
+
+  if (userType === 'recentlyLoggedIn' && days < 1) {
+    throw new Meteor.Error(403, `天數至少為一天！`);
+  }
+
+  const userModifier = {};
+
+  switch (giftType) {
+    case 'saintStone':
+      userModifier.$inc = { 'profile.stones.saint': amount };
+      break;
+    case 'rainbowStone':
+      userModifier.$inc = { 'profile.stones.rainbow': amount };
+      break;
+    case 'rainbowStoneFragment':
+      userModifier.$inc = { 'profile.stones.rainbowFragment': amount };
+      break;
+    case 'questStone':
+      userModifier.$inc = { 'profile.stones.quest': amount };
+      break;
+    case 'money':
+      userModifier.$inc = { 'profile.money': amount };
+      break;
+    case 'voucher':
+      userModifier.$inc = { 'profile.vouchers': amount };
+      break;
+    case 'voteTicket':
+      userModifier.$inc = { 'profile.voteTickets': amount };
+      break;
+    default:
+      throw new Meteor.Error(403, '不合法的禮物類型！');
+  }
+
+  const userFilter = {};
+
+  switch (userType) {
+    case 'all':
+      // no-op
+      break;
+    case 'active':
+      userFilter._id = { $in: computeActiveUserIds() };
+      break;
+    case 'recentlyLoggedIn':
+      userFilter['status.lastLogin.date'] = { $gte: new Date(Date.now() - days * 24 * 60 * 60 * 1000) };
+      break;
+    case 'specified':
+      userFilter._id = { $in: users };
+      break;
+    default:
+      throw new Meteor.Error(403, '不合法的玩家類型！');
+  }
+
+  Meteor.users.update(userFilter, userModifier, { multi: true });
+
+  const logUserIds = [currentUser._id];
+
+  if (userType === 'specified') {
+    logUserIds.push(...users);
+  }
+  else {
+    logUserIds.push('!all');
+  }
+
+  const logData = { userType, giftType, amount, reason };
+
+  if (userType === 'recentlyLoggedIn') {
+    logData.days = days;
+  }
+
+  dbLog.insert({
+    logType: '營運送禮',
+    userId: logUserIds,
+    data: logData,
+    createdAt: new Date()
+  });
+}


### PR DESCRIPTION
1. 超級管理員與企劃部成員可以對玩家發送禮物
   目標玩家可為所有玩家、活躍玩家、近 n 日內有登入之玩家，或指定的玩家
   禮物類型可選聖晶石、彩虹石、彩虹石碎片、金錢、消費券、推薦票
2. 上方導覽列新增「控制中心」選單，當有可用的功能時即會顯示，目前儘有「發送禮物」一項
3. 將舊有的「免費得石」紀錄改為新的「營運送禮」紀錄格式