### PR TITLE
調整 VIP 在換季時的掉級機制

### DIFF
--- a/client/layout/tutorial.js
+++ b/client/layout/tutorial.js
@@ -61,9 +61,6 @@ Template.tutorial.helpers({
   productRebateDeliverAmount() {
     return Meteor.settings.public.productRebates.deliverAmount;
   },
-  vipLevelDownChancePercent() {
-    return Math.round(Meteor.settings.public.vipLevelDownChance * 100);
-  },
   vipPreviousSeasonScoreWeightPercent() {
     return Math.round(Meteor.settings.public.vipPreviousSeasonScoreWeight * 100);
   },

--- a/config.js
+++ b/config.js
@@ -128,7 +128,6 @@ export const config = {
     }
   },
   vipLevelCheckInterval: 1800000, // VIP 等級更新時間 (ms)
-  vipLevelDownChance: 0.05, // VIP 掉級的機率
   vipPreviousSeasonScoreWeight: 0.80, // VIP 上季分數的權重
   companyProfitDistribution: { // 公司營利的分配設定
     lockTime: 86400000, // 分配設定調整的封關時間 (ms)

--- a/config.json
+++ b/config.json
@@ -128,7 +128,6 @@
       }
     },
     "vipLevelCheckInterval": 1800000,
-    "vipLevelDownChance": 0.05,
     "vipPreviousSeasonScoreWeight": 0.80,
     "companyProfitDistribution": {
       "lockTime": 86400000,

--- a/server/functions/vip/levelDownThresholdUnmetVips.js
+++ b/server/functions/vip/levelDownThresholdUnmetVips.js
@@ -16,7 +16,6 @@ export function levelDownThresholdUnmetVips() {
     }, {});
   const unsealedCompanyIds = Object.keys(companyVipThresholdsMap);
 
-  const { vipLevelDownChance } = Meteor.settings.public;
   const vipModifyList = [];
 
   dbVips
@@ -39,15 +38,10 @@ export function levelDownThresholdUnmetVips() {
         return;
       }
 
-      // 機率性降級
-      if (Math.random() > vipLevelDownChance) {
-        return;
-      }
-
-      // 符合條件的 VIP，調降一級
+      // 降級至最低符合的等級
       vipModifyList.push({
         query: { userId, companyId },
-        update: { $set: { level: level - 1 } }
+        update: { $set: { level: maxLevel } }
       });
     });
 


### PR DESCRIPTION
依照 https://acgn-stock.com/announcement/view/Z3yRemNrBXsame5YD 之計劃

1. 在低於門檻時，移除機率性掉級的判定，改成必定掉級
2. 進行掉級操作時，由原先的必定只掉一級，改為掉至最低符合門檻之等級