### PR TITLE
修正公司各評級的分割點與實際結果差一間的問題

### DIFF
--- a/server/functions/company/updateCompanyGrades.js
+++ b/server/functions/company/updateCompanyGrades.js
@@ -17,7 +17,7 @@ export function updateCompanyGrades() {
       skip: splitPosition
     });
 
-    return companyData ? companyData.capital : 0;
+    return companyData ? companyData.capital : -Infinity;
   });
 
   gradeNameList.forEach((grade, i) => {
@@ -27,8 +27,8 @@ export function updateCompanyGrades() {
     dbCompanies.update({
       isSeal: false,
       capital: {
-        $lt: capitalUpperBound,
-        $gte: capitalLowerBound
+        $lte: capitalUpperBound,
+        $gt: capitalLowerBound
       }
     }, {
       $set: { grade }


### PR DESCRIPTION
目前的寫法是，
以資本額排序後 skip 掉 n 間公司（也就是第 n + 1 間）當該評級資本額下界，
以前一評級的資本額下界當該評級資本額上界（若無則以 `Infinity` 為上界）。
但在實際分級時，誤將上界判斷用 `$lt` 以及下界判斷用 `$gte`，導致該評級原本只有 n 間公司的，現在會多一間。
解決方式是將上界判斷改用 `$lte` 以及下界判斷用 `$gt`。
配合本次調整，若最後一個評級的下界因 skip 掉所有公司而無法取得，此處以
`-Infinity` 作為下界值，而非先前預設的 0。