### PR TITLE
實作無量跌停機制

### DIFF
--- a/config.js
+++ b/config.js
@@ -15,6 +15,10 @@ export const config = {
     min: 10800000,
     max: 21600000
   },
+  zeroVolumePriceDrop: { // 無量跌停設定
+    orderAgeThreshold: 21600000, // 賣單需要存在的時間 (ms)
+    tradeVolumeLookbackTime: 86400000 // 交易量的統計時間 (ms)
+  },
   checkChairmanInterval: 600000, // 董事長檢查的排程時間 (ms)
   founderEarnestMoney: 1024, // 創立公司者需付出的保證金
   foundExpireTime: 43200000, // 創立公司的投資時間期限，單位為毫秒

--- a/config.json
+++ b/config.json
@@ -15,6 +15,10 @@
       "min": 10800000,
       "max": 21600000
     },
+    "zeroVolumePriceDrop": {
+      "orderAgeThreshold": 21600000,
+      "tradeVolumeLookbackTime": 86400000
+    },
     "checkChairmanInterval": 600000,
     "founderEarnestMoney": 1024,
     "foundExpireTime": 43200000,

--- a/server/functions/company/executeZeroVolumePriceDrop.js
+++ b/server/functions/company/executeZeroVolumePriceDrop.js
@@ -1,0 +1,56 @@
+import { _ } from 'meteor/underscore';
+import { Meteor } from 'meteor/meteor';
+
+import { dbCompanies } from '/db/dbCompanies';
+import { dbOrders } from '/db/dbOrders';
+import { calculateDealAmount, getPriceLimits } from '/server/functions/company/helpers';
+import { resourceManager } from '/server/imports/threading/resourceManager';
+
+export function executeZeroVolumePriceDrop() {
+  const { orderAgeThreshold, tradeVolumeLookbackTime } = Meteor.settings.public.zeroVolumePriceDrop;
+
+  return resourceManager.requestPromise('executeZeroVolumePriceDrop', ['allCompanyOrders'], (release) => {
+    const companyUpdateModifierMap = dbOrders.aggregate([ {
+      $match: {
+        orderType: '賣出',
+        createdAt: { $lt: new Date(Date.now() - orderAgeThreshold) }
+      }
+    }, {
+      $group: {
+        _id: '$companyId',
+        minSellOrderPrice: { $min: '$unitPrice' }
+      }
+    }, {
+      $lookup: {
+        from: 'companies',
+        localField: '_id',
+        foreignField: '_id',
+        as: 'companyData'
+      }
+    }, {
+      $unwind: '$companyData'
+    }, {
+      $match: { 'companyData.isSeal': false }
+    } ])
+      .reduce((obj, { _id: companyId, companyData, minSellOrderPrice }) => {
+        const tradeVolume = calculateDealAmount(companyData, tradeVolumeLookbackTime);
+        const { lower: lowerPriceLimit } = getPriceLimits(companyData);
+
+        if (tradeVolume === 0 && minSellOrderPrice <= lowerPriceLimit) {
+          obj[companyId] = { $set: { lastPrice: minSellOrderPrice } };
+        }
+
+        return obj;
+      }, {});
+
+    if (! _.isEmpty(companyUpdateModifierMap)) {
+      const companyBulk = dbCompanies.rawCollection().initializeUnorderedBulkOp();
+      Object.entries(companyUpdateModifierMap).forEach(([companyId, modifier]) => {
+        companyBulk.find({ _id: companyId }).updateOne(modifier);
+      });
+      Meteor.wrapAsync(companyBulk.execute, companyBulk)();
+    }
+
+    release();
+  });
+}

--- a/server/functions/company/helpers.js
+++ b/server/functions/company/helpers.js
@@ -20,12 +20,14 @@ export function isHighPriceCompany(companyData) {
 export function getPriceLimits(companyData) {
   if (isLowPriceCompany(companyData)) {
     return {
-      upper: Math.ceil(companyData.listPrice * 1.30)
+      upper: Math.ceil(companyData.listPrice * 1.30),
+      lower: Math.max(Math.floor(companyData.listPrice * 0.85), 1)
     };
   }
   else {
     return {
-      upper: Math.ceil(companyData.listPrice * 1.15)
+      upper: Math.ceil(companyData.listPrice * 1.15),
+      lower: Math.max(Math.floor(companyData.listPrice * 0.85), 1)
     };
   }
 }

--- a/server/functions/company/recordListPrice.js
+++ b/server/functions/company/recordListPrice.js
@@ -1,3 +1,4 @@
+import { _ } from 'meteor/underscore';
 import { Meteor } from 'meteor/meteor';
 
 import { resourceManager } from '/server/imports/threading/resourceManager';
@@ -14,40 +15,29 @@ export function updateRecordListPricePeriod() {
 
 // 更新參考價（與參考市值）
 export function recordListPrice() {
-  dbCompanies
-    .find({ isSeal: false }, {
-      fields: {
-        _id: 1,
-        lastPrice: 1,
-        listPrice: 1
-      },
-      disableOplog: true
-    })
-    .forEach(({ _id: companyId }) => {
-      // 先鎖定資源，再重新讀取一次資料進行運算
-      resourceManager.request('recordListPrice', [`companyOrder${companyId}`], (release) => {
-        const { lastPrice, listPrice, totalRelease } = dbCompanies.findOne(companyId, {
-          fields: {
-            lastPrice: 1,
-            listPrice: 1,
-            totalRelease: 1
-          }
-        });
-
-        if (lastPrice === listPrice) {
-          release();
-
-          return;
-        }
-
-        dbCompanies.update(companyId, {
+  resourceManager.requestPromise('recordListPrice', ['allCompanyOrders'], (release) => {
+    const companyUpdateModifierMap = dbCompanies
+      .find({ isSeal: false }, { fields: { lastPrice: 1, totalRelease: 1 } })
+      .fetch()
+      .reduce((obj, { _id: companyId, lastPrice, totalRelease }) => {
+        obj[companyId] = {
           $set: {
             listPrice: lastPrice,
             totalValue: lastPrice * totalRelease
           }
-        });
+        };
 
-        release();
+        return obj;
+      }, {});
+
+    if (! _.isEmpty(companyUpdateModifierMap)) {
+      const companyBulk = dbCompanies.rawCollection().initializeUnorderedBulkOp();
+      Object.entries(companyUpdateModifierMap).forEach(([companyId, modifier]) => {
+        companyBulk.find({ _id: companyId }).updateOne(modifier);
       });
-    });
+      Meteor.wrapAsync(companyBulk.execute, companyBulk)();
+    }
+
+    release();
+  });
 }

--- a/server/functions/company/sellFscStocks.js
+++ b/server/functions/company/sellFscStocks.js
@@ -5,24 +5,12 @@ import { dbDirectors } from '/db/dbDirectors';
 
 // 金管會掛單賣出持股
 export function sellFscStocks() {
-  dbDirectors
-    .find({ userId: '!FSC' })
-    .forEach(({ companyId, stocks }) => {
-      resourceManager.request('sellFSCStocks', [`companyOrder${companyId}`], (release) => {
-        const companyData = dbCompanies.findOne({
-          _id: companyId,
-          isSeal: false
-        }, {
-          fields: {
-            _id: 1,
-            listPrice: 1,
-            isSeal: 1
-          }
-        });
+  return resourceManager.requestPromise('sellFscStocks', ['allCompanyOrders'], (release) => {
+    dbDirectors.find({ userId: '!FSC' })
+      .forEach(({ companyId, stocks }) => {
+        const companyData = dbCompanies.findOne({ _id: companyId, isSeal: false }, { fields: { listPrice: 1 } });
 
         if (! companyData) {
-          release();
-
           return;
         }
 
@@ -37,8 +25,7 @@ export function sellFscStocks() {
           unitPrice: listPrice,
           amount
         });
-
-        release();
       });
-    });
+    release();
+  });
 }

--- a/server/imports/threading/resourceManager.js
+++ b/server/imports/threading/resourceManager.js
@@ -43,11 +43,19 @@ export const resourceManager = {
       }
       catch (e) {
         release();
-        console.error('error happens while requesting resources, automatic release resources lock' + JSON.stringify({ resourceList, task, threadId, time }) + '!');
+        console.error(`error happens while requesting resources, automatic release resources lock${JSON.stringify({ resourceList, task, threadId, time })}!`);
 
         throw e;
       }
     }
+  },
+  requestPromise(task, resourceList, callback) {
+    return new Promise((resolve) => {
+      this.request(task, resourceList, (release) => {
+        callback(release);
+        resolve();
+      });
+    });
   },
   throwErrorIsResourceIsLock(resourceList) {
     const someResourceIsLock = _.some(resourceList, (resource) => {

--- a/server/methods/order/createBuyOrder.js
+++ b/server/methods/order/createBuyOrder.js
@@ -67,7 +67,7 @@ export function createBuyOrder(user, orderData) {
     throw new Meteor.Error(404, '不存在的公司股票，訂單無法成立！');
   }
   if (companyData.isSeal) {
-    throw new Meteor.Error(403, '「' + companyData.companyName + '」公司已被金融管理委員會查封關停了！');
+    throw new Meteor.Error(403, `「${companyData.companyName}」公司已被金融管理委員會查封關停了！`);
   }
   if (orderData.unitPrice < Math.max(Math.floor(companyData.listPrice * 0.85), 1)) {
     throw new Meteor.Error(403, '每股單價不可偏離該股票參考價格的百分之十五！');
@@ -80,9 +80,9 @@ export function createBuyOrder(user, orderData) {
   else if (orderData.unitPrice > Math.max(Math.ceil(companyData.listPrice * 1.15), 1)) {
     throw new Meteor.Error(403, '每股單價不可偏離該股票參考價格的百分之十五！');
   }
-  resourceManager.throwErrorIsResourceIsLock(['season', 'companyOrder' + companyId, 'user' + userId]);
+  resourceManager.throwErrorIsResourceIsLock(['season', 'allCompanyOrders', `companyOrder${companyId}`, `user${userId}`]);
   // 先鎖定資源，再重新讀取一次資料進行運算
-  resourceManager.request('createBuyOrder', ['companyOrder' + companyId, 'user' + userId], (release) => {
+  resourceManager.request('createBuyOrder', [`companyOrder${companyId}`, `user${userId}`], (release) => {
     const user = Meteor.users.findOne(userId, {
       fields: {
         profile: 1

--- a/server/methods/order/createSellOrder.js
+++ b/server/methods/order/createSellOrder.js
@@ -69,7 +69,7 @@ export function createSellOrder(user, orderData) {
     throw new Meteor.Error(404, '不存在的公司股票，訂單無法成立！');
   }
   if (companyData.isSeal) {
-    throw new Meteor.Error(403, '「' + companyData.companyName + '」公司已被金融管理委員會查封關停了！');
+    throw new Meteor.Error(403, `「${companyData.companyName}」公司已被金融管理委員會查封關停了！`);
   }
   if (orderData.unitPrice < Math.max(Math.floor(companyData.listPrice * 0.85), 1)) {
     throw new Meteor.Error(403, '每股單價不可偏離該股票參考價格的百分之十五！');
@@ -82,9 +82,9 @@ export function createSellOrder(user, orderData) {
   else if (orderData.unitPrice > Math.max(Math.ceil(companyData.listPrice * 1.15), 1)) {
     throw new Meteor.Error(403, '每股單價不可偏離該股票參考價格的百分之十五！');
   }
-  resourceManager.throwErrorIsResourceIsLock(['season', 'companyOrder' + companyId, 'user' + userId]);
+  resourceManager.throwErrorIsResourceIsLock(['season', 'allCompanyOrders', `companyOrder${companyId}`, `user${userId}`]);
   // 先鎖定資源，再重新讀取一次資料進行運算
-  resourceManager.request('createSellOrder', ['companyOrder' + companyId, 'user' + userId], (release) => {
+  resourceManager.request('createSellOrder', [`companyOrder${companyId}`, `user${userId}`], (release) => {
     const directorData = dbDirectors.findOne({ companyId, userId }, {
       fields: {
         stocks: 1

--- a/server/methods/order/retrieveOrder.js
+++ b/server/methods/order/retrieveOrder.js
@@ -33,9 +33,9 @@ export function retrieveOrder(user, orderId) {
     throw new Meteor.Error(401, '該訂單並非使用者所有，撤回訂單失敗！');
   }
   const companyId = orderData.companyId;
-  resourceManager.throwErrorIsResourceIsLock(['season', 'companyOrder' + companyId, 'user' + userId]);
+  resourceManager.throwErrorIsResourceIsLock(['season', 'allCompanyOrders', `companyOrder${companyId}`, `user${userId}`]);
   // 先鎖定資源，再重新讀取一次資料進行運算
-  resourceManager.request('retrieveOrder', ['companyOrder' + companyId, 'user' + userId], (release) => {
+  resourceManager.request('retrieveOrder', [`companyOrder${companyId}`, `user${userId}`], (release) => {
     const user = Meteor.users.findOne(userId, {
       fields: {
         profile: 1


### PR DESCRIPTION
依照 https://acgn-stock.com/announcement/view/NwZG2i23KzTSgBTBG 之規劃
實作無量跌停機制

1. 修改 `recordListPrice` function 的寫法，使其可以被 await，以便讓特定工作在其之前或之後執行
2. 配合前項修改， `resourceManager` 新增 `requestPromise` 方法，以方便利用 async-await 語法
   等待其 callback 完成
2. 配合前前項修改， `sellFscStocks` function 將在價格更新時、`recordListPrice` 執行後才執行
   （解決價格更新與金管會賣股掛單的順序不一定的問題）
3. 增加無量跌停機制的 function `executeZeroVolumePriceDrop`，
   在價格更新時、`recordListPrice` 之前執行
4. `recordListPrice`、`sellFscStocks`
   使用新的 resouce lock key `allCompanyOrders`，取代單一公司的買賣單 lock，
   一律等待工作完成之後才解鎖，避免公司數多時更新到一半有人搶掛單的狀況
5. 配合前項修改，掛買賣單與撤單的 methods 增加 `allCompanyOrders` 的 recource lock 判斷