### PR TITLE
實作新稅制系統(現金股票分離課稅)

### DIFF
--- a/client/accountInfo/accountInfoTaxList.html
+++ b/client/accountInfo/accountInfoTaxList.html
@@ -1,9 +1,10 @@
 <template name="accountInfoTaxList">
-  <table class="table table-bordered mt-3 custom-responsive-table-md account-tax-list w-100" style="table-layout: fixed;">
+  <table class="table table-bordered mt-3 custom-responsive-table-md account-tax-list w-100" style="table-layout: automatic;">
     <thead>
       <tr>
         <th class="text-center text-nowrap" style="width: 160px">繳稅期限</th>
-        <th class="text-center text-nowrap">財稅額</th>
+        <th class="text-center text-nowrap">股票資產稅</th>
+        <th class="text-center text-nowrap">現金資產稅</th>
         <th class="text-center text-nowrap">殭屍稅</th>
         <th class="text-center text-nowrap ">逾期罰金</th>
         <th class="text-center text-nowrap">已繳納</th>
@@ -15,14 +16,17 @@
     <tbody>
     {{#each taxes in taxesList}}
       <tr>
-        <td class="text-right text-truncate text-nowrap" data-title="繳稅期限">
+        <td class="text-center text-truncate text-nowrap" data-title="繳稅期限">
             {{formatDateTimeText taxes.expireDate}}
         </td>
-        <td class="text-right text-truncate text-nowrap" data-title="財稅額" title="{{taxes.tax}}">
-            $ {{currencyFormat taxes.tax}}
+        <td class="text-right text-truncate text-nowrap" data-title="股票資產稅" title="{{taxes.stockTax}}">
+            $ {{currencyFormat taxes.stockTax}}
         </td>
-        <td class="text-right text-truncate text-nowrap" data-title="殭屍稅" title="{{taxes.zombie}}">
-            $ {{currencyFormat taxes.zombie}}
+        <td class="text-right text-truncate text-nowrap" data-title="現金資產稅" title="{{taxes.moneyTax}}">
+          $ {{currencyFormat taxes.moneyTax}}
+        </td>
+        <td class="text-right text-truncate text-nowrap" data-title="殭屍稅" title="{{taxes.zombieTax}}">
+            $ {{currencyFormat taxes.zombieTax}}
         </td>
         <td class="text-right text-truncate text-nowrap" data-title="逾期罰金" title="{{taxes.fine}}">
             $ {{currencyFormat taxes.fine}}
@@ -41,9 +45,9 @@
     {{else}}
       <tr class="default-content">
         {{#if isCurrentUser}}
-          <td class="text-center text-truncate p-1" colspan="6">目前沒有需要繳納的稅金！</td>
+          <td class="text-center text-truncate p-1" colspan="7">目前沒有需要繳納的稅金！</td>
         {{else}}
-          <td class="text-center text-truncate p-1" colspan="5">目前沒有需要繳納的稅金！</td>
+          <td class="text-center text-truncate p-1" colspan="6">目前沒有需要繳納的稅金！</td>
         {{/if}}
       </tr>
     {{/each}}

--- a/client/accountInfo/accountInfoTaxList.js
+++ b/client/accountInfo/accountInfoTaxList.js
@@ -50,7 +50,7 @@ Template.accountInfoTaxList.events({
     const taxData = dbTaxes.findOne(taxId);
     if (taxData) {
       const user = paramUser();
-      const totalNeedPay = taxData.tax + taxData.zombie + taxData.fine - taxData.paid;
+      const totalNeedPay = taxData.stockTax + taxData.moneyTax + taxData.zombieTax + taxData.fine - taxData.paid;
       const maxPayMoney = Math.min(user.profile.money, totalNeedPay);
       if (maxPayMoney < 1) {
         alertDialog.alert('您的金錢不足以繳納稅金！');

--- a/client/utils/displayLog.js
+++ b/client/utils/displayLog.js
@@ -244,7 +244,7 @@ Template.displayLog.helpers({
         return `【消費回饋】${users[0]}得到了「${company}」公司的產品消費回饋金$${currencyFormat(data.rebate)}！`;
       }
       case '季度賦稅': {
-        return `【季度賦稅】${users[0]}在此次商業季度中產生了$${currencyFormat(data.assetTax)}的財富稅與$${currencyFormat(data.zombieTax)}的殭屍稅！`;
+        return `【季度賦稅】${users[0]}在此次商業季度中產生了$${currencyFormat(data.stockTax)}的股票資產稅、$${currencyFormat(data.moneyTax)}的現金資產稅與$${currencyFormat(data.zombieTax)}的殭屍稅！`;
       }
       case '繳納稅金': {
         return `【繳納稅金】${users[0]}向系統繳納了$${currencyFormat(data.paid)}的稅金！`;

--- a/db/dbLog.js
+++ b/db/dbLog.js
@@ -172,7 +172,7 @@ export const logTypeList = [
   '消費回饋',
 
   /**
-   * 【季度賦稅】userId0在此次商業季度中產生了$data.assetTax的財富稅與$data.zombieTax的殭屍稅！
+   * 【季度賦稅】userId0在此次商業季度中產生了$data.stockTax的股票資產稅、$data.moneyTax的現金資產稅與$data.zombieTax的殭屍稅！
    */
   '季度賦稅',
 

--- a/db/dbTaxes.js
+++ b/db/dbTaxes.js
@@ -12,15 +12,20 @@ const schema = new SimpleSchema({
   userId: {
     type: String
   },
-  // 需繳納的財產稅金
-  tax: {
+  // 需繳納的股票稅
+  stockTax: {
     type: SimpleSchema.Integer,
-    min: 1
+    min: 0
+  },
+  // 需繳納的現金稅
+  moneyTax: {
+    type: SimpleSchema.Integer,
+    min: 0
   },
   // 需繳納的殭屍稅金
-  zombie: {
+  zombieTax: {
     type: SimpleSchema.Integer,
-    min: 1
+    min: 0
   },
   // 因逾期未繳產生的罰金
   fine: {

--- a/dev-utils/createSeedData.js
+++ b/dev-utils/createSeedData.js
@@ -61,7 +61,7 @@ if (Meteor.isServer && Meteor.isDevelopment) {
     });
 
     console.log('make user1 be admin...');
-    Meteor.users.update({ username: 'user1' }, { $set: { 'profile.isAdmin': true } });
+    Meteor.users.update({ username: 'user1' }, { $set: { 'profile.roles': 'superAdmin' } });
 
     console.log('create companies...');
     companyFactory.buildList(100).forEach((c) => {

--- a/dev-utils/factories.js
+++ b/dev-utils/factories.js
@@ -92,10 +92,13 @@ export const productFactory = new Factory()
 
 export const taxFactory = new Factory()
   .attrs({
-    tax() {
+    stockTax() {
       return faker.random.number({ min: 1 });
     },
-    zombie() {
+    moneyTax() {
+      return faker.random.number({ min: 1 });
+    },
+    zombieTax() {
       return faker.random.number({ min: 1 });
     },
     fine: 0,

--- a/server/imports/migrations/032-tax-separate.js
+++ b/server/imports/migrations/032-tax-separate.js
@@ -1,0 +1,20 @@
+import { defineMigration } from '/server/imports/utils/defineMigration';
+import { dbTaxes } from '/db/dbTaxes';
+import { dbLog } from '/db/dbLog';
+
+defineMigration({
+  version: 32,
+  name: 'tax separate',
+  async up() {
+    // 將 tax 換為 stockTax,  zombie 改名為 zombieTax
+    await dbTaxes.rawCollection().update({}, {
+      $rename: { 'tax': 'stockTax', 'zombie': 'zombieTax' },
+      $set: { 'moneyTax': 0 }
+    }, { multi: true });
+
+    await dbLog.rawCollection().update({ logType: '季度賦稅' }, {
+      $rename: { 'data.assetTax': 'data.stockTax' },
+      $set: { 'data.moneyTax': 0 }
+    }, { multi: true });
+  }
+});

--- a/server/imports/migrations/index.js
+++ b/server/imports/migrations/index.js
@@ -29,3 +29,4 @@ import './028-admin-gift-sending-system';
 import './029-enhancing-violation-case-tracking-system';
 import './030-rename-lastReadAccuseLogDate-to-lastReadFscLogDate-in-user-profile';
 import './031-add-activeUserCount-to-ruleAgendas';
+import './032-tax-separate';

--- a/server/methods/accounts/payTax.js
+++ b/server/methods/accounts/payTax.js
@@ -33,7 +33,7 @@ function payTax(user, taxId, amount) {
   if (! taxData) {
     throw new Meteor.Error(404, '找不到識別碼為「' + taxId + '」的稅金資料！');
   }
-  const totalNeedPay = taxData.tax + taxData.zombie + taxData.fine - taxData.paid;
+  const totalNeedPay = taxData.stockTax + taxData.moneyTax + taxData.zombieTax + taxData.fine - taxData.paid;
   if (amount > totalNeedPay) {
     throw new Meteor.Error(403, '繳納金額與應納金額不相符！');
   }
@@ -53,7 +53,7 @@ function payTax(user, taxId, amount) {
     if (! taxData) {
       throw new Meteor.Error(404, '找不到識別碼為「' + taxId + '」的稅金資料！');
     }
-    const totalNeedPay = taxData.tax + taxData.zombie + taxData.fine - taxData.paid;
+    const totalNeedPay = taxData.stockTax + taxData.moneyTax + taxData.zombieTax + taxData.fine - taxData.paid;
     if (amount > totalNeedPay) {
       throw new Meteor.Error(403, '繳納金額與應納金額不相符！');
     }

--- a/server/paySalaryAndCheckTax.js
+++ b/server/paySalaryAndCheckTax.js
@@ -158,7 +158,7 @@ function checkTax(todayBeginTime) {
       const createdAtBasicTime = Date.now();
       // 增加稅單罰金
       if (overdueDay < 7) {
-        const amount = Math.ceil(taxData.tax * 0.1);
+        const amount = Math.ceil((taxData.stockTax + taxData.moneyTax) * 0.1);
         taxesBulk
           .find({
             _id: taxId
@@ -177,7 +177,7 @@ function checkTax(todayBeginTime) {
       }
       // 開始強制徵收
       else {
-        const needPay = taxData.tax + taxData.zombie - taxData.paid + taxData.fine;
+        const needPay = taxData.stockTax + taxData.moneyTax + taxData.zombieTax + taxData.fine - taxData.paid;
         let imposedMoney = 0;
         // 先徵收使用者的現金
         const userData = Meteor.users.findOne(userId, {


### PR DESCRIPTION
依照 https://acgn-stock.com/announcement/view/L9HsZTEKYPSbaSjj8 之規劃
實作新稅制系統(現金股票分離課稅)
原資產稅分裂為 股票資產稅 與 現金資產稅

1. 修改 generateNoStockUserWealthList() 的輸出，增加 money 的項目，以利後續使用
2. 將稅金計算函式獨立成 computeTax() 方便查表算稅金
3. tax 分為 stockTax 與 moneyTax
4. 因應前項改動，逾期繳稅罰金由 tax的10% 改為 (stockTax + moneyTax)的10%
4. 捨棄log中的assetTax，新增stockTax與moneyTax
5. tax中的 zombie 改為 zombieTax
6. 將 dbTaxes 中誤植的 min: 1 改為 min: 0
7. 改變 accountInfoTaxList 的table排版方式，使其可以配合內容調整長度