### PR TITLE
為工程組成員新增規則更新計劃與套用的公告權限

### DIFF
--- a/db/dbAnnouncements.js
+++ b/db/dbAnnouncements.js
@@ -18,11 +18,11 @@ export const announcementCategoryMap = {
   },
   plannedRuleChanges: {
     displayName: '規則更動計劃',
-    announceableBy: ['planner']
+    announceableBy: ['planner', 'developer']
   },
   appliedRuleChanges: {
     displayName: '規則更動套用',
-    announceableBy: ['planner']
+    announceableBy: ['planner', 'developer']
   },
   knownProblems: {
     displayName: '已知問題',


### PR DESCRIPTION
依照現行章程 https://acgn-stock.com/ruleDiscuss/view/F4zD6RXS8v8GF8Kb5
之第三條：

> 開發部主導之系統更新，不須經過投票程序，然應先行公告三至七天給予玩家周知，並保留玩家否決之權利。
> 系統更新實裝後，需進行更新公告，並於十四天內保留玩家否決之權利。

並未明訂規則更新計劃或套用公告只能由企劃組進行，
因此將工程組增加發佈此兩類公告的權限，在規則更新套用時能及時發佈公告，
並在適當的時候提供企劃組人力支援。