### PR TITLE
 修正在某些頁面切換時，玩家連結會突然消失或顯示錯誤的問題 

### DIFF
--- a/client/utils/displayLink.js
+++ b/client/utils/displayLink.js
@@ -3,23 +3,33 @@ import { Template } from 'meteor/templating';
 import { FlowRouter } from 'meteor/kadira:flow-router';
 
 Template.userLink.onRendered(function() {
-  let userId = this.data;
-
-  if (typeof userId === 'object') {
-    userId = this.data.id;
-  }
-
-  if (userId === '!none') {
-    this.$('a').text('無');
-  }
-  else if (userId === '!system') {
-    this.$('a').text('系統');
-  }
-  else if (userId === '!FSC') {
-    this.$('a').text('金管會');
-  }
-  else if (userId) {
+  this.refreshContent = (userId) => {
     const $link = this.$('a');
+
+    if (! userId) {
+      $link.text('（無資料）');
+
+      return;
+    }
+
+    if (userId === '!none') {
+      $link.text('無');
+
+      return;
+    }
+
+    if (userId === '!system') {
+      $link.text('系統');
+
+      return;
+    }
+
+    if (userId === '!FSC') {
+      $link.text('金管會');
+
+      return;
+    }
+
     $.ajax({
       url: '/userInfo',
       data: {
@@ -45,7 +55,13 @@ Template.userLink.onRendered(function() {
         $link.text('???');
       }
     });
-  }
+  };
+
+  this.autorun(() => {
+    const data = Template.currentData();
+    const userId = typeof data === 'object' ? data.id : data;
+    this.refreshContent(userId);
+  });
 });
 
 Template.companyLink.onRendered(function() {


### PR DESCRIPTION
此修正加入 userLink template 對 `Template.currentData()` 的更新偵測，
如此一來在 template instance 被系統重用，資料因此更新時，才會顯示正確的資料。

此修正也同時解決新創計劃投資團隊因名單變動造成的顯示錯誤。