### PR TITLE
實作公司打工續任儲備員工 (#368)

### DIFF
--- a/integration-test/server/functions/employee/autoRegisterEmployees.test.js
+++ b/integration-test/server/functions/employee/autoRegisterEmployees.test.js
@@ -1,0 +1,96 @@
+import { resetDatabase } from 'meteor/xolvio:cleaner';
+import { Accounts } from 'meteor/accounts-base';
+import faker from 'faker';
+import expect from 'must';
+
+import { autoRegisterEmployees } from '/server/functions/employee/autoRegisterEmployees';
+import { pttUserFactory } from '/dev-utils/factories';
+import { dbEmployees } from '/db/dbEmployees';
+import { dbLog } from '/db/dbLog';
+
+describe('function autoRegisterEmployees', function() {
+  this.timeout(10000);
+
+  let companyId;
+  let userId;
+  let registerAt;
+
+  beforeEach(function() {
+    resetDatabase();
+    companyId = 'someCompany';
+    userId = Accounts.createUser(pttUserFactory.build());
+    registerAt = new Date();
+    dbEmployees.insert({ companyId, userId, registerAt, employed: true });
+  });
+
+  it('should not register employees if no active user', function() {
+    autoRegisterEmployees();
+    expect(findRegisterEmployee({ companyId, userId })).to.not.exist();
+  });
+
+  it('should register employees for active user', function() {
+    letUserActive(userId);
+    autoRegisterEmployees();
+
+    expect(findRegisterEmployee({ companyId, userId })).to.exist();
+  });
+
+
+  describe('when multi-user and multi companies', function() {
+    let testGroups;
+
+    beforeEach(function() {
+      testGroups = [ { userId, companyId } ];
+
+      const newUserTest = 2;
+      for (let i = 0; i < newUserTest; i += 1) {
+        const newUserId = Accounts.createUser(pttUserFactory.build());
+        const newTestGroup = { userId: newUserId, companyId };
+        testGroups.push(newTestGroup);
+        dbEmployees.insert({ ...newTestGroup, registerAt, employed: true });
+      }
+
+      const newCompanyTest = 2;
+      for (let i = 0; i < newCompanyTest; i += 1) {
+        const newUserId = Accounts.createUser(pttUserFactory.build());
+        const newCompanyId = faker.random.uuid();
+        const newTestGroup = { userId: newUserId, companyId: newCompanyId };
+        testGroups.push(newTestGroup);
+        dbEmployees.insert({ ...newTestGroup, registerAt, employed: true });
+      }
+    });
+
+    it('should register employees for active users', function() {
+      letUserActive(testGroups[0].userId);
+      letUserActive(testGroups[3].userId);
+      autoRegisterEmployees();
+
+      expect(findRegisterEmployee(testGroups[0])).to.exist();
+      expect(findRegisterEmployee(testGroups[1])).to.not.exist();
+      expect(findRegisterEmployee(testGroups[2])).to.not.exist();
+      expect(findRegisterEmployee(testGroups[3])).to.exist();
+      expect(findRegisterEmployee(testGroups[4])).to.not.exist();
+    });
+  });
+});
+
+function findRegisterEmployee(selector) {
+  if (selector) {
+    return dbEmployees.findOne({ ...selector, employed: false, resigned: false });
+  }
+  else {
+    return dbEmployees.findOne({ employed: false, resigned: false });
+  }
+}
+
+function letUserActive(userId) {
+  const companyId = 'someCompany';
+  const productId = 'someProduct';
+  dbLog.insert({
+    logType: '推薦產品',
+    userId: [userId],
+    companyId,
+    data: { productId },
+    createdAt: new Date()
+  });
+}

--- a/integration-test/server/functions/employee/hireEmployees.test.js
+++ b/integration-test/server/functions/employee/hireEmployees.test.js
@@ -1,0 +1,130 @@
+import { Meteor } from 'meteor/meteor';
+import { resetDatabase } from 'meteor/xolvio:cleaner';
+import { Accounts } from 'meteor/accounts-base';
+import expect from 'must';
+
+import { hireEmployees } from '/server/functions/employee/hireEmployees';
+import { companyFactory, pttUserFactory } from '/dev-utils/factories';
+import { dbCompanies } from '/db/dbCompanies';
+import { dbEmployees } from '/db/dbEmployees';
+
+describe('function hireEmployees', function() {
+  this.timeout(10000);
+
+  let companyId;
+  let userId;
+  let registerAt;
+
+  beforeEach(function() {
+    resetDatabase();
+    companyId = dbCompanies.insert(companyFactory.build());
+    userId = Accounts.createUser(pttUserFactory.build());
+    registerAt = new Date();
+    dbEmployees.insert({ companyId, userId, registerAt });
+  });
+
+  it('should not hire if the user is in vacation', function() {
+    setUserInVacation(userId);
+    hireEmployees();
+
+    expect(findHiredEmployee()).to.not.exist();
+  });
+
+  it('should not hire if the user is been ban deal', function() {
+    setUserBeenBanDeal(userId);
+    hireEmployees();
+
+    expect(findHiredEmployee()).to.not.exist();
+  });
+
+  it('should not hire if the company does not exist', function() {
+    setCompanyNotExist(companyId);
+    hireEmployees();
+
+    expect(findHiredEmployee()).to.not.exist();
+  });
+
+  it('should not hire if the company is been seal', function() {
+    setCompanyBeenSeal(companyId);
+    hireEmployees();
+
+    expect(findHiredEmployee()).to.not.exist();
+  });
+
+  it('should hire employee', function() {
+    hireEmployees();
+    expect(findHiredEmployee({ companyId, userId, registerAt })).to.exist();
+  });
+
+
+  describe('when multi-user and multi companies', function() {
+    let testGroups;
+
+    beforeEach(function() {
+      testGroups = [ { userId, companyId, registerAt } ];
+
+      const newUserTest = 2;
+      for (let i = 0; i < newUserTest; i += 1) {
+        const newUserId = Accounts.createUser(pttUserFactory.build());
+        const newTestGroup = { userId: newUserId, companyId, registerAt };
+        testGroups.push(newTestGroup);
+        dbEmployees.insert(newTestGroup);
+      }
+
+      const newCompanyTest = 2;
+      for (let i = 0; i < newCompanyTest; i += 1) {
+        const newUserId = Accounts.createUser(pttUserFactory.build());
+        const newCompanyId = dbCompanies.insert(companyFactory.build());
+        const newTestGroup = { userId: newUserId, companyId: newCompanyId, registerAt };
+        testGroups.push(newTestGroup);
+        dbEmployees.insert(newTestGroup);
+      }
+    });
+
+    it('should hire normal employees and not be affected by other violations', function() {
+      setUserInVacation(testGroups[1].userId);
+      setUserBeenBanDeal(testGroups[2].userId);
+      setCompanyNotExist(testGroups[3].companyId);
+      setCompanyBeenSeal(testGroups[4].companyId);
+      hireEmployees();
+
+      expect(findHiredEmployee(testGroups[0])).to.exist();
+      expect(findHiredEmployee(testGroups[1])).to.not.exist();
+      expect(findHiredEmployee(testGroups[2])).to.not.exist();
+      expect(findHiredEmployee(testGroups[3])).to.not.exist();
+      expect(findHiredEmployee(testGroups[4])).to.not.exist();
+    });
+
+    it('should hire all normal employees', function() {
+      hireEmployees();
+      testGroups.forEach((testGroup) => {
+        expect(findHiredEmployee(testGroup)).to.exist();
+      });
+    });
+  });
+});
+
+function findHiredEmployee(selector) {
+  if (selector) {
+    return dbEmployees.findOne({ ...selector, employed: true, resigned: false });
+  }
+  else {
+    return dbEmployees.findOne({ employed: true, resigned: false });
+  }
+}
+
+function setUserInVacation(userId) {
+  Meteor.users.update(userId, { $set: { 'profile.isInVacation': true } });
+}
+
+function setUserBeenBanDeal(userId) {
+  Meteor.users.update(userId, { $addToSet: { 'profile.ban': 'deal' } });
+}
+
+function setCompanyNotExist(companyId) {
+  dbCompanies.remove(companyId);
+}
+
+function setCompanyBeenSeal(companyId) {
+  dbCompanies.update(companyId, { $set: { isSeal: true } });
+}

--- a/integration-test/server/methods/employee/registerEmployee.test.js
+++ b/integration-test/server/methods/employee/registerEmployee.test.js
@@ -1,0 +1,89 @@
+import { Meteor } from 'meteor/meteor';
+import { resetDatabase } from 'meteor/xolvio:cleaner';
+import expect from 'must';
+
+import { registerEmployee } from '/server/methods/employee/registerEmployee';
+import { companyFactory } from '/dev-utils/factories';
+import { dbCompanies } from '/db/dbCompanies';
+import { dbEmployees } from '/db/dbEmployees';
+
+describe('method registerEmployee', function() {
+  this.timeout(10000);
+
+  const userId = 'someUser';
+  let user;
+  let companyId;
+
+  beforeEach(function() {
+    resetDatabase();
+
+    user = {
+      _id: userId,
+      profile: {
+        isInVacation: false,
+        ban: []
+      }
+    };
+    companyId = 'someCompany';
+  });
+
+  it('should fail if the user is in vacation', function() {
+    user.profile.isInVacation = true;
+    registerEmployee.bind(null, user, companyId)
+      .must.throw(Meteor.Error, '您現在正在渡假中，請好好放鬆！ [403]');
+    expect(dbEmployees.findOne({})).to.not.exist();
+  });
+
+  it('should fail if the user is been ban deal', function() {
+    user.profile.ban.push('deal');
+    registerEmployee.bind(null, user, companyId)
+      .must.throw(Meteor.Error, '您現在被金融管理會禁止了所有投資下單行為！ [403]');
+    expect(dbEmployees.findOne({})).to.not.exist();
+  });
+
+  it('should fail if the company does not exist', function() {
+    registerEmployee.bind(null, user, companyId)
+      .must.throw(Meteor.Error, '找不到識別碼為「' + companyId + '」的公司！ [404]');
+    expect(dbEmployees.findOne({})).to.not.exist();
+  });
+
+
+  describe('when company is exist', function() {
+    let companyId;
+    let companyData;
+
+    beforeEach(function() {
+      companyId = dbCompanies.insert(companyFactory.build({ isSeal: false }));
+      companyData = dbCompanies.findOne(companyId);
+    });
+
+    it('should fail if the company is been seal', function() {
+      dbCompanies.update(companyId, { $set: { isSeal: true } });
+      registerEmployee.bind(null, user, companyId)
+        .must.throw(Meteor.Error, '「' + companyData.companyName + '」公司已被金融管理委員會查封關停了！ [403]');
+      expect(dbEmployees.findOne({})).to.not.exist();
+    });
+
+
+    const employed = false;
+    const resigned = false;
+
+    it('should success register employee', function() {
+      registerEmployee.bind(null, user, companyId).must.not.throw();
+
+      const dbEmployeesData = dbEmployees.findOne({ userId, employed, resigned, companyId });
+      expect(dbEmployeesData).to.exist();
+    });
+
+    it('should success register employee and only register in one company', function() {
+      const companyId2 = dbCompanies.insert(companyFactory.build({ isSeal: false }));
+      registerEmployee.bind(null, user, companyId).must.not.throw();
+      registerEmployee.bind(null, user, companyId2).must.not.throw();
+
+      const dbEmployeesData = dbEmployees.findOne({ userId, employed, resigned, companyId });
+      const dbEmployeesData2 = dbEmployees.findOne({ userId, employed, resigned, companyId: companyId2 });
+      expect(dbEmployeesData).to.not.exist();
+      expect(dbEmployeesData2).to.exist();
+    });
+  });
+});

--- a/server/functions/employee/autoRegisterEmployees.js
+++ b/server/functions/employee/autoRegisterEmployees.js
@@ -1,0 +1,24 @@
+import { dbEmployees } from '/db/dbEmployees';
+import { computeActiveUserIds } from '/server/imports/utils/computeActiveUserIds';
+
+// 為 在職員工 報名 儲備員工
+export function autoRegisterEmployees() {
+  const registerAt = new Date();
+  const activeUsers = computeActiveUserIds();
+  dbEmployees
+    .find(
+      {
+        employed: true,
+        resigned: false,
+        userId: { $in: activeUsers }
+      }, {
+        fields: {
+          userId: 1,
+          companyId: 1
+        }
+      }
+    )
+    .forEach(({ userId, companyId }) => {
+      dbEmployees.insert({ userId, companyId, registerAt });
+    });
+}

--- a/server/functions/employee/hireEmployees.js
+++ b/server/functions/employee/hireEmployees.js
@@ -1,3 +1,65 @@
-export function hireEmployees() {
+import { dbEmployees } from '/db/dbEmployees';
 
+export function hireEmployees() {
+  dbEmployees.update(
+    { employed: false, resigned: false },
+    { $set: { employed: true } },
+    { multi: true }
+  );
+
+  removeErrorCompanies();
+  removeErrorUsers();
+}
+
+function removeErrorCompanies() {
+  const normalCompanies = dbEmployees
+    .aggregate([
+      { $match: { employed: true, resigned: false } },
+      {
+        $group: {
+          _id: '$companyId',
+          ids: { $push: { id: '$_id' } }
+        }
+      },
+      {
+        $lookup: {
+          from: 'companies',
+          localField: '_id',
+          foreignField: '_id',
+          as: 'companyData'
+        }
+      },
+      { $unwind: '$companyData' },
+      { $match: { 'companyData.isSeal': false } }
+    ])
+    .map(({ _id }) => {
+      return _id;
+    });
+  dbEmployees.remove({ companyId: { $nin: normalCompanies }, employed: true, resigned: false });
+}
+
+function removeErrorUsers() {
+  const normalUsers = dbEmployees
+    .aggregate([
+      { $match: { employed: true, resigned: false } },
+      {
+        $lookup: {
+          from: 'users',
+          localField: 'userId',
+          foreignField: '_id',
+          as: 'userData'
+        }
+      },
+      { $unwind: '$userData' },
+      {
+        $match: {
+          'userData.profile.isInVacation': false,
+          'userData.profile.ban': { $nin: ['deal'] }
+        }
+      }
+    ])
+    .map(({ userId }) => {
+      return userId;
+    });
+  dbEmployees.remove({ userId: { $nin: normalUsers }, employed: true, resigned: false });
 }

--- a/server/functions/employee/hireEmployees.js
+++ b/server/functions/employee/hireEmployees.js
@@ -1,5 +1,6 @@
 import { dbEmployees } from '/db/dbEmployees';
 
+// 將所有 儲備員工 更新為 在職員工
 export function hireEmployees() {
   dbEmployees.update(
     { employed: false, resigned: false },

--- a/server/functions/employee/hireEmployees.js
+++ b/server/functions/employee/hireEmployees.js
@@ -1,0 +1,3 @@
+export function hireEmployees() {
+
+}

--- a/server/imports/utils/computeActiveUserIds.js
+++ b/server/imports/utils/computeActiveUserIds.js
@@ -1,7 +1,6 @@
 import { _ } from 'meteor/underscore';
 
 import { dbLog } from '/db/dbLog';
-import { dbEmployees } from '/db/dbEmployees';
 
 /*
  * 計算系統中的活躍玩家數量
@@ -25,16 +24,5 @@ export function computeActiveUserIds() {
     '_id'
   );
 
-  // 有報名員工的玩家
-  const activeUsersByEmployee = _.pluck(
-    dbEmployees.aggregate([ {
-      $match: { registerAt: { $gte: lookbackDate } }
-    }, {
-      $group: { _id: '$userId' }
-    } ]),
-    '_id'
-  );
-
-  // 以上所有條件的聯集
-  return [...new Set([...activeUsersByLog, ...activeUsersByEmployee])];
+  return activeUsersByLog;
 }

--- a/server/intervalCheck.js
+++ b/server/intervalCheck.js
@@ -5,6 +5,7 @@ import { UserStatus } from 'meteor/mizzao:user-status';
 import { resourceManager } from '/server/imports/threading/resourceManager';
 import { debug } from '/server/imports/utils/debug';
 import { backupMongo } from '/server/imports/utils/backupMongo';
+import { hireEmployees } from '/server/functions/employee/hireEmployees';
 import { dbAdvertising } from '/db/dbAdvertising';
 import { dbArena, getCurrentArena } from '/db/dbArena';
 import { dbArenaFighters } from '/db/dbArenaFighters';
@@ -488,16 +489,7 @@ function generateNewSeason() {
   // 排程最後出清時間
   eventScheduler.scheduleEvent('product.finalSale', seasonEndDate.getTime() - Meteor.settings.public.productFinalSaleTime);
   // 雇用所有上季報名的使用者
-  dbEmployees.update(
-    {
-      resigned: false,
-      registerAt: {
-        $lt: new Date(seasonEndDate.getTime() - Meteor.settings.public.seasonTime)
-      }
-    },
-    { $set: { employed: true } },
-    { multi: true }
-  );
+  hireEmployees();
   // 更新所有公司員工薪資
   dbCompanies.find().forEach((companyData) => {
     dbCompanies.update(companyData, { $set: { salary: companyData.nextSeasonSalary } });

--- a/server/intervalCheck.js
+++ b/server/intervalCheck.js
@@ -6,6 +6,7 @@ import { resourceManager } from '/server/imports/threading/resourceManager';
 import { debug } from '/server/imports/utils/debug';
 import { backupMongo } from '/server/imports/utils/backupMongo';
 import { hireEmployees } from '/server/functions/employee/hireEmployees';
+import { autoRegisterEmployees } from '/server/functions/employee/autoRegisterEmployees';
 import { dbAdvertising } from '/db/dbAdvertising';
 import { dbArena, getCurrentArena } from '/db/dbArena';
 import { dbArenaFighters } from '/db/dbArenaFighters';
@@ -490,6 +491,8 @@ function generateNewSeason() {
   eventScheduler.scheduleEvent('product.finalSale', seasonEndDate.getTime() - Meteor.settings.public.productFinalSaleTime);
   // 雇用所有上季報名的使用者
   hireEmployees();
+  // 幫所有活躍的正職員工報名儲備員工
+  autoRegisterEmployees();
   // 更新所有公司員工薪資
   dbCompanies.find().forEach((companyData) => {
     dbCompanies.update(companyData, { $set: { salary: companyData.nextSeasonSalary } });


### PR DESCRIPTION
依照 https://acgn-stock.com/ruleDiscuss/view/b86GSJQnC58RrYGzd 之議程決議
與　 https://acgn-stock.com/announcement/view/XWD8Y6P2MHvjCkHrt 公告之修正
實作公司打工續任儲備員工 (#368)

1. `generateNewSeason()` 中雇用員工的部分改為調用 `hireEmployees()` 來操作

2. 計算活躍玩家時，不再判斷員工報名

3. `autoRegisterEmployees()` 用於幫活躍玩家報名儲備員工

4. `generateNewSeason()` 於僱用員工後呼叫 `autoRegisterEmployees()`