### PR TITLE
修正金管會相關紀錄中有帶公司 ID 的紀錄在換賽季時會丟失的問題

### DIFF
--- a/server/intervalCheck.js
+++ b/server/intervalCheck.js
@@ -171,12 +171,6 @@ export function doRoundWorks(lastRoundData, lastSeasonData) {
         $nin: accuseLogTypeList
       }
     });
-    // 移除所有與金管會相關且與公司相關的紀錄資料
-    dbLog.remove({
-      companyId: {
-        $exists: true
-      }
-    });
     // 移除所有最萌亂鬥大賽資料
     dbArenaLog.dropAll();
     dbArenaFighters.remove({});


### PR DESCRIPTION
前面已經將非金管會相關的所有紀錄移除了，無需再特別移除帶有公司 ID 資訊的紀錄。