### PR TITLE
修正 & 微調公司卡片的排版

### DIFF
--- a/client/company/companyList.html
+++ b/client/company/companyList.html
@@ -111,13 +111,13 @@
         {{>companyLink this._id}}
       </div>
       <div class="row row-info d-flex flex-column justify-content-between">
-        <div class="text-left">
+        <div class="text-left mx-3">
           {{#if isCurrentUserChairmanOf this._id}}
-            <a class="small" href="#" data-action="changeChairmanTitle">
+            <a href="#" data-action="changeChairmanTitle">
               {{this.chairmanTitle}}
             </a>
           {{else}}
-            <small>{{this.chairmanTitle}}</small>
+            {{this.chairmanTitle}}
           {{/if}}
         </div>
         <div class="text-right mx-3">
@@ -125,8 +125,8 @@
         </div>
       </div>
       <div class="row row-info d-flex flex-column justify-content-between">
-        <div class="text-left">
-          <small>經理人</small>
+        <div class="text-left mx-3">
+          經理人
         </div>
         <div class="text-right mx-3 text-truncate">
           <h4 class="text-truncate">{{>userLink this.manager}}</h4>

--- a/client/company/companyList.html
+++ b/client/company/companyList.html
@@ -77,7 +77,7 @@
   <div class="col-12 col-md-6 col-lg-4 col-xl-3" style="margin-bottom: 25px;">
     <div class="company-card {{cardDisplayClass this}}">
       <div class="row row-info">
-        <small>{{formatDateTimeText this.createdAt}} 創立</small>
+        <small class="ml-3">{{formatDateTimeText this.createdAt}} 創立</small>
         {{#if currentUser}}
           {{#if isFavorite this._id}}
             <i class="fa fa-heart btn-favorite" aria-hidden="true" data-toggle-favorite="{{this._id}}"></i>

--- a/client/foundation/foundationList.html
+++ b/client/foundation/foundationList.html
@@ -92,8 +92,8 @@
           {{>companyLink this._id}}
         </div>
         <div class="row row-info d-flex flex-column justify-content-between">
-          <div class="text-left">
-            <small>經理人</small>
+          <div class="text-left mx-3">
+            經理人
           </div>
           <div class="text-right mx-3 text-truncate">
             <h4 class="text-truncate">{{>userLink this.manager}}</h4>

--- a/client/foundation/foundationList.html
+++ b/client/foundation/foundationList.html
@@ -65,7 +65,7 @@
     <div class="company-card {{cardDisplayClass this}}">
       <div class="company-card-mask">
         <div class="row row-info">
-          <small>{{getExpireDateText this.createdAt}} 截止</small>
+          <small class="ml-3">{{getExpireDateText this.createdAt}} 截止</small>
         </div>
         <hr class="m-0"/>
         {{#if this.illegalReason}}

--- a/client/utils/styles.css
+++ b/client/utils/styles.css
@@ -295,10 +295,6 @@ body {
   color: #000;
   margin: 0.1rem 1rem;
 }
-.company-card .row-info small {
-  color: #000;
-  margin: 0px 1rem;
-}
 .company-card .row-cover {
   padding: 0.3rem 0px;
 }


### PR DESCRIPTION
1. 修正董事長頭銜的連結錯位問題
2. 將董事長與經理人頭銜放大為一般字型大小
3. 些微調整公司卡片的排版結構寫法，移除用 `small` 元素為基礎的縮排規則，改用 bootstrap 內建的 class 
代替，以減少誤解