### PR TITLE
修正公司紀錄的跳頁無法正常運作的問題

### DIFF
--- a/client/company/companyLogList.html
+++ b/client/company/companyLogList.html
@@ -1,9 +1,11 @@
 <template name="companyLogList">
-  {{#if onlyShowMine}}
-    <button class="btn btn-outline-info btn-sm mt-1">檢視所有紀錄</button>
-  {{else}}
-    <button class="btn btn-outline-info btn-sm mt-1">只檢視自身紀錄</button>
-  {{/if}}
+  <button class="btn btn-outline-info btn-sm mt-1" data-action="toggleOnlyShowMine">
+    {{#if onlyShowMine}}
+      檢視所有紀錄
+    {{else}}
+      只檢視自身紀錄
+    {{/if}}
+  </button>
   {{#each logData in logList}}
     {{>displayLog logData}}
   {{else}}

--- a/client/company/companyLogList.js
+++ b/client/company/companyLogList.js
@@ -40,7 +40,7 @@ Template.companyLogList.helpers({
   }
 });
 Template.companyLogList.events({
-  'click button'(event) {
+  'click [data-action="toggleOnlyShowMine"]'(event) {
     event.preventDefault();
     rIsOnlyShowMine.set(! rIsOnlyShowMine.get());
   }


### PR DESCRIPTION
「只檢視自身紀錄」切換按鍵的監聽事件原為 `click button`，但會與同 template instance 底下的跳頁 button 
的 click 事件衝突，導致按下跳頁時事件同時觸發了「只檢視自身紀錄」按鍵的事件。