### PR TITLE
修正新創投資團隊的排序方式

### DIFF
--- a/client/foundation/foundationDetail.js
+++ b/client/foundation/foundationDetail.js
@@ -164,7 +164,12 @@ Template.foundationFounderList.helpers({
   orderedInvestList() {
     const { invest } = paramFoundation();
 
-    return _.sortBy(invest, 'amount').reverse();
+    return _.pluck(invest.map((x, i) => {
+      return [x, i];
+    }).sort(([a, ai], [b, bi]) => {
+      // 對 amount 反向排序，如相同則以原始順序決定前後
+      return b.amount - a.amount || ai - bi;
+    }), 0);
   },
   getPercentage(amount) {
     const { invest } = paramFoundation();


### PR DESCRIPTION
改為以投資額做反向 stable sort，而非對投資額正向 sort 再反轉，以維持投資的實際先後次序