### PR TITLE
使用者名稱顯示時加上認證來源以協助識別

### DIFF
--- a/client/accountInfo/accountInfo.html
+++ b/client/accountInfo/accountInfo.html
@@ -63,8 +63,9 @@
           text-overflow: ellipsis;
           min-height: 3.5rem;
           max-height: 8.4rem;
-          word-wrap: break-word;">
-      使用者「{{this.profile.name}}」帳號資訊
+          word-wrap: break-word;
+          line-height: normal;">
+      使用者「{{{styledValidateTypeMarkHtml this.profile.validateType}}}{{this.profile.name}}」帳號資訊
     </h1>
     <hr />
     {{#if currentUser}}

--- a/client/company/companyEditForm.html
+++ b/client/company/companyEditForm.html
@@ -67,7 +67,7 @@
           {{/if}}
         {{/if}}
       </div>
-      <small class="form-text">大小為100x100。</small>
+      <small class="form-text">大小為150x150。</small>
       {{{errorHtmlOf 'pictureSmall'}}}
     </div>
     <div class="form-group">
@@ -125,4 +125,3 @@
     </div>
   </div>
 </template>
-

--- a/client/company/companyList.html
+++ b/client/company/companyList.html
@@ -106,34 +106,33 @@
           {{/if}}
         </div>
         </div>
-        <div class="d-flex flex-column align-self-center">
-          <div class="d-flex flex-row-reverse">
-            <div class="member-panel">
-              <div class="d-flex flex-row-reverse">
-                {{#if isCurrentUserChairmanOf this._id}}
-                  <a class="small" href="#" data-action="changeChairmanTitle">
-                    {{this.chairmanTitle}}
-                  </a>
-                {{else}}
-                  <small>{{this.chairmanTitle}}</small>
-                {{/if}}
-              </div>
-              <div class="d-flex flex-row-reverse">
-                <h4>{{>userLink this.chairman}}</h4>
-              </div>
-              <div class="d-flex flex-row-reverse mt-2">
-                <small>經理人</small>
-              </div>
-              <div class="d-flex flex-row-reverse">
-                <h4>{{>userLink this.manager}}</h4>
-              </div>
-            </div>
-          </div>
-        </div>
       </div>
       <div class="title">
         {{>companyLink this._id}}
       </div>
+      <div class="row row-info d-flex flex-column justify-content-between">
+        <div class="text-left">
+          {{#if isCurrentUserChairmanOf this._id}}
+            <a class="small" href="#" data-action="changeChairmanTitle">
+              {{this.chairmanTitle}}
+            </a>
+          {{else}}
+            <small>{{this.chairmanTitle}}</small>
+          {{/if}}
+        </div>
+        <div class="text-right mx-3">
+          <h4 class="text-truncate">{{>userLink this.chairman}}</h4>
+        </div>
+      </div>
+      <div class="row row-info d-flex flex-column justify-content-between">
+        <div class="text-left">
+          <small>經理人</small>
+        </div>
+        <div class="text-right mx-3 text-truncate">
+          <h4 class="text-truncate">{{>userLink this.manager}}</h4>
+        </div>
+      </div>
+      <hr class="m-0">
       <div class="row row-info d-flex justify-content-between">
         <p>股票價格</p>
         <p class="{{priceDisplayClass this.lastPrice this.listPrice}}">
@@ -162,7 +161,7 @@
           <p>{{getCurrentUserOwnedStockAmount this._id}} ({{getStockPercentage this._id this.totalRelease}}%)</p>
         </div>
         {{#if existOwnOrder this._id}}
-          <hr style="margin: 0px;" />
+          <hr class="m-0">
           <div class="row">
             <button class="btn btn-tab accordion dropdown-toggle" data-expand-order="1">顯示未完成訂單</button>
             <div class="order-panel">
@@ -177,7 +176,7 @@
             </div>
           </div>
         {{/if}}
-        <hr style="margin: 0px;" />
+        <hr class="m-0">
         <div class="row btn-group">
           {{#if currentUserCanManage this}}
             <a class="btn btn-tab" href="{{getManageHref this._id}}">

--- a/client/foundation/editFoundation.html
+++ b/client/foundation/editFoundation.html
@@ -105,7 +105,7 @@
           {{/if}}
         {{/if}}
       </div>
-      <small class="form-text">大小為。</small>
+      <small class="form-text">大小為150x150。</small>
       {{{errorHtmlOf 'pictureSmall'}}}
     </div>
     <div class="form-group">

--- a/client/foundation/editFoundation.html
+++ b/client/foundation/editFoundation.html
@@ -105,7 +105,7 @@
           {{/if}}
         {{/if}}
       </div>
-      <small class="form-text">大小為100x100。</small>
+      <small class="form-text">大小為。</small>
       {{{errorHtmlOf 'pictureSmall'}}}
     </div>
     <div class="form-group">

--- a/client/foundation/foundationList.html
+++ b/client/foundation/foundationList.html
@@ -87,22 +87,19 @@
               {{/if}}
             </div>
           </div>
-          <div class="d-flex flex-column align-self-center">
-            <div class="d-flex flex-row-reverse">
-              <div class="member-panel">
-                <div class="d-flex flex-row-reverse mt-2">
-                  <small>經理人</small>
-                </div>
-                <div class="d-flex flex-row-reverse">
-                  <h4>{{>userLink this.manager}}</h4>
-                </div>
-              </div>
-            </div>
-          </div>
         </div>
-        <div class="row title-starter">
+        <div class="title-starter">
           {{>companyLink this._id}}
         </div>
+        <div class="row row-info d-flex flex-column justify-content-between">
+          <div class="text-left">
+            <small>經理人</small>
+          </div>
+          <div class="text-right mx-3 text-truncate">
+            <h4 class="text-truncate">{{>userLink this.manager}}</h4>
+          </div>
+        </div>
+        <hr class="m-0">
         <div class="row row-info d-flex justify-content-between">
           <p>投資人數</p>
           <p class="{{investPplsNumberClass this.invest.length}}">

--- a/client/layout/nav.html
+++ b/client/layout/nav.html
@@ -4,6 +4,7 @@
       <span class="navbar-brand dropdown" title="當前登入使用者：{{currentUser.profile.name}}">
         <a class="dropdown-toggle d-inline-block text-truncate mw-100" href="#">
           <i class="fa fa-user-o" aria-hidden="true"></i>
+          {{{styledValidateTypeMarkHtml currentUser.profile.validateType}}}
           {{currentUser.profile.name}}
         </a>
         <div class="dropdown-menu px-3 text-right">

--- a/client/utils/displayLink.html
+++ b/client/utils/displayLink.html
@@ -1,5 +1,5 @@
 <template name="userLink">
-  <a class="{{class}}"></a>
+  <span class="user-link-container {{class}}"></span>
 </template>
 
 <template name="companyLink">

--- a/client/utils/displayLink.js
+++ b/client/utils/displayLink.js
@@ -2,65 +2,13 @@ import { $ } from 'meteor/jquery';
 import { Template } from 'meteor/templating';
 import { FlowRouter } from 'meteor/kadira:flow-router';
 
+import { populateUserLink } from '/client/utils/populateUserLink';
+
 Template.userLink.onRendered(function() {
-  this.refreshContent = (userId) => {
-    const $link = this.$('a');
-
-    if (! userId) {
-      $link.text('（無資料）');
-
-      return;
-    }
-
-    if (userId === '!none') {
-      $link.text('無');
-
-      return;
-    }
-
-    if (userId === '!system') {
-      $link.text('系統');
-
-      return;
-    }
-
-    if (userId === '!FSC') {
-      $link.text('金管會');
-
-      return;
-    }
-
-    $.ajax({
-      url: '/userInfo',
-      data: {
-        id: userId
-      },
-      dataType: 'json',
-      success: (userData) => {
-        const userName = userData.name;
-        if (userData.status === 'registered') {
-          const path = FlowRouter.path('accountInfo', { userId });
-          $link
-            .attr('href', path)
-            .text(('' + userName).trim() || '???');
-        }
-        else {
-          $link.wrapInner('<span></sapn>');
-          $link.find('span')
-            .text(('' + userName).trim() || '???')
-            .unwrap();
-        }
-      },
-      error: () => {
-        $link.text('???');
-      }
-    });
-  };
-
   this.autorun(() => {
     const data = Template.currentData();
     const userId = typeof data === 'object' ? data.id : data;
-    this.refreshContent(userId);
+    populateUserLink(this.$('span'), userId);
   });
 });
 

--- a/client/utils/displayLog.js
+++ b/client/utils/displayLog.js
@@ -4,6 +4,7 @@ import { Template } from 'meteor/templating';
 import { FlowRouter } from 'meteor/kadira:flow-router';
 
 import { roleDisplayName } from '/db/users';
+import { populateUserLink } from '/client/utils/populateUserLink';
 import { stoneDisplayName, currencyFormat } from './helpers';
 
 Template.displayLog.onRendered(function() {
@@ -11,29 +12,7 @@ Template.displayLog.onRendered(function() {
     const $link = $(elem);
     const userId = $link.attr('data-user-link');
 
-    // TODO write a helper
-    if (userId === '!system') {
-      $link.text('系統');
-    }
-    else if (userId === '!FSC') {
-      $link.text('金管會');
-    }
-    else {
-      $.ajax({
-        url: '/userInfo',
-        data: { id: userId },
-        dataType: 'json',
-        success: ({ name: userName, status }) => {
-          if (status === 'registered') {
-            const path = FlowRouter.path('accountInfo', { userId });
-            $link.html(`<a href="${path}">${userName}</a>`);
-          }
-          else {
-            $link.text(userName);
-          }
-        }
-      });
-    }
+    populateUserLink($link, userId);
   });
 
   this.$('[data-company-link]').each((_, elem) => {

--- a/client/utils/helpers.js
+++ b/client/utils/helpers.js
@@ -385,3 +385,17 @@ export function pathFor(pathDef, kw = { hash: {} }) {
   return FlowRouter.path(pathDef, params, queryParams);
 }
 Template.registerHelper('pathFor', pathFor);
+
+function simpleValidateTypeText(validateType) {
+  switch (validateType) {
+    case 'PTT': return 'PTT';
+    case 'Bahamut': return '巴哈';
+    case 'Google': return 'G帳';
+    default: return '？';
+  }
+}
+
+export function styledValidateTypeMarkHtml(validateType) {
+  return `<sup>⟨${simpleValidateTypeText(validateType)}⟩</sup>`;
+}
+Template.registerHelper('styledValidateTypeMarkHtml', styledValidateTypeMarkHtml);

--- a/client/utils/populateUserLink.js
+++ b/client/utils/populateUserLink.js
@@ -1,0 +1,58 @@
+import { $ } from 'meteor/jquery';
+import { _ } from 'meteor/underscore';
+import { FlowRouter } from 'meteor/kadira:flow-router';
+
+import { styledValidateTypeMarkHtml } from '/client/utils/helpers';
+
+const specialUserDisplayNameMap = {
+  '!none': '無',
+  '!system': '系統',
+  '!FSC': '金管會'
+};
+
+function fetchUserInfo(userId) {
+  return new Promise((resolve, reject) => {
+    $.ajax({
+      url: '/userInfo',
+      data: { id: userId },
+      dataType: 'json',
+      success: (result) => {
+        resolve(result);
+      },
+      error: (xhr, status, err) => {
+        reject(err);
+      }
+    });
+  });
+}
+
+export async function populateUserLink($container, userId) {
+  if (! userId) {
+    $container.text('（無資料）');
+
+    return;
+  }
+
+  const specialUserDisplayName = specialUserDisplayNameMap[userId];
+  if (specialUserDisplayName) {
+    $container.text(specialUserDisplayName);
+
+    return;
+  }
+
+  try {
+    const { name: userName, status, validateType } = await fetchUserInfo(userId);
+    const userText = `${styledValidateTypeMarkHtml(validateType)}${_.escape(userName)}`.trim() || '???';
+    const path = FlowRouter.path('accountInfo', { userId });
+
+    if (status === 'registered') {
+      $container.html(`<a href="${path}">${userText}</a>`);
+    }
+    else {
+      $container.html(userText);
+    }
+  }
+  catch (err) {
+    $container.text('???');
+  }
+}

--- a/client/utils/styles.css
+++ b/client/utils/styles.css
@@ -241,8 +241,8 @@ body {
   background: linear-gradient(135deg, #eef2f3, #8e9eab);
 }
 .company-card .picture img {
-  width: 100px;
-  height: 100px;
+  width: 150px;
+  height: 150px;
   object-fit: cover;
 }
 .company-card .title {
@@ -258,6 +258,7 @@ body {
   margin: 0 5%;
   overflow: hidden;
   white-space: nowrap;
+  text-align: center;
   text-overflow: ellipsis;
   display: block;
 }
@@ -274,6 +275,7 @@ body {
   margin: 0 5%;
   overflow: hidden;
   white-space: nowrap;
+  text-align: center;
   text-overflow: ellipsis;
   display: block;
 }
@@ -298,13 +300,7 @@ body {
   margin: 0px 1rem;
 }
 .company-card .row-cover {
-  height: 120px;
-}
-.company-card .row-cover a, .company-card .row-cover h4, .company-card .row-cover small {
-  margin: 0rem;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
+  padding: 0.3rem 0px;
 }
 .company-card .btn-tab {
   color: #000;
@@ -669,4 +665,8 @@ table.arena-fighter-body tr td:nth-child(9) {
 
 .violation-case-action-reason p:last-child {
   margin-bottom: 0;
+}
+
+.user-link-container {
+  line-height: normal;
 }


### PR DESCRIPTION
避免玩家無法輕易辨別來自不同認證來源，但名稱卻完全相同的帳號
（e.g., PTT 的 foobar、巴哈姆特的 foobar）

1. 在所有玩家連結以及帳號資訊頁的顯示，加入認證來源的前置字
  * PTT 帳號將顯示「PTT」
  * 巴哈姆特帳號將顯示「巴哈」
  * Google 帳號將顯示「G帳」
2. 調整公司卡片的排版，以配合帳號的認證來源顯示
  * 小圖從 100x100 改為 150x150
  * 經理人與董事長由小圖右邊移至公司名稱下方
  * 其他細部微調
3. 重構 client 端 userInfo 的 ajax 請求處理與顯示流程，將 log 的玩家連結部分與 userLink 樣版共同處合併