### PR TITLE
修正公司的 市值 與 資本額 資訊錯置的BUG

### DIFF
--- a/server/imports/metaTag/getCompanyMetaTag.js
+++ b/server/imports/metaTag/getCompanyMetaTag.js
@@ -28,7 +28,7 @@ function createCompanyMetaTag(companyData) {
 }
 
 function createCompanyDescription({ listPrice, capital, totalValue, description }) {
-  return `｜ 價格: ${listPrice.toLocaleString()} ｜ 市值: ${capital.toLocaleString()} ｜ 資本額: ${totalValue.toLocaleString()} ｜
+  return `｜ 價格: ${listPrice.toLocaleString()} ｜ 市值: ${totalValue.toLocaleString()} ｜ 資本額: ${capital.toLocaleString()} ｜
 
     ${removeMarkdown(description)}
   `;


### PR DESCRIPTION
在公司預覽資料裡的 市值 與 資本額 的資料互相放錯了，將其修正回來