### PR TITLE
移除 Google 帳號的名稱顯示 & 重整 ajax 相關的 server 端程式碼

### DIFF
--- a/server/http/companyInfo.js
+++ b/server/http/companyInfo.js
@@ -9,7 +9,7 @@ import { dbFoundations } from '/db/dbFoundations';
 import { debug } from '/server/imports/utils/debug';
 
 // 以Ajax方式發布公司名稱
-WebApp.connectHandlers.use('/companyInfo', function(req, res) {
+WebApp.connectHandlers.use('/companyInfo', (req, res) => {
   debug.log('connectHandlers companyInfo');
 
   const { query } = url.parse(req.url);

--- a/server/http/companyInfo.js
+++ b/server/http/companyInfo.js
@@ -3,60 +3,57 @@ import { WebApp } from 'meteor/webapp';
 import url from 'url';
 import querystring from 'querystring';
 
+import { getCurrentRound } from '/db/dbRound';
 import { dbCompanyArchive } from '/db/dbCompanyArchive';
 import { dbFoundations } from '/db/dbFoundations';
-import { dbRound } from '/db/dbRound';
 import { debug } from '/server/imports/utils/debug';
 
 // 以Ajax方式發布公司名稱
-WebApp.connectHandlers.use(function(req, res, next) {
+WebApp.connectHandlers.use('/companyInfo', function(req, res) {
   debug.log('connectHandlers companyInfo');
-  const parsedUrl = url.parse(req.url);
-  if (parsedUrl.pathname === '/companyInfo') {
-    const query = querystring.parse(parsedUrl.query);
-    const companyId = query.id;
-    const companyData = dbCompanyArchive.findOne(companyId, {
+
+  const { query } = url.parse(req.url);
+  const { id: companyId } = querystring.parse(query);
+
+  const companyData = dbCompanyArchive.findOne(companyId, {
+    fields: {
+      name: 1,
+      status: 1
+    }
+  });
+
+  if (! companyData) {
+    res.statusCode = 404;
+    res.end();
+
+    return;
+  }
+
+  if (companyData.status === 'market') {
+    const currentRound = getCurrentRound();
+
+    if (currentRound) {
+      const cacheTime = currentRound.endDate.getTime() - Date.now();
+      if (cacheTime > 0) {
+        const cacheTimeSeconds = Math.min(Math.floor(cacheTime / 1000), 604800);
+        res.setHeader('Cache-Control', 'public, max-age=' + cacheTimeSeconds);
+      }
+    }
+  }
+  else if (companyData.status === 'foundation') {
+    const foundationData = dbFoundations.findOne(companyId, {
       fields: {
-        name: 1,
-        status: 1
+        createdAt: 1
       }
     });
-    if (companyData) {
-      if (companyData.status === 'market') {
-        const lastRoundData = dbRound.findOne({}, {
-          sort: {
-            beginDate: -1
-          }
-        });
-        if (lastRoundData) {
-          const cacheMicroTime = lastRoundData.endDate.getTime() - Date.now();
-          if (cacheMicroTime > 0) {
-            const cacheTime = Math.min(Math.floor(cacheMicroTime / 1000), 604800);
-            res.setHeader('Cache-Control', 'public, max-age=' + cacheTime);
-          }
-        }
+    if (foundationData) {
+      const cacheTime = foundationData.createdAt.getTime() + Meteor.settings.public.foundExpireTime - Date.now();
+      if (cacheTime > 0) {
+        const cacheTimeSeconds = Math.floor(cacheTime / 1000);
+        res.setHeader('Cache-Control', 'public, max-age=' + cacheTimeSeconds);
       }
-      else if (companyData.status === 'foundation') {
-        const foundationData = dbFoundations.findOne(companyId, {
-          fields: {
-            createdAt: 1
-          }
-        });
-        if (foundationData) {
-          const cacheMicroTime = foundationData.createdAt.getTime() + Meteor.settings.public.foundExpireTime - Date.now();
-          if (cacheMicroTime > 0) {
-            const cacheTime = Math.floor(cacheMicroTime / 1000);
-            res.setHeader('Cache-Control', 'public, max-age=' + cacheTime);
-          }
-        }
-      }
-      res.end(JSON.stringify(companyData));
-    }
-    else {
-      res.end('');
     }
   }
-  else {
-    next();
-  }
+
+  res.end(JSON.stringify(companyData));
 });

--- a/server/http/productInfo.js
+++ b/server/http/productInfo.js
@@ -6,29 +6,27 @@ import { dbProducts } from '/db/dbProducts';
 import { debug } from '/server/imports/utils/debug';
 
 // 以Ajax方式發布產品名稱、連結
-WebApp.connectHandlers.use(function(req, res, next) {
+WebApp.connectHandlers.use('/productInfo', function(req, res) {
   debug.log('connectHandlers productInfo');
-  const parsedUrl = url.parse(req.url);
-  if (parsedUrl.pathname === '/productInfo') {
-    const query = querystring.parse(parsedUrl.query);
-    const productId = query.id;
-    const productData = dbProducts.findOne(productId, {
-      fields: {
-        productName: 1,
-        url: 1,
-        type: 1,
-        companyId: 1
-      }
-    });
-    if (productData) {
-      res.setHeader('Cache-Control', 'public, max-age=604800');
-      res.end(JSON.stringify(productData));
+  const { query } = url.parse(req.url);
+  const { id: productId } = querystring.parse(query);
+
+  const productData = dbProducts.findOne(productId, {
+    fields: {
+      productName: 1,
+      url: 1,
+      type: 1,
+      companyId: 1
     }
-    else {
-      res.end('');
-    }
+  });
+
+  if (! productData) {
+    res.statusCode = 404;
+    res.end();
+
+    return;
   }
-  else {
-    next();
-  }
+
+  res.setHeader('Cache-Control', 'public, max-age=604800');
+  res.end(JSON.stringify(productData));
 });

--- a/server/http/productInfo.js
+++ b/server/http/productInfo.js
@@ -6,7 +6,7 @@ import { dbProducts } from '/db/dbProducts';
 import { debug } from '/server/imports/utils/debug';
 
 // 以Ajax方式發布產品名稱、連結
-WebApp.connectHandlers.use('/productInfo', function(req, res) {
+WebApp.connectHandlers.use('/productInfo', (req, res) => {
   debug.log('connectHandlers productInfo');
   const { query } = url.parse(req.url);
   const { id: productId } = querystring.parse(query);

--- a/server/http/userInfo.js
+++ b/server/http/userInfo.js
@@ -1,57 +1,34 @@
-import { Meteor } from 'meteor/meteor';
 import { WebApp } from 'meteor/webapp';
-import { HTTP } from 'meteor/http';
 import url from 'url';
 import querystring from 'querystring';
 
 import { dbUserArchive } from '/db/dbUserArchive';
 import { debug } from '/server/imports/utils/debug';
 
-// 以Ajax方式發布使用者名稱
-WebApp.connectHandlers.use(function(req, res, next) {
+// 以Ajax方式發布使用者資訊
+WebApp.connectHandlers.use('/userInfo', (req, res) => {
   debug.log('connectHandlers userName');
-  const parsedUrl = url.parse(req.url);
-  if (parsedUrl.pathname === '/userInfo') {
-    const query = querystring.parse(parsedUrl.query);
-    const userId = query.id;
-    const userData = dbUserArchive.findOne(userId, {
-      fields: {
-        name: 1,
-        status: 1,
-        validateType: 1
-      }
-    });
-    if (userData) {
-      if (userData.status === 'registered') {
-        res.setHeader('Cache-Control', 'public, max-age=604800');
-      }
-      if (userData.validateType === 'Google') {
-        try {
-          const accessToken = Meteor.users.findOne(userId, {
-            fields: {
-              'services.google.accessToken': 1
-            }
-          }).services.google.accessToken;
-          /* eslint-disable camelcase */
-          const response = HTTP.get('https://www.googleapis.com/oauth2/v1/userinfo', {
-            params: {
-              access_token: accessToken
-            }
-          });
-          /* eslint-enable camelcase */
-          userData.name = response.data.name;
-        }
-        catch (e) {
-          userData.name = userData.name;
-        }
-      }
-      res.end(JSON.stringify(userData));
+  const { query } = url.parse(req.url);
+  const { id: userId } = querystring.parse(query);
+
+  const userData = dbUserArchive.findOne(userId, {
+    fields: {
+      name: 1,
+      status: 1,
+      validateType: 1
     }
-    else {
-      res.end('');
-    }
+  });
+
+  if (! userData) {
+    res.statusCode = 404;
+    res.end();
+
+    return;
   }
-  else {
-    next();
+
+  if (userData.status === 'registered') {
+    res.setHeader('Cache-Control', 'public, max-age=604800');
   }
+
+  res.end(JSON.stringify(userData));
 });


### PR DESCRIPTION
1. `/userInfo` 發佈 Google 帳號玩家資訊時，不再透過 Google API 取得顯示名稱，
    一律以 email 作為玩家名稱顯示，避免因自訂名稱造成辨識困難
2. 調整 `/userInfo`、`/productInfo` 與 `/companyInfo`，簡化部分寫法，
    在該 id 不存在時以 404 回應而非丟回單純空資料