### PR TITLE
修正 有員工的公司在計算分紅時多扣錢的問題 與 產品中心未正確限制訂閱次數的問題

### DIFF
--- a/client/utils/pagination.js
+++ b/client/utils/pagination.js
@@ -15,8 +15,7 @@ Template.pagination.helpers({
   pages() {
     const totalCount = Counts.get(this.counterName) || dbVariables.get(this.useVariableForTotalCount);
     const totalPages = Math.ceil(totalCount / this.dataNumberPerPage);
-    let displayCount = 6;
-    displayCount = Math.max(3, displayCount);
+    const displayCount = 6;
 
     if (totalPages <= displayCount) {
       return _.range(1, totalPages + 1);

--- a/server/functions/company/summarizeAndDistributeProfits.js
+++ b/server/functions/company/summarizeAndDistributeProfits.js
@@ -50,7 +50,7 @@ export function summarizeAndDistributeProfits() {
 
     // 計算員工投票獎金
     const employeeProductVotingRewardMap = computeEmployeeProductVotingRewardMap(companyData, remainingProfit);
-    remainingProfit -= Object.values(employeeBonusMap).reduce(add, 0);
+    remainingProfit -= Object.values(employeeProductVotingRewardMap).reduce(add, 0);
     if (! _.isEmpty(employeeProductVotingRewardMap)) {
       companyBonusMap.employeeProductVotingReward = employeeProductVotingRewardMap;
     }

--- a/server/publications/product/productListBySeasonId.js
+++ b/server/publications/product/productListBySeasonId.js
@@ -49,4 +49,4 @@ Meteor.publish('productListBySeasonId', function({ seasonId, sortBy, sortDir, of
   });
 });
 // 一分鐘最多重複訂閱10次
-limitSubscription('allAdvertising', 10);
+limitSubscription('productListBySeasonId', 10);


### PR DESCRIPTION
- 計算分紅時因誤用了錯誤的變數，使得應該只扣1%的員工獎勵金 變成 多扣一次員工分紅(預設為5%)
- 產品中心的訂閱限制因誤用別的名字導致沒有被限制