### PR TITLE
 實作市值過小時的跌幅限制 (新創低市值緩跌)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ typings/
 
 # dotenv environment variables file
 .env
+
+# vscode settings
+.vscode/
+jsconfig.json

--- a/client/utils/methods.js
+++ b/client/utils/methods.js
@@ -1,6 +1,6 @@
 import { _ } from 'meteor/underscore';
 import { Meteor } from 'meteor/meteor';
-import { dbCompanies } from '/db/dbCompanies';
+import { dbCompanies, getPriceLimits } from '/db/dbCompanies';
 import { dbFoundations } from '/db/dbFoundations';
 import { dbDirectors } from '/db/dbDirectors';
 import { dbOrders } from '/db/dbOrders';
@@ -71,14 +71,8 @@ export function createBuyOrder(user, companyData) {
     return false;
   }
   const userMoney = user.profile.money;
-  const minimumUnitPrice = Math.max(Math.floor(companyData.listPrice * 0.85), 1);
-  let maximumUnitPrice;
-  if (companyData.listPrice < dbVariables.get('lowPriceThreshold')) {
-    maximumUnitPrice = Math.min(userMoney, Math.ceil(companyData.listPrice * 1.3));
-  }
-  else {
-    maximumUnitPrice = Math.min(userMoney, Math.ceil(companyData.listPrice * 1.15));
-  }
+  const minimumUnitPrice = getPriceLimits(companyData).lower;
+  const maximumUnitPrice = getPriceLimits(companyData).upper;
   if (minimumUnitPrice > maximumUnitPrice) {
     alertDialog.alert('您的金錢不足以購買此公司的股票！');
 
@@ -149,14 +143,8 @@ export function createSellOrder(user, companyData) {
 
     return false;
   }
-  const minimumUnitPrice = Math.max(Math.floor(companyData.listPrice * 0.85), 1);
-  let maximumUnitPrice;
-  if (companyData.listPrice < dbVariables.get('lowPriceThreshold')) {
-    maximumUnitPrice = Math.ceil(companyData.listPrice * 1.3);
-  }
-  else {
-    maximumUnitPrice = Math.ceil(companyData.listPrice * 1.15);
-  }
+  const minimumUnitPrice = getPriceLimits(companyData).lower;
+  const maximumUnitPrice = getPriceLimits(companyData).upper;
   alertDialog.dialog({
     type: 'prompt',
     title: '股份賣出',

--- a/config.js
+++ b/config.js
@@ -15,6 +15,15 @@ export const config = {
     min: 10800000,
     max: 21600000
   },
+  priceLimits: { // 訂單漲跌停幅度設定
+    normal: { // 一般公司
+      upper: 1.15,
+      lower: 0.85
+    },
+    lowPriceCompany: {
+      upper: 1.30
+    }
+  },
   zeroVolumePriceDrop: { // 無量跌停設定
     orderAgeThreshold: 21600000, // 賣單需要存在的時間 (ms)
     tradeVolumeLookbackTime: 86400000 // 交易量的統計時間 (ms)

--- a/config.js
+++ b/config.js
@@ -22,7 +22,17 @@ export const config = {
     },
     lowPriceCompany: {
       upper: 1.30
+    },
+    firstStageValueLowerThanCapitalCompany: {
+      lower: 0.95
+    },
+    secondStageValueLowerThanCapitalCompany: {
+      lower: 0.9
     }
+  },
+  valueLowerThanCapitalCompanyFallLimitTimes: { // 公司創立多少時間內 市值低於資本額將進行跌幅限制
+    firstStageTime: 604800000, // 在多少時間(ms)內 進行第一階段的跌幅限制
+    secondStageTime: 1209600000
   },
   zeroVolumePriceDrop: { // 無量跌停設定
     orderAgeThreshold: 21600000, // 賣單需要存在的時間 (ms)

--- a/config.json
+++ b/config.json
@@ -15,6 +15,15 @@
       "min": 10800000,
       "max": 21600000
     },
+    "priceLimits": {
+      "normal": {
+        "upper": 1.15,
+        "lower": 0.85
+      },
+      "lowPriceCompany": {
+        "upper": 1.30
+      }
+    },
     "zeroVolumePriceDrop": {
       "orderAgeThreshold": 21600000,
       "tradeVolumeLookbackTime": 86400000

--- a/config.json
+++ b/config.json
@@ -22,7 +22,17 @@
       },
       "lowPriceCompany": {
         "upper": 1.30
+      },
+      "firstStageValueLowerThanCapitalCompany": {
+        "lower": 0.95
+      },
+      "secondStageValueLowerThanCapitalCompany": {
+        "lower": 0.9
       }
+    },
+    "valueLowerThanCapitalCompanyFallLimitTimes": {
+      "firstStageTime": 604800000,
+      "secondStageTime": 1209600000
     },
     "zeroVolumePriceDrop": {
       "orderAgeThreshold": 21600000,

--- a/db/dbCompanies.js
+++ b/db/dbCompanies.js
@@ -90,19 +90,59 @@ export function getPriceLimits(companyData) {
 
 function getPriceUpperLimit(companyData) {
   const priceLimits = Meteor.settings.public.priceLimits;
+  let upperPrice;
   if (isLowPriceCompany(companyData)) {
-    return Math.ceil(companyData.listPrice * priceLimits.lowPriceCompany.upper);
+    upperPrice = companyData.listPrice * priceLimits.lowPriceCompany.upper;
   }
   else {
-    return Math.ceil(companyData.listPrice * priceLimits.normal.upper);
+    upperPrice = companyData.listPrice * priceLimits.normal.upper;
   }
+
+  return Math.ceil(upperPrice);
 }
 
 function getPriceLowerLimit(companyData) {
   const priceLimits = Meteor.settings.public.priceLimits;
+  let lowerPrice;
+  if (isFirstStageValueLowerThanCapitalCompany(companyData)) {
+    lowerPrice = companyData.listPrice * priceLimits.firstStageValueLowerThanCapitalCompany.lower;
+  }
+  else if (isSecondStageValueLowerThanCapitalCompany(companyData)) {
+    lowerPrice = companyData.listPrice * priceLimits.secondStageValueLowerThanCapitalCompany.lower;
+  }
+  else {
+    lowerPrice = companyData.listPrice * priceLimits.normal.lower;
+  }
 
-  return Math.max(Math.floor(companyData.listPrice * priceLimits.normal.lower), 1);
+  return Math.max(Math.floor(lowerPrice), 1);
 }
+
+function isValueLowerThanCapital(companyData) {
+  return companyData.totalValue < companyData.capital;
+}
+
+function isFirstStageValueLowerThanCapitalCompany(companyData) {
+  const firstStageTime = Meteor.settings.public.valueLowerThanCapitalCompanyFallLimitTimes.firstStageTime;
+  const createdTime = Date.now() - companyData.createdAt.getTime();
+  if (createdTime < firstStageTime) {
+    return isValueLowerThanCapital(companyData);
+  }
+  else {
+    return false;
+  }
+}
+
+function isSecondStageValueLowerThanCapitalCompany(companyData) {
+  const secondStageTime = Meteor.settings.public.valueLowerThanCapitalCompanyFallLimitTimes.secondStageTime;
+  const createdTime = Date.now() - companyData.createdAt.getTime();
+  if (createdTime < secondStageTime) {
+    return isValueLowerThanCapital(companyData);
+  }
+  else {
+    return false;
+  }
+}
+
 
 const schema = new SimpleSchema({
   // 公司名稱

--- a/db/dbCompanies.js
+++ b/db/dbCompanies.js
@@ -4,6 +4,7 @@ import { Mongo } from 'meteor/mongo';
 import SimpleSchema from 'simpl-schema';
 
 import { dbProducts } from './dbProducts';
+import { dbVariables } from './dbVariables';
 
 // 公司資料集
 export const dbCompanies = new Mongo.Collection('companies');
@@ -63,6 +64,41 @@ export function getUsedProductionFund(companyData) {
 // 取得公司剩餘可用的生產資金
 export function getAvailableProductionFund(companyData) {
   return getTotalProductionFund(companyData) - getUsedProductionFund(companyData);
+}
+
+// 判斷是否為低價公司
+export function isLowPriceCompany(companyData) {
+  const lowPriceThreshold = dbVariables.get('lowPriceThreshold');
+
+  return companyData.listPrice < lowPriceThreshold;
+}
+
+// 判斷是否為高價公司
+export function isHighPriceCompany(companyData) {
+  const highPriceThreshold = dbVariables.get('highPriceThreshold');
+
+  return companyData.listPrice >= highPriceThreshold;
+}
+
+// 取得買賣單的上下限
+export function getPriceLimits(companyData) {
+  const upper = getPriceUpperLimit(companyData);
+  const lower = getPriceLowerLimit(companyData);
+
+  return { upper, lower };
+}
+
+function getPriceUpperLimit(companyData) {
+  if (isLowPriceCompany(companyData)) {
+    return Math.ceil(companyData.listPrice * 1.30);
+  }
+  else {
+    return Math.ceil(companyData.listPrice * 1.15);
+  }
+}
+
+function getPriceLowerLimit(companyData) {
+  return Math.max(Math.floor(companyData.listPrice * 0.85), 1);
 }
 
 const schema = new SimpleSchema({

--- a/db/dbCompanies.js
+++ b/db/dbCompanies.js
@@ -80,7 +80,11 @@ export function isHighPriceCompany(companyData) {
   return companyData.listPrice >= highPriceThreshold;
 }
 
-// 取得買賣單的上下限
+/**
+ * 取得買賣單的上下限
+ * @param {Object} companyData 內容必須包含 listPrice, capital, totalValue, createdAt
+ * @returns {Object} upper, lower
+ */
 export function getPriceLimits(companyData) {
   const upper = getPriceUpperLimit(companyData);
   const lower = getPriceLowerLimit(companyData);

--- a/db/dbCompanies.js
+++ b/db/dbCompanies.js
@@ -89,16 +89,19 @@ export function getPriceLimits(companyData) {
 }
 
 function getPriceUpperLimit(companyData) {
+  const priceLimits = Meteor.settings.public.priceLimits;
   if (isLowPriceCompany(companyData)) {
-    return Math.ceil(companyData.listPrice * 1.30);
+    return Math.ceil(companyData.listPrice * priceLimits.lowPriceCompany.upper);
   }
   else {
-    return Math.ceil(companyData.listPrice * 1.15);
+    return Math.ceil(companyData.listPrice * priceLimits.normal.upper);
   }
 }
 
 function getPriceLowerLimit(companyData) {
-  return Math.max(Math.floor(companyData.listPrice * 0.85), 1);
+  const priceLimits = Meteor.settings.public.priceLimits;
+
+  return Math.max(Math.floor(companyData.listPrice * priceLimits.normal.lower), 1);
 }
 
 const schema = new SimpleSchema({

--- a/integration-test/server/functions/company/releaseStocksForHighPrice.test.js
+++ b/integration-test/server/functions/company/releaseStocksForHighPrice.test.js
@@ -1,3 +1,4 @@
+import { Meteor } from 'meteor/meteor';
 import { resetDatabase } from 'meteor/xolvio:cleaner';
 import expect from 'must';
 import mustSinon from 'must-sinon';
@@ -42,7 +43,7 @@ describe('function releaseStocksForHighPrice', function() {
     });
 
     expect(orderData).to.exist();
-    orderData.unitPrice.must.be.equal(Math.ceil(listPrice * 1.15)); // 漲停價
+    orderData.unitPrice.must.be.equal(Math.ceil(listPrice * Meteor.settings.public.priceLimits.normal.upper)); // 漲停價
     orderData.amount.must.be.between(1, Math.floor(Math.sqrt(totalRelease)));
 
     const logData = dbLog.findOne({ logType: '公司釋股', companyId });

--- a/integration-test/server/functions/company/releaseStocksForNoDeal.test.js
+++ b/integration-test/server/functions/company/releaseStocksForNoDeal.test.js
@@ -22,7 +22,7 @@ describe('function releaseStocksForNoDeal', function() {
   const defaultListPrice = 100;
   const defaultTotalRelease = 1000;
   const defaultCreatedAt = new Date(0);
-  const defaultUpperPriceLimit = Math.ceil(defaultListPrice * 1.15);
+  const defaultUpperPriceLimit = Math.ceil(defaultListPrice * Meteor.settings.public.priceLimits.normal.upper);
 
   const buyOrderFactory = new Factory()
     .attrs({
@@ -85,7 +85,7 @@ describe('function releaseStocksForNoDeal', function() {
     }
 
     describe('with normal company', function() {
-      runTests({ upperPriceLimit: Math.ceil(defaultListPrice * 1.15) });
+      runTests({ upperPriceLimit: Math.ceil(defaultListPrice * Meteor.settings.public.priceLimits.normal.upper) });
     });
 
     describe('with low-price company', function() {
@@ -93,7 +93,7 @@ describe('function releaseStocksForNoDeal', function() {
         dbVariables.set('lowPriceThreshold', defaultListPrice + 1);
       });
 
-      runTests({ upperPriceLimit: Math.ceil(defaultListPrice * 1.30) });
+      runTests({ upperPriceLimit: Math.ceil(defaultListPrice * Meteor.settings.public.priceLimits.lowPriceCompany.upper) });
     });
   });
 

--- a/integration-test/server/methods/order/createBuyOrder.test.js
+++ b/integration-test/server/methods/order/createBuyOrder.test.js
@@ -1,0 +1,150 @@
+import { Meteor } from 'meteor/meteor';
+import { resetDatabase } from 'meteor/xolvio:cleaner';
+import { Accounts } from 'meteor/accounts-base';
+import expect from 'must';
+
+import { createBuyOrder } from '/server/methods/order/createBuyOrder';
+import { dbOrders } from '/db/dbOrders';
+import { dbCompanies, getPriceLimits } from '/db/dbCompanies';
+import { companyFactory, pttUserFactory } from '/dev-utils/factories';
+
+describe('method createBuyOrder', function() {
+  this.timeout(10000);
+
+  let user;
+  let orderData;
+
+  beforeEach(function() {
+    resetDatabase();
+    user = {
+      _id: 'someUser',
+      profile: {
+        money: 1000000,
+        isInVacation: false,
+        notPayTax: false,
+        ban: []
+      }
+    };
+    orderData = {
+      userId: 'someUser',
+      companyId: 'someCompany',
+      orderType: '購入',
+      unitPrice: 100,
+      amount: 10
+    };
+  });
+
+  it('should fail if the user is in vacation', function() {
+    user.profile.isInVacation = true;
+    createBuyOrder.bind(null, user, orderData)
+      .must.throw(Meteor.Error, '您現在正在渡假中，請好好放鬆！ [403]');
+  });
+
+  it('should fail if the user is not pay tax', function() {
+    user.profile.notPayTax = true;
+    createBuyOrder.bind(null, user, orderData)
+      .must.throw(Meteor.Error, '您現在有稅單逾期未繳！ [403]');
+  });
+
+  it('should fail if the user is been ban deal', function() {
+    user.profile.ban.push('deal');
+    createBuyOrder.bind(null, user, orderData)
+      .must.throw(Meteor.Error, '您現在被金融管理會禁止了所有投資下單行為！ [403]');
+  });
+
+  it('should fail if the unit price is lower than 1', function() {
+    orderData.unitPrice = 0;
+    createBuyOrder.bind(null, user, orderData)
+      .must.throw(Meteor.Error, '購買單價不可小於1！ [403]');
+  });
+
+  it('should fail if the amount is lower than 1', function() {
+    orderData.amount = 0;
+    createBuyOrder.bind(null, user, orderData)
+      .must.throw(Meteor.Error, '購買數量不可小於1！ [403]');
+  });
+
+  it('should fail if the user does not have enough money', function() {
+    user.profile.money = 9;
+    orderData.unitPrice = 2;
+    orderData.amount = 5;
+    createBuyOrder.bind(null, user, orderData)
+      .must.throw(Meteor.Error, '剩餘金錢不足，訂單無法成立！ [403]');
+  });
+
+  it('should fail if the user is selling same company stock', function() {
+    dbOrders.insert({
+      companyId: orderData.companyId,
+      userId: orderData.userId,
+      orderType: '賣出',
+      unitPrice: 100,
+      amount: 100,
+      done: 0,
+      createdAt: new Date(0)
+    });
+    createBuyOrder.bind(null, user, orderData)
+      .must.throw(Meteor.Error, '有賣出該公司股票的訂單正在執行中，無法同時下達購買的訂單！ [403]');
+  });
+
+  it('should fail if the company does not exist', function() {
+    createBuyOrder.bind(null, user, orderData)
+      .must.throw(Meteor.Error, '不存在的公司股票，訂單無法成立！ [404]');
+  });
+
+  it('should fail if the company is been seal', function() {
+    const companyName = 'someCompany';
+    const companyId = dbCompanies.insert(companyFactory.build({
+      companyName,
+      isSeal: true
+    }));
+    orderData.companyId = companyId;
+    createBuyOrder.bind(null, user, orderData)
+      .must.throw(Meteor.Error, `「${companyName}」公司已被金融管理委員會查封關停了！ [403]`);
+  });
+
+  describe('when company is exist', function() {
+    let companyId;
+    let companyData;
+
+    beforeEach(function() {
+      companyId = dbCompanies.insert(companyFactory.build({ listPrice: 100, isSeal: false }));
+      companyData = dbCompanies.findOne(companyId);
+      orderData.companyId = companyId;
+    });
+
+    it('should fail if the price is higher than the upper price', function() {
+      const price = getPriceLimits(companyData).upper + 1;
+      orderData.unitPrice = price;
+      createBuyOrder.bind(null, user, orderData)
+        .must.throw(Meteor.Error, '每股單價不可大於該股票的漲停價格！ [403]');
+    });
+
+    it('should fail if the price is lower than the lower price', function() {
+      const price = getPriceLimits(companyData).lower - 1;
+      orderData.unitPrice = price;
+      createBuyOrder.bind(null, user, orderData)
+        .must.throw(Meteor.Error, '每股單價不可低於該股票的跌停價格！ [403]');
+    });
+
+    describe('when user is exist', function() {
+      let userId;
+
+      beforeEach(function() {
+        userId = Accounts.createUser(pttUserFactory.build());
+        user._id = userId;
+        orderData.userId = userId;
+        Meteor.users.update(userId, { $set: { 'profile.money': 1000000 } });
+      });
+
+      it('should success create buy order', function() {
+        createBuyOrder.bind(null, user, orderData).must.not.throw();
+        const buyOrder = dbOrders.findOne({
+          userId: orderData.userId,
+          companyId: orderData.companyId,
+          orderType: '購入'
+        });
+        expect(buyOrder).to.exist();
+      });
+    });
+  });
+});

--- a/integration-test/server/methods/order/createSellOrder.test.js
+++ b/integration-test/server/methods/order/createSellOrder.test.js
@@ -1,0 +1,214 @@
+import { Meteor } from 'meteor/meteor';
+import { resetDatabase } from 'meteor/xolvio:cleaner';
+import { Accounts } from 'meteor/accounts-base';
+import expect from 'must';
+
+import { createSellOrder } from '/server/methods/order/createSellOrder';
+import { dbOrders } from '/db/dbOrders';
+import { dbCompanies, getPriceLimits } from '/db/dbCompanies';
+import { companyFactory, pttUserFactory } from '/dev-utils/factories';
+import { dbDirectors } from '/db/dbDirectors';
+
+describe('method createSellOrder', function() {
+  this.timeout(10000);
+
+  let user;
+  let orderData;
+
+  beforeEach(function() {
+    resetDatabase();
+    user = {
+      _id: 'someUser',
+      profile: {
+        money: 1000000,
+        isInVacation: false,
+        notPayTax: false,
+        ban: []
+      }
+    };
+    orderData = {
+      userId: 'someUser',
+      companyId: 'someCompany',
+      orderType: '賣出',
+      unitPrice: 100,
+      amount: 10
+    };
+  });
+
+  it('should fail if the user is in vacation', function() {
+    user.profile.isInVacation = true;
+    createSellOrder.bind(null, user, orderData)
+      .must.throw(Meteor.Error, '您現在正在渡假中，請好好放鬆！ [403]');
+  });
+
+  it('should fail if the user is been ban deal', function() {
+    user.profile.ban.push('deal');
+    createSellOrder.bind(null, user, orderData)
+      .must.throw(Meteor.Error, '您現在被金融管理會禁止了所有投資下單行為！ [403]');
+  });
+
+  it('should fail if the unit price is lower than 1', function() {
+    orderData.unitPrice = 0;
+    createSellOrder.bind(null, user, orderData)
+      .must.throw(Meteor.Error, '販賣單價不可小於1！ [403]');
+  });
+
+  it('should fail if the amount is lower than 1', function() {
+    orderData.amount = 0;
+    createSellOrder.bind(null, user, orderData)
+      .must.throw(Meteor.Error, '販賣數量不可小於1！ [403]');
+  });
+
+  it('should fail if the user is selling same company stock', function() {
+    dbOrders.insert({
+      companyId: orderData.companyId,
+      userId: orderData.userId,
+      orderType: '購入',
+      unitPrice: 100,
+      amount: 100,
+      done: 0,
+      createdAt: new Date(0)
+    });
+    createSellOrder.bind(null, user, orderData)
+      .must.throw(Meteor.Error, '有買入該公司股票的訂單正在執行中，無法同時下達賣出的訂單！ [403]');
+  });
+
+  it('should fail if the user does not have any stock', function() {
+    createSellOrder.bind(null, user, orderData)
+      .must.throw(Meteor.Error, '擁有的股票數量不足，訂單無法成立！ [403]');
+  });
+
+  it('should fail if the user does not have enough stock', function() {
+    dbDirectors.insert({
+      companyId: orderData.companyId,
+      userId: orderData.userId,
+      stocks: orderData.amount - 1,
+      createdAt: new Date()
+    });
+    createSellOrder.bind(null, user, orderData)
+      .must.throw(Meteor.Error, '擁有的股票數量不足，訂單無法成立！ [403]');
+  });
+
+
+  describe('when the user has enough stock', function() {
+    beforeEach(function() {
+      dbDirectors.insert({
+        companyId: orderData.companyId,
+        userId: orderData.userId,
+        stocks: orderData.amount,
+        createdAt: new Date()
+      });
+    });
+
+    it('should fail if the company does not exist', function() {
+      createSellOrder.bind(null, user, orderData)
+        .must.throw(Meteor.Error, '不存在的公司股票，訂單無法成立！ [404]');
+    });
+  });
+
+  describe('when the user has enough stock, company is exist', function() {
+    const companyName = 'someCompany';
+    let companyId;
+    let companyData;
+
+    beforeEach(function() {
+      companyId = dbCompanies.insert(companyFactory.build({
+        companyName,
+        listPrice: 100,
+        isSeal: false
+      }));
+      companyData = dbCompanies.findOne(companyId);
+      orderData.companyId = companyId;
+
+      dbDirectors.insert({
+        companyId: orderData.companyId,
+        userId: orderData.userId,
+        stocks: orderData.amount,
+        createdAt: new Date()
+      });
+    });
+
+    it('should fail if the company is been seal', function() {
+      dbCompanies.update(companyId, { $set: { isSeal: true } });
+      orderData.companyId = companyId;
+      createSellOrder.bind(null, user, orderData)
+        .must.throw(Meteor.Error, `「${companyName}」公司已被金融管理委員會查封關停了！ [403]`);
+    });
+
+    it('should fail if the price is higher than the upper price', function() {
+      const price = getPriceLimits(companyData).upper + 1;
+      orderData.unitPrice = price;
+      createSellOrder.bind(null, user, orderData)
+        .must.throw(Meteor.Error, '每股單價不可大於該股票的漲停價格！ [403]');
+    });
+
+    it('should fail if the price is lower than the lower price', function() {
+      const price = getPriceLimits(companyData).lower - 1;
+      orderData.unitPrice = price;
+      createSellOrder.bind(null, user, orderData)
+        .must.throw(Meteor.Error, '每股單價不可低於該股票的跌停價格！ [403]');
+    });
+  });
+
+  describe('when the user has enough stock, company is exist, user is exist', function() {
+    const companyName = 'someCompany';
+    let companyId;
+    let userId;
+
+    beforeEach(function() {
+      userId = Accounts.createUser(pttUserFactory.build());
+      user._id = userId;
+      orderData.userId = userId;
+
+      companyId = dbCompanies.insert(companyFactory.build({
+        companyName,
+        listPrice: 100,
+        isSeal: false
+      }));
+      orderData.companyId = companyId;
+
+      dbDirectors.insert({
+        companyId: orderData.companyId,
+        userId: orderData.userId,
+        stocks: orderData.amount,
+        createdAt: new Date()
+      });
+    });
+
+    it('should success create buy order and do not have directorData', function() {
+      dbDirectors.update({ companyId, userId }, { $set: { stocks: orderData.amount } });
+      createSellOrder.bind(null, user, orderData).must.not.throw();
+      const sellOrder = dbOrders.findOne({
+        userId: orderData.userId,
+        companyId: orderData.companyId,
+        orderType: '賣出'
+      });
+      expect(sellOrder).to.exist();
+
+      const directorData = dbDirectors.findOne({ companyId, userId }, {
+        fields: {
+          stocks: 1
+        }
+      });
+      expect(directorData).to.not.exist();
+    });
+
+    it('should success create buy order and still have directorData', function() {
+      dbDirectors.update({ companyId, userId }, { $set: { stocks: orderData.amount + 1 } });
+      createSellOrder.bind(null, user, orderData).must.not.throw();
+      const sellOrder = dbOrders.findOne({
+        userId: orderData.userId,
+        companyId: orderData.companyId,
+        orderType: '賣出'
+      });
+      expect(sellOrder).to.exist();
+
+      const directorData = dbDirectors.findOne({ companyId, userId }, {
+        fields: {
+          stocks: 1
+        }
+      });
+      expect(directorData).to.exist();
+    });
+  });
+});

--- a/server/functions/company/executeZeroVolumePriceDrop.js
+++ b/server/functions/company/executeZeroVolumePriceDrop.js
@@ -1,9 +1,9 @@
 import { _ } from 'meteor/underscore';
 import { Meteor } from 'meteor/meteor';
 
-import { dbCompanies } from '/db/dbCompanies';
+import { dbCompanies, getPriceLimits } from '/db/dbCompanies';
 import { dbOrders } from '/db/dbOrders';
-import { calculateDealAmount, getPriceLimits } from '/server/functions/company/helpers';
+import { calculateDealAmount } from '/server/functions/company/helpers';
 import { resourceManager } from '/server/imports/threading/resourceManager';
 
 export function executeZeroVolumePriceDrop() {

--- a/server/functions/company/helpers.js
+++ b/server/functions/company/helpers.js
@@ -18,18 +18,23 @@ export function isHighPriceCompany(companyData) {
 
 // 取得買賣單的上下限
 export function getPriceLimits(companyData) {
+  const upper = getPriceUpperLimit(companyData);
+  const lower = getPriceLowerLimit(companyData);
+
+  return { upper, lower };
+}
+
+function getPriceUpperLimit(companyData) {
   if (isLowPriceCompany(companyData)) {
-    return {
-      upper: Math.ceil(companyData.listPrice * 1.30),
-      lower: Math.max(Math.floor(companyData.listPrice * 0.85), 1)
-    };
+    return Math.ceil(companyData.listPrice * 1.30);
   }
   else {
-    return {
-      upper: Math.ceil(companyData.listPrice * 1.15),
-      lower: Math.max(Math.floor(companyData.listPrice * 0.85), 1)
-    };
+    return Math.ceil(companyData.listPrice * 1.15);
   }
+}
+
+function getPriceLowerLimit(companyData) {
+  return Math.max(Math.floor(companyData.listPrice * 0.85), 1);
 }
 
 // 統計一段時間之內的交易數量

--- a/server/functions/company/helpers.js
+++ b/server/functions/company/helpers.js
@@ -1,41 +1,6 @@
 import { dbOrders } from '/db/dbOrders';
-import { dbVariables } from '/db/dbVariables';
 import { dbLog } from '/db/dbLog';
-
-// 判斷是否為低價公司
-export function isLowPriceCompany(companyData) {
-  const lowPriceThreshold = dbVariables.get('lowPriceThreshold');
-
-  return companyData.listPrice < lowPriceThreshold;
-}
-
-// 判斷是否為高價公司
-export function isHighPriceCompany(companyData) {
-  const highPriceThreshold = dbVariables.get('highPriceThreshold');
-
-  return companyData.listPrice >= highPriceThreshold;
-}
-
-// 取得買賣單的上下限
-export function getPriceLimits(companyData) {
-  const upper = getPriceUpperLimit(companyData);
-  const lower = getPriceLowerLimit(companyData);
-
-  return { upper, lower };
-}
-
-function getPriceUpperLimit(companyData) {
-  if (isLowPriceCompany(companyData)) {
-    return Math.ceil(companyData.listPrice * 1.30);
-  }
-  else {
-    return Math.ceil(companyData.listPrice * 1.15);
-  }
-}
-
-function getPriceLowerLimit(companyData) {
-  return Math.max(Math.floor(companyData.listPrice * 0.85), 1);
-}
+import { getPriceLimits } from '/db/dbCompanies';
 
 // 統計一段時間之內的交易數量
 export function calculateDealAmount(companyData, lookBackTime) {

--- a/server/functions/company/releaseStocksForHighPrice.js
+++ b/server/functions/company/releaseStocksForHighPrice.js
@@ -35,7 +35,10 @@ export function releaseStocksForHighPrice() {
           fields: {
             _id: 1,
             listPrice: 1,
-            totalRelease: 1
+            totalRelease: 1,
+            capital: 1,
+            totalValue: 1,
+            createdAt: 1
           }
         });
 

--- a/server/functions/company/releaseStocksForHighPrice.js
+++ b/server/functions/company/releaseStocksForHighPrice.js
@@ -2,10 +2,9 @@ import { Meteor } from 'meteor/meteor';
 
 import { createOrder } from '/server/imports/createOrder';
 import { resourceManager } from '/server/imports/threading/resourceManager';
-import { dbCompanies } from '/db/dbCompanies';
+import { dbCompanies, getPriceLimits } from '/db/dbCompanies';
 import { dbOrders } from '/db/dbOrders';
 import { dbVariables } from '/db/dbVariables';
-import { getPriceLimits } from './helpers';
 
 // 記錄高價釋股時間
 export function updateReleaseStocksForHighPricePeriod() {

--- a/server/functions/company/releaseStocksForNoDeal.js
+++ b/server/functions/company/releaseStocksForNoDeal.js
@@ -26,7 +26,15 @@ export function releaseStocksForNoDeal() {
       resourceManager.request('releaseStocksForNoDeal', [`companyOrder${companyId}`], (release) => {
         const { releaseStocksForNoDealTradeLogLookbackIntervalTime: lookbackTime } = Meteor.settings.public;
 
-        const companyData = dbCompanies.findOne(companyId, { fields: { _id: 1, listPrice: 1 } });
+        const companyData = dbCompanies.findOne(companyId, {
+          fields: {
+            _id: 1,
+            listPrice: 1,
+            capital: 1,
+            totalValue: 1,
+            createdAt: 1
+          }
+        });
         const dealAmount = calculateDealAmount(companyData, lookbackTime);
         const highPriceBuyAmount = calculateHighPriceBuyAmount(companyData);
 

--- a/server/functions/company/releaseStocksForNoDeal.js
+++ b/server/functions/company/releaseStocksForNoDeal.js
@@ -2,9 +2,9 @@ import { Meteor } from 'meteor/meteor';
 
 import { createOrder } from '/server/imports/createOrder';
 import { resourceManager } from '/server/imports/threading/resourceManager';
-import { dbCompanies } from '/db/dbCompanies';
+import { dbCompanies, getPriceLimits } from '/db/dbCompanies';
 import { dbVariables } from '/db/dbVariables';
-import { calculateHighPriceBuyAmount, calculateDealAmount, getPriceLimits } from './helpers';
+import { calculateHighPriceBuyAmount, calculateDealAmount } from './helpers';
 
 export function updateReleaseStocksForNoDealPeriod() {
   const { min: intervalMin, max: intervalMax } = Meteor.settings.public.releaseStocksForNoDealInterval;

--- a/server/methods/order/createBuyOrder.js
+++ b/server/methods/order/createBuyOrder.js
@@ -59,7 +59,10 @@ export function createBuyOrder(user, orderData) {
       companyName: 1,
       listPrice: 1,
       lastPrice: 1,
-      isSeal: 1
+      isSeal: 1,
+      capital: 1,
+      totalValue: 1,
+      createdAt: 1
     }
   });
   if (! companyData) {
@@ -94,7 +97,10 @@ export function createBuyOrder(user, orderData) {
       fields: {
         _id: 1,
         listPrice: 1,
-        lastPrice: 1
+        lastPrice: 1,
+        capital: 1,
+        totalValue: 1,
+        createdAt: 1
       }
     });
     if (! companyData) {

--- a/server/methods/order/createBuyOrder.js
+++ b/server/methods/order/createBuyOrder.js
@@ -3,12 +3,11 @@ import { Meteor } from 'meteor/meteor';
 import { check, Match } from 'meteor/check';
 
 import { resourceManager } from '/server/imports/threading/resourceManager';
-import { dbCompanies } from '/db/dbCompanies';
+import { dbCompanies, getPriceLimits } from '/db/dbCompanies';
 import { dbOrders } from '/db/dbOrders';
 import { limitMethod } from '/server/imports/utils/rateLimit';
 import { createOrder } from '/server/imports/createOrder';
 import { debug } from '/server/imports/utils/debug';
-import { getPriceLimits } from '/server/functions/company/helpers';
 
 Meteor.methods({
   createBuyOrder(orderData) {

--- a/server/methods/order/createSellOrder.js
+++ b/server/methods/order/createSellOrder.js
@@ -61,7 +61,10 @@ export function createSellOrder(user, orderData) {
       companyName: 1,
       listPrice: 1,
       lastPrice: 1,
-      isSeal: 1
+      isSeal: 1,
+      capital: 1,
+      totalValue: 1,
+      createdAt: 1
     }
   });
   if (! companyData) {
@@ -96,7 +99,10 @@ export function createSellOrder(user, orderData) {
         _id: 1,
         companyName: 1,
         listPrice: 1,
-        lastPrice: 1
+        lastPrice: 1,
+        capital: 1,
+        totalValue: 1,
+        createdAt: 1
       }
     });
     if (! companyData) {

--- a/server/methods/order/createSellOrder.js
+++ b/server/methods/order/createSellOrder.js
@@ -6,10 +6,10 @@ import { resourceManager } from '/server/imports/threading/resourceManager';
 import { dbCompanies } from '/db/dbCompanies';
 import { dbDirectors } from '/db/dbDirectors';
 import { dbOrders } from '/db/dbOrders';
-import { dbVariables } from '/db/dbVariables';
 import { limitMethod } from '/server/imports/utils/rateLimit';
 import { createOrder } from '/server/imports/createOrder';
 import { debug } from '/server/imports/utils/debug';
+import { getPriceLimits } from '/server/functions/company/helpers';
 
 Meteor.methods({
   createSellOrder(orderData) {
@@ -71,17 +71,8 @@ export function createSellOrder(user, orderData) {
   if (companyData.isSeal) {
     throw new Meteor.Error(403, `「${companyData.companyName}」公司已被金融管理委員會查封關停了！`);
   }
-  if (orderData.unitPrice < Math.max(Math.floor(companyData.listPrice * 0.85), 1)) {
-    throw new Meteor.Error(403, '每股單價不可偏離該股票參考價格的百分之十五！');
-  }
-  if (companyData.listPrice < dbVariables.get('lowPriceThreshold')) {
-    if (orderData.unitPrice > Math.ceil(companyData.listPrice * 1.3)) {
-      throw new Meteor.Error(403, '每股單價不可高於該股票參考價格的百分之三十！');
-    }
-  }
-  else if (orderData.unitPrice > Math.max(Math.ceil(companyData.listPrice * 1.15), 1)) {
-    throw new Meteor.Error(403, '每股單價不可偏離該股票參考價格的百分之十五！');
-  }
+  checkPriceError(orderData, companyData);
+
   resourceManager.throwErrorIsResourceIsLock(['season', 'allCompanyOrders', `companyOrder${companyId}`, `user${userId}`]);
   // 先鎖定資源，再重新讀取一次資料進行運算
   resourceManager.request('createSellOrder', [`companyOrder${companyId}`, `user${userId}`], (release) => {
@@ -112,17 +103,8 @@ export function createSellOrder(user, orderData) {
     if (! companyData) {
       throw new Meteor.Error(404, '不存在的公司股票，訂單無法成立！');
     }
-    if (orderData.unitPrice < Math.max(Math.floor(companyData.listPrice * 0.85), 1)) {
-      throw new Meteor.Error(403, '每股單價不可偏離該股票參考價格的百分之十五！');
-    }
-    if (companyData.listPrice < dbVariables.get('lowPriceThreshold')) {
-      if (orderData.unitPrice > Math.ceil(companyData.listPrice * 1.3)) {
-        throw new Meteor.Error(403, '每股單價不可高於該股票參考價格的百分之三十！');
-      }
-    }
-    else if (orderData.unitPrice > Math.max(Math.ceil(companyData.listPrice * 1.15), 1)) {
-      throw new Meteor.Error(403, '每股單價不可偏離該股票參考價格的百分之十五！');
-    }
+    checkPriceError(orderData, companyData);
+
     createOrder({
       userId: userId,
       companyId: companyId,
@@ -133,5 +115,16 @@ export function createSellOrder(user, orderData) {
     release();
   });
 }
+
+function checkPriceError(orderData, companyData) {
+  const priceLimits = getPriceLimits(companyData);
+  if (orderData.unitPrice < priceLimits.lower) {
+    throw new Meteor.Error(403, '每股單價不可低於該股票的跌停價格！');
+  }
+  if (orderData.unitPrice > priceLimits.upper) {
+    throw new Meteor.Error(403, '每股單價不可大於該股票的漲停價格！');
+  }
+}
+
 // 兩秒鐘最多一次
 limitMethod('createSellOrder', 1, 2000);

--- a/server/methods/order/createSellOrder.js
+++ b/server/methods/order/createSellOrder.js
@@ -3,13 +3,12 @@ import { Meteor } from 'meteor/meteor';
 import { check, Match } from 'meteor/check';
 
 import { resourceManager } from '/server/imports/threading/resourceManager';
-import { dbCompanies } from '/db/dbCompanies';
+import { dbCompanies, getPriceLimits } from '/db/dbCompanies';
 import { dbDirectors } from '/db/dbDirectors';
 import { dbOrders } from '/db/dbOrders';
 import { limitMethod } from '/server/imports/utils/rateLimit';
 import { createOrder } from '/server/imports/createOrder';
 import { debug } from '/server/imports/utils/debug';
-import { getPriceLimits } from '/server/functions/company/helpers';
 
 Meteor.methods({
   createSellOrder(orderData) {


### PR DESCRIPTION
依照 https://acgn-stock.com/announcement/view/s25E8ic86Gse8RnPQ 之規劃
實作股票跌幅限制，對 新創14天內市值低於資本額的公司 實施緩跌機制

1. 重構 `getPriceLimits()` ，計算邏輯分散至 `getPriceUpperLimit()` 與 `getPriceLowerLimit()` ，並將其搬移至 `dbCompanies`，輸入的 `companyData` 除原本要求的 `listPrice` 外，另還需要 `capital`, `totalValue`, `createdAt`

2. 將所有漲跌幅度設定寫入 `config` 中的 `priceLimits`

3. `config` 中增加 `valueLowerThanCapitalCompanyFallLimitTimes` 用來設定創立多少時間內市值過低的公司在跌幅限制內，目前設定第一階段限制時間為新創後 `7天` 內，第二階段限制時間為新創後 `14天` 內

4. 將所有判斷價格上下限的code以 `getPriceLimits()` 取代

5. 在用到 `getPriceLimits()` 的地方，對 `dbCompanies` 取得 `companyData` 時增加輸出 `capital`, `totalValue`, `createdAt` 等欄位，用於計算是否在跌幅限制目標內

6. 新增server端 `createBuyOrder()` 與 `createSellOrder()` 的整合測試

7. 將 vscode 的設定檔加進 `.gitignore`