### PR TITLE
 修正預覽資料的時間使用UTC+0導致的時間錯誤

### DIFF
--- a/common/imports/utils/formatTimeUtils.js
+++ b/common/imports/utils/formatTimeUtils.js
@@ -77,7 +77,7 @@ export function padZero(n) {
  * @returns {Date} 轉換時區後的時間
  */
 export function toCustomTimezone(date, timezone) {
-  if (isNaN(timezone)) {
+  if (typeof timezone !== 'number') {
     timezone = Meteor.settings.public.websiteInfo.timezone;
   }
 

--- a/common/imports/utils/formatTimeUtils.js
+++ b/common/imports/utils/formatTimeUtils.js
@@ -1,3 +1,5 @@
+import { Meteor } from 'meteor/meteor';
+
 export function formatDateTimeText(date) {
   if (! date) {
     return '????/??/?? ??:??:??';
@@ -66,4 +68,18 @@ export function formatLongDurationTimeText(time) {
 
 export function padZero(n) {
   return n < 10 ? `0${n}` : `${n}`;
+}
+
+/**
+ * 到指定的時區
+ * @param {Date} date 要轉換的時間
+ * @param {Number} [timezone] 時區，如 UTC+8 為 8，預設用config中的 websiteInfo.timezone
+ * @returns {Date} 轉換時區後的時間
+ */
+export function toCustomTimezone(date, timezone) {
+  if (isNaN(timezone)) {
+    timezone = Meteor.settings.public.websiteInfo.timezone;
+  }
+
+  return new Date(date.getTime() + date.getTimezoneOffset() * 60000 + timezone * 3600000);
 }

--- a/config.js
+++ b/config.js
@@ -5,7 +5,8 @@ export const config = {
     websiteName: 'ACGN股票交易市場', // 網站名稱
     description: '｜ 尋找你的老婆！ \n｜ 喜歡嗎？那麼就入股吧！',
     domainName: 'acgn-stock.com',
-    image: 'https://acgn-stock.com/ms-icon-310x310.png'
+    image: 'https://acgn-stock.com/ms-icon-310x310.png',
+    timezone: 8 // 主要客群所在的時區 (可能與server的時區不同)
   },
   intervalTimer: 60000, // 每隔多少毫秒進行一次工作檢查
   releaseStocksForHighPriceInterval: { // 高價釋股的排程時間範圍 (ms)

--- a/config.json
+++ b/config.json
@@ -5,7 +5,8 @@
       "websiteName": "ACGN股票交易市場",
       "description": "｜ 尋找你的老婆！ \n｜ 喜歡嗎？那麼就入股吧！",
       "domainName": "acgn-stock.com",
-      "image": "https://acgn-stock.com/ms-icon-310x310.png"
+      "image": "https://acgn-stock.com/ms-icon-310x310.png",
+      "timezone": 8
     },
     "intervalTimer": 60000,
     "releaseStocksForHighPriceInterval": {

--- a/server/imports/metaTag/getAnnouncementMetaTag.js
+++ b/server/imports/metaTag/getAnnouncementMetaTag.js
@@ -3,7 +3,7 @@ import { Meteor } from 'meteor/meteor';
 import { dbAnnouncements, announcementCategoryMap } from '/db/dbAnnouncements';
 import { createMetaProperty } from '/server/imports/metaTag/createMeta';
 import { removeMarkdown } from '/server/imports/metaTag/removeMarkdown';
-import { formatDateTimeText } from '/common/imports/utils/formatTimeUtils';
+import { formatDateTimeText, toCustomTimezone } from '/common/imports/utils/formatTimeUtils';
 
 export function getAnnouncementMetaTag(announcementId) {
   const announcementData = announcementId ? getAnnouncementData(announcementId) : null;
@@ -46,7 +46,7 @@ function createAnnouncementTitle({ category, subject, voided }) {
 }
 
 function createAnnouncementDescription({ content, createdAt, voided, voidedAt }) {
-  return `｜ 發佈時間: ${formatDateTimeText(createdAt)} ${voided ? `\n｜ 作廢時間: ${formatDateTimeText(voidedAt)}` : ''}
+  return `｜ 發佈時間: ${formatDateTimeText(toCustomTimezone(createdAt))} ${voided ? `\n｜ 作廢時間: ${formatDateTimeText(toCustomTimezone(voidedAt))}` : ''}
 
     ${removeMarkdown(content)}
   `;

--- a/server/imports/metaTag/getFoundationMetaTag.js
+++ b/server/imports/metaTag/getFoundationMetaTag.js
@@ -29,7 +29,7 @@ function createFoundationMetaTag(foundationData) {
 }
 
 function createFoundationDescription({ createdAt, description }) {
-  return `｜ 新創投資截止時間: ${getExpireDateText(toCustomTimezone(createdAt))} ｜
+  return `｜ 新創投資截止時間: ${getExpireDateText(createdAt)} ｜
 
     ${removeMarkdown(description)}
   `;
@@ -52,5 +52,5 @@ function getFoundationData(companyId) {
 function getExpireDateText(createdAt) {
   const expireDate = new Date(createdAt.getTime() + Meteor.settings.public.foundExpireTime);
 
-  return formatShortDateTimeText(expireDate);
+  return formatShortDateTimeText(toCustomTimezone(expireDate));
 }

--- a/server/imports/metaTag/getFoundationMetaTag.js
+++ b/server/imports/metaTag/getFoundationMetaTag.js
@@ -3,7 +3,7 @@ import { Meteor } from 'meteor/meteor';
 import { dbFoundations } from '/db/dbFoundations';
 import { createMetaProperty } from '/server/imports/metaTag/createMeta';
 import { removeMarkdown } from '/server/imports/metaTag/removeMarkdown';
-import { formatShortDateTimeText } from '/common/imports/utils/formatTimeUtils';
+import { formatShortDateTimeText, toCustomTimezone } from '/common/imports/utils/formatTimeUtils';
 
 export function getFoundationMetaTag(companyId) {
   const foundationData = companyId ? getFoundationData(companyId) : null;
@@ -29,7 +29,7 @@ function createFoundationMetaTag(foundationData) {
 }
 
 function createFoundationDescription({ createdAt, description }) {
-  return `｜ 新創投資截止時間: ${getExpireDateText(createdAt)} ｜
+  return `｜ 新創投資截止時間: ${getExpireDateText(toCustomTimezone(createdAt))} ｜
 
     ${removeMarkdown(description)}
   `;

--- a/server/imports/metaTag/getRuleAgendaMetaTag.js
+++ b/server/imports/metaTag/getRuleAgendaMetaTag.js
@@ -3,7 +3,7 @@ import { Meteor } from 'meteor/meteor';
 import { dbRuleAgendas } from '/db/dbRuleAgendas';
 import { createMetaProperty } from '/server/imports/metaTag/createMeta';
 import { removeMarkdown } from '/server/imports/metaTag/removeMarkdown';
-import { formatDateTimeText } from '/common/imports/utils/formatTimeUtils';
+import { formatDateTimeText, toCustomTimezone } from '/common/imports/utils/formatTimeUtils';
 
 export function getRuleAgendaMetaTag(agendaId) {
   const agendaData = agendaId ? getAgendaData(agendaId) : null;
@@ -30,7 +30,7 @@ function createAgendaMetaTag(agendaData) {
 }
 
 function createAgendaDescription(agendaData) {
-  return `｜ 投票結束時間: ${formatExpireDate(agendaData)} ｜
+  return `｜ 投票結束時間: ${formatExpireDate(toCustomTimezone(agendaData))} ｜
 
     ${removeMarkdown(agendaData.description)}
   `;

--- a/server/imports/metaTag/getRuleAgendaMetaTag.js
+++ b/server/imports/metaTag/getRuleAgendaMetaTag.js
@@ -30,7 +30,7 @@ function createAgendaMetaTag(agendaData) {
 }
 
 function createAgendaDescription(agendaData) {
-  return `｜ 投票結束時間: ${formatExpireDate(toCustomTimezone(agendaData))} ｜
+  return `｜ 投票結束時間: ${formatExpireDate(agendaData)} ｜
 
     ${removeMarkdown(agendaData.description)}
   `;
@@ -39,7 +39,7 @@ function createAgendaDescription(agendaData) {
 function formatExpireDate(agendaData) {
   const expireDate = new Date(agendaData.createdAt.getTime() + (agendaData.duration * 60 * 60 * 1000));
 
-  return formatDateTimeText(expireDate);
+  return formatDateTimeText(toCustomTimezone(expireDate));
 }
 
 function getAgendaData(agendaId) {

--- a/server/imports/metaTag/getViolationCaseMetaTag.js
+++ b/server/imports/metaTag/getViolationCaseMetaTag.js
@@ -3,7 +3,7 @@ import { Meteor } from 'meteor/meteor';
 import { dbViolationCases, stateMap, categoryMap } from '/db/dbViolationCases';
 import { createMetaProperty } from '/server/imports/metaTag/createMeta';
 import { removeMarkdown } from '/server/imports/metaTag/removeMarkdown';
-import { formatDateTimeText } from '/common/imports/utils/formatTimeUtils';
+import { formatDateTimeText, toCustomTimezone } from '/common/imports/utils/formatTimeUtils';
 
 export function getViolationCaseMetaTag(violationCaseId) {
   const violationCase = violationCaseId ? getViolationCase(violationCaseId) : null;
@@ -45,7 +45,7 @@ function createViolationCaseTitle({ state, category }) {
 }
 
 function createViolationCaseDescription({ description, createdAt, updatedAt }) {
-  return `｜ 舉報時間: ${formatDateTimeText(createdAt)} \n｜ 更新時間: ${formatDateTimeText(updatedAt)}
+  return `｜ 舉報時間: ${formatDateTimeText(toCustomTimezone(createdAt))} \n｜ 更新時間: ${formatDateTimeText(toCustomTimezone(updatedAt))}
 
     ${removeMarkdown(description)}
   `;


### PR DESCRIPTION
由於預覽資訊由server產生，但server所設定的時區(UTC+0) 與 多數使用者所用時區(UTC+8) 不同，因此要手動轉換時間來方便預覽

* config 中增加 `timezone` 的設定，可以設定主要客群所在的時區，產生預覽資訊時會依據此設定轉換時區
* `formatTimeUtils.js`中新增 `toCustomTimezone()` ，用於將時間轉換至指定時區，沒有指定時區會轉換成config中的 `timezone`