### PR TITLE
為新創計劃 / 公司新增創立人欄位，並修正一些問題

### DIFF
--- a/client/accountInfo/accountInfo.html
+++ b/client/accountInfo/accountInfo.html
@@ -196,6 +196,9 @@
       {{#if viewType 'manager'}}
         {{> managerTitleList}}
       {{/if}}
+      {{#if viewType 'creator'}}
+        {{> creatorTitleList}}
+      {{/if}}
       {{#if viewType 'employee'}}
         {{> employeeTitleList}}
       {{/if}}
@@ -213,6 +216,9 @@
     </li>
     <li class="nav-item">
       <a class="{{getClass 'manager'}}" href="#" data-type="manager">經理人</a>
+    </li>
+    <li class="nav-item">
+      <a class="{{getClass 'creator'}}" href="#" data-type="creator">創立人</a>
     </li>
     <li class="nav-item">
       <a class="{{getClass 'employee'}}" href="#" data-type="employee">員工</a>
@@ -251,6 +257,17 @@
 <template name="managerTitleList">
   {{#each titleList}}
     {{> companyTitle companyId=this._id title='經理人'}}
+  {{else}}
+    查無資料！
+  {{/each}}
+  {{#with paginationData}}
+    {{> pagination}}
+  {{/with}}
+</template>
+
+<template name="creatorTitleList">
+  {{#each titleList}}
+    {{> companyTitle companyId=this._id title='創立人'}}
   {{else}}
     查無資料！
   {{/each}}

--- a/client/accountInfo/accountInfo.html
+++ b/client/accountInfo/accountInfo.html
@@ -196,8 +196,8 @@
       {{#if viewType 'manager'}}
         {{> managerTitleList}}
       {{/if}}
-      {{#if viewType 'creator'}}
-        {{> creatorTitleList}}
+      {{#if viewType 'founder'}}
+        {{> founderTitleList}}
       {{/if}}
       {{#if viewType 'employee'}}
         {{> employeeTitleList}}
@@ -218,7 +218,7 @@
       <a class="{{getClass 'manager'}}" href="#" data-type="manager">經理人</a>
     </li>
     <li class="nav-item">
-      <a class="{{getClass 'creator'}}" href="#" data-type="creator">創立人</a>
+      <a class="{{getClass 'founder'}}" href="#" data-type="founder">創立人</a>
     </li>
     <li class="nav-item">
       <a class="{{getClass 'employee'}}" href="#" data-type="employee">員工</a>
@@ -265,7 +265,7 @@
   {{/with}}
 </template>
 
-<template name="creatorTitleList">
+<template name="founderTitleList">
   {{#each titleList}}
     {{> companyTitle companyId=this._id title='創立人'}}
   {{else}}

--- a/client/accountInfo/accountInfo.js
+++ b/client/accountInfo/accountInfo.js
@@ -159,7 +159,7 @@ Template.accountInfoBasic.events({
   }
 });
 
-export const companyTitleView = new ReactiveVar('chairman');
+const companyTitleView = new ReactiveVar('chairman');
 Template.companyTitleTab.helpers({
   getClass(type) {
     if (companyTitleView.get() === type) {
@@ -184,7 +184,7 @@ Template.accountCompanyTitle.helpers({
   }
 });
 
-export const chairmanOffset = new ReactiveVar(0);
+const chairmanOffset = new ReactiveVar(0);
 inheritedShowLoadingOnSubscribing(Template.chairmanTitleList);
 Template.chairmanTitleList.onCreated(function() {
   chairmanOffset.set(0);
@@ -225,7 +225,7 @@ Template.chairmanTitleList.events({
   }
 });
 
-export const managerOffset = new ReactiveVar(0);
+const managerOffset = new ReactiveVar(0);
 inheritedShowLoadingOnSubscribing(Template.managerTitleList);
 Template.managerTitleList.onCreated(function() {
   managerOffset.set(0);
@@ -255,6 +255,40 @@ Template.managerTitleList.helpers({
       useVariableForTotalCount: 'totalCountOfManagerTitle',
       dataNumberPerPage: 10,
       offset: managerOffset
+    };
+  }
+});
+
+const creatorOffset = new ReactiveVar(0);
+inheritedShowLoadingOnSubscribing(Template.creatorTitleList);
+Template.creatorTitleList.onCreated(function() {
+  creatorOffset.set(0);
+  this.autorun(() => {
+    if (shouldStopSubscribe()) {
+      return false;
+    }
+    const userId = paramUserId();
+    if (userId) {
+      this.subscribe('accountCreatorTitle', userId, creatorOffset.get());
+    }
+  });
+});
+Template.creatorTitleList.helpers({
+  titleList() {
+    return dbCompanies
+      .find({
+        creator: this._id,
+        isSeal: false
+      },
+      {
+        limit: 10
+      });
+  },
+  paginationData() {
+    return {
+      useVariableForTotalCount: 'totalCountOfCreatorTitle',
+      dataNumberPerPage: 10,
+      offset: creatorOffset
     };
   }
 });

--- a/client/accountInfo/accountInfo.js
+++ b/client/accountInfo/accountInfo.js
@@ -259,25 +259,25 @@ Template.managerTitleList.helpers({
   }
 });
 
-const creatorOffset = new ReactiveVar(0);
-inheritedShowLoadingOnSubscribing(Template.creatorTitleList);
-Template.creatorTitleList.onCreated(function() {
-  creatorOffset.set(0);
+const founderOffset = new ReactiveVar(0);
+inheritedShowLoadingOnSubscribing(Template.founderTitleList);
+Template.founderTitleList.onCreated(function() {
+  founderOffset.set(0);
   this.autorun(() => {
     if (shouldStopSubscribe()) {
       return false;
     }
     const userId = paramUserId();
     if (userId) {
-      this.subscribe('accountCreatorTitle', userId, creatorOffset.get());
+      this.subscribe('accountFounderTitle', userId, founderOffset.get());
     }
   });
 });
-Template.creatorTitleList.helpers({
+Template.founderTitleList.helpers({
   titleList() {
     return dbCompanies
       .find({
-        creator: this._id,
+        founder: this._id,
         isSeal: false
       },
       {
@@ -286,9 +286,9 @@ Template.creatorTitleList.helpers({
   },
   paginationData() {
     return {
-      useVariableForTotalCount: 'totalCountOfCreatorTitle',
+      useVariableForTotalCount: 'totalCountOfFounderTitle',
       dataNumberPerPage: 10,
-      offset: creatorOffset
+      offset: founderOffset
     };
   }
 });

--- a/client/company/companyDetailNormalContent.html
+++ b/client/company/companyDetailNormalContent.html
@@ -39,7 +39,6 @@
       <a href="#" class="badge badge-primary text-nowrap" data-action="showAllTags">顯示全部標籤</a>
     {{/unless}}
   </div>
-  <div class="text-nowrap my-1"><small>公司識別碼：{{company._id}}</small></div>
   <hr />
   <h2 class="card-subtitle mb-2 text-muted" style="word-break: break-all;">
     {{company.chairmanTitle}}：

--- a/client/company/companyList.js
+++ b/client/company/companyList.js
@@ -153,8 +153,8 @@ const companyListHelpers = {
     if (isCurrentUser(companyData.manager)) {
       return 'company-card-manager';
     }
-    if (isCurrentUser(companyData.creator)) {
-      return 'company-card-creator';
+    if (isCurrentUser(companyData.founder)) {
+      return 'company-card-founder';
     }
     const amount = companyListHelpers.getCurrentUserOwnedStockAmount(companyData._id);
     if (amount > 0) {

--- a/client/company/companyList.js
+++ b/client/company/companyList.js
@@ -153,6 +153,9 @@ const companyListHelpers = {
     if (isCurrentUser(companyData.manager)) {
       return 'company-card-manager';
     }
+    if (isCurrentUser(companyData.creator)) {
+      return 'company-card-creator';
+    }
     const amount = companyListHelpers.getCurrentUserOwnedStockAmount(companyData._id);
     if (amount > 0) {
       return 'company-card-holder';

--- a/client/company/companyMarketDataPanel.html
+++ b/client/company/companyMarketDataPanel.html
@@ -45,13 +45,23 @@
       <span class="text-nowrap">{{getCompanyEPRatio company}}</span>
     </div>
 
-    <div class="col-4 col-md-2 col-lg-1 border-grid d-flex flex-column align-items-center justify-content-between">
+    <div class="col-6 col-md-2 col-lg-1 border-grid d-flex flex-column align-items-center justify-content-between">
       <span class="text-nowrap">公司評級</span>
       <span class="text-nowrap">{{company.grade}}</span>
     </div>
-    <div class="col-8 col-md-4 col-lg-3 border-grid d-flex flex-column align-items-center justify-content-between">
+
+    <div class="col-6 col-md-4 col-lg-3 border-grid d-flex flex-column align-items-center justify-content-between">
+      <span class="text-nowrap">識別碼</span>
+      <span class="text-nowrap">{{company._id}}</span>
+    </div>
+
+    <div class="col-6 border-grid d-flex flex-column align-items-center justify-content-between">
       <span class="text-nowrap">創立時間</span>
       <span class="text-nowrap">{{formatDateTimeText company.createdAt}}</span>
+    </div>
+    <div class="col-6 border-grid d-flex flex-column align-items-center justify-content-between">
+      <span class="text-nowrap">創立人</span>
+      <span class="text-nowrap">{{>userLink company.creator}}</span>
     </div>
   </div>
 </template>

--- a/client/company/companyMarketDataPanel.html
+++ b/client/company/companyMarketDataPanel.html
@@ -61,7 +61,7 @@
     </div>
     <div class="col-6 border-grid d-flex flex-column align-items-center justify-content-between">
       <span class="text-nowrap">創立人</span>
-      <span class="text-nowrap">{{>userLink company.creator}}</span>
+      <span class="text-nowrap">{{>userLink company.founder}}</span>
     </div>
   </div>
 </template>

--- a/client/foundation/foundationDetail.html
+++ b/client/foundation/foundationDetail.html
@@ -51,7 +51,7 @@
         <hr />
         <h3>
           創立人：
-          {{>userLink this.creator}}
+          {{>userLink this.founder}}
         </h3>
         <h3>
           經理人：

--- a/client/foundation/foundationDetail.html
+++ b/client/foundation/foundationDetail.html
@@ -50,6 +50,10 @@
         {{/if}}
         <hr />
         <h3>
+          創立人：
+          {{>userLink this.creator}}
+        </h3>
+        <h3>
           經理人：
           {{>userLink this.manager}}
         </h3>

--- a/client/foundation/foundationList.html
+++ b/client/foundation/foundationList.html
@@ -93,6 +93,14 @@
         </div>
         <div class="row row-info d-flex flex-column justify-content-between">
           <div class="text-left mx-3">
+            創立人
+          </div>
+          <div class="text-right mx-3 text-truncate">
+            <h4 class="text-truncate">{{>userLink this.creator}}</h4>
+          </div>
+        </div>
+        <div class="row row-info d-flex flex-column justify-content-between">
+          <div class="text-left mx-3">
             經理人
           </div>
           <div class="text-right mx-3 text-truncate">

--- a/client/foundation/foundationList.html
+++ b/client/foundation/foundationList.html
@@ -96,7 +96,7 @@
             創立人
           </div>
           <div class="text-right mx-3 text-truncate">
-            <h4 class="text-truncate">{{>userLink this.creator}}</h4>
+            <h4 class="text-truncate">{{>userLink this.founder}}</h4>
           </div>
         </div>
         <div class="row row-info d-flex flex-column justify-content-between">

--- a/client/foundation/foundationList.js
+++ b/client/foundation/foundationList.js
@@ -149,6 +149,9 @@ const foundationListHelpers = {
     if (isCurrentUser(this.manager)) {
       return 'company-card-manager';
     }
+    if (isCurrentUser(this.creator)) {
+      return 'company-card-creator';
+    }
     const invest = this.invest;
     const userId = Meteor.user()._id;
     const investData = _.findWhere(invest, { userId });

--- a/client/foundation/foundationList.js
+++ b/client/foundation/foundationList.js
@@ -149,8 +149,8 @@ const foundationListHelpers = {
     if (isCurrentUser(this.manager)) {
       return 'company-card-manager';
     }
-    if (isCurrentUser(this.creator)) {
-      return 'company-card-creator';
+    if (isCurrentUser(this.founder)) {
+      return 'company-card-founder';
     }
     const invest = this.invest;
     const userId = Meteor.user()._id;

--- a/client/utils/styles.css
+++ b/client/utils/styles.css
@@ -233,7 +233,7 @@ body {
   background: -moz-linear-gradient(225deg, #fffbd5, #b20a2c);
   background: linear-gradient(225deg, #fffbd5, #b20a2c);
 }
-.company-card-creator {
+.company-card-founder {
   background: #39c5bb;
   background: -webkit-linear-gradient(225deg, #fffbd5, #39c5bb);
   background: -o-linear-gradient(225deg, #fffbd5, #39c5bb);

--- a/client/utils/styles.css
+++ b/client/utils/styles.css
@@ -233,6 +233,13 @@ body {
   background: -moz-linear-gradient(225deg, #fffbd5, #b20a2c);
   background: linear-gradient(225deg, #fffbd5, #b20a2c);
 }
+.company-card-creator {
+  background: #39c5bb;
+  background: -webkit-linear-gradient(225deg, #fffbd5, #39c5bb);
+  background: -o-linear-gradient(225deg, #fffbd5, #39c5bb);
+  background: -moz-linear-gradient(225deg, #fffbd5, #39c5bb);
+  background: linear-gradient(225deg, #fffbd5, #39c5bb);
+}
 .company-card-holder {
   background: #8e9eab;
   background: -webkit-linear-gradient(135deg, #eef2f3, #8e9eab);

--- a/db/dbCompanies.js
+++ b/db/dbCompanies.js
@@ -8,7 +8,6 @@ import { dbVariables } from './dbVariables';
 
 // 公司資料集
 export const dbCompanies = new Mongo.Collection('companies');
-export default dbCompanies;
 
 // 公司評等名稱
 export const gradeNameList = ['S', 'A', 'B', 'C', 'D'];
@@ -155,7 +154,11 @@ const schema = new SimpleSchema({
     min: 1,
     max: 100
   },
-  // 總經理userId
+  // 創立者 userId
+  creator: {
+    type: String
+  },
+  // 經理人 userId
   manager: {
     type: String
   },
@@ -165,7 +168,7 @@ const schema = new SimpleSchema({
     max: 20,
     defaultValue: '董事長'
   },
-  // 董事長userId
+  // 董事長 userId
   chairman: {
     type: String
   },

--- a/db/dbCompanies.js
+++ b/db/dbCompanies.js
@@ -155,7 +155,7 @@ const schema = new SimpleSchema({
     max: 100
   },
   // 創立者 userId
-  creator: {
+  founder: {
     type: String
   },
   // 經理人 userId

--- a/db/dbFoundations.js
+++ b/db/dbFoundations.js
@@ -13,7 +13,7 @@ const schema = new SimpleSchema({
     max: 100
   },
   // 創立人 userId
-  creator: {
+  founder: {
     type: String
   },
   // 經理人 userId

--- a/db/dbFoundations.js
+++ b/db/dbFoundations.js
@@ -12,7 +12,11 @@ const schema = new SimpleSchema({
     min: 1,
     max: 100
   },
-  // 創立人userId
+  // 創立人 userId
+  creator: {
+    type: String
+  },
+  // 經理人 userId
   manager: {
     type: String
   },

--- a/dev-utils/factories.js
+++ b/dev-utils/factories.js
@@ -24,6 +24,7 @@ export const companyFactory = new Factory()
     companyName() {
       return faker.company.companyName();
     },
+    creator: 'some-user',
     manager: '!none',
     chairman: '!none',
     description() {
@@ -58,6 +59,7 @@ export const foundationFactory = new Factory()
     companyName() {
       return faker.company.companyName();
     },
+    creator: 'some-user',
     manager: '!none',
     description() {
       return faker.lorem.paragraph();

--- a/dev-utils/factories.js
+++ b/dev-utils/factories.js
@@ -24,7 +24,7 @@ export const companyFactory = new Factory()
     companyName() {
       return faker.company.companyName();
     },
-    creator: 'some-user',
+    founder: 'some-user',
     manager: '!none',
     chairman: '!none',
     description() {
@@ -59,7 +59,7 @@ export const foundationFactory = new Factory()
     companyName() {
       return faker.company.companyName();
     },
-    creator: 'some-user',
+    founder: 'some-user',
     manager: '!none',
     description() {
       return faker.lorem.paragraph();

--- a/integration-test/server/functions/foundation/doOnFoundationFailure.test.js
+++ b/integration-test/server/functions/foundation/doOnFoundationFailure.test.js
@@ -82,26 +82,26 @@ describe('function doOnFoundationFailure', function() {
     });
   });
 
-  it('should return only fund except "founderEarnestMoney" if the investor is the creator', function() {
+  it('should return only fund except "founderEarnestMoney" if the investor is the founder', function() {
     const extraAmount = 1000;
-    const creatorUserId = 'the-creator';
+    const founderUserId = 'the-founder';
 
-    const creatorInvestor = {
-      userId: creatorUserId,
+    const founderInvestor = {
+      userId: founderUserId,
       amount: Meteor.settings.public.founderEarnestMoney + extraAmount
     };
 
-    Meteor.users.rawCollection().insert({ _id: creatorUserId, profile: { money: 0 } });
+    Meteor.users.rawCollection().insert({ _id: founderUserId, profile: { money: 0 } });
 
     dbFoundations.update(companyId, {
-      $set: { creator: creatorUserId },
-      $push: { invest: creatorInvestor }
+      $set: { founder: founderUserId },
+      $push: { invest: founderInvestor }
     });
     const foundationData = dbFoundations.findOne(companyId);
     doOnFoundationFailure(foundationData);
 
-    const { refund } = dbLog.findOne({ logType: '創立退款', userId: creatorUserId }).data;
-    const { money } = Meteor.users.findOne(creatorUserId).profile;
+    const { refund } = dbLog.findOne({ logType: '創立退款', userId: founderUserId }).data;
+    const { money } = Meteor.users.findOne(founderUserId).profile;
 
     refund.must.be.equal(extraAmount);
     money.must.be.equal(extraAmount);

--- a/integration-test/server/functions/foundation/doOnFoundationFailure.test.js
+++ b/integration-test/server/functions/foundation/doOnFoundationFailure.test.js
@@ -60,7 +60,7 @@ describe('function doOnFoundationFailure', function() {
 
     const logData = dbLog.findOne({ logType: '創立失敗' });
     expect(logData).to.exist();
-    logData.userId.must.be.eql(_.union([foundationData.manager], _.pluck(investors, 'userId')));
+    logData.userId.must.be.eql(_.pluck(investors, 'userId'));
     logData.data.companyName.must.be.equal(foundationData.companyName);
   });
 
@@ -82,26 +82,26 @@ describe('function doOnFoundationFailure', function() {
     });
   });
 
-  it('should return only fund except "founderEarnestMoney" if the investor is the manager', function() {
+  it('should return only fund except "founderEarnestMoney" if the investor is the creator', function() {
     const extraAmount = 1000;
-    const managerUserId = 'manager';
+    const creatorUserId = 'the-creator';
 
-    const managerInvestor = {
-      userId: managerUserId,
+    const creatorInvestor = {
+      userId: creatorUserId,
       amount: Meteor.settings.public.founderEarnestMoney + extraAmount
     };
 
-    Meteor.users.rawCollection().insert({ _id: managerUserId, profile: { money: 0 } });
+    Meteor.users.rawCollection().insert({ _id: creatorUserId, profile: { money: 0 } });
 
     dbFoundations.update(companyId, {
-      $set: { manager: managerUserId },
-      $push: { invest: managerInvestor }
+      $set: { creator: creatorUserId },
+      $push: { invest: creatorInvestor }
     });
     const foundationData = dbFoundations.findOne(companyId);
     doOnFoundationFailure(foundationData);
 
-    const { refund } = dbLog.findOne({ logType: '創立退款', userId: managerUserId }).data;
-    const { money } = Meteor.users.findOne(managerUserId).profile;
+    const { refund } = dbLog.findOne({ logType: '創立退款', userId: creatorUserId }).data;
+    const { money } = Meteor.users.findOne(creatorUserId).profile;
 
     refund.must.be.equal(extraAmount);
     money.must.be.equal(extraAmount);

--- a/server/functions/foundation/doOnFoundationFailure.js
+++ b/server/functions/foundation/doOnFoundationFailure.js
@@ -7,7 +7,7 @@ import { dbCompanyArchive } from '/db/dbCompanyArchive';
 
 // 新創公司失敗之處理
 export function doOnFoundationFailure(foundationData) {
-  const { _id: companyId, invest, companyName, creator } = foundationData;
+  const { _id: companyId, invest, companyName, founder } = foundationData;
 
   const logBulk = dbLog.rawCollection().initializeUnorderedBulkOp();
   const usersBulk = Meteor.users.rawCollection().initializeUnorderedBulkOp();
@@ -22,7 +22,7 @@ export function doOnFoundationFailure(foundationData) {
   });
 
   invest.forEach(({ userId, amount }, index) => {
-    if (userId === creator) {
+    if (userId === founder) {
       amount -= Meteor.settings.public.founderEarnestMoney;
     }
 

--- a/server/functions/foundation/doOnFoundationFailure.js
+++ b/server/functions/foundation/doOnFoundationFailure.js
@@ -7,7 +7,7 @@ import { dbCompanyArchive } from '/db/dbCompanyArchive';
 
 // 新創公司失敗之處理
 export function doOnFoundationFailure(foundationData) {
-  const { _id: companyId, invest, companyName, manager } = foundationData;
+  const { _id: companyId, invest, companyName, creator } = foundationData;
 
   const logBulk = dbLog.rawCollection().initializeUnorderedBulkOp();
   const usersBulk = Meteor.users.rawCollection().initializeUnorderedBulkOp();
@@ -16,13 +16,13 @@ export function doOnFoundationFailure(foundationData) {
 
   logBulk.insert({
     logType: '創立失敗',
-    userId: _.union([manager], _.pluck(invest, 'userId')),
+    userId: _.pluck(invest, 'userId'),
     data: { companyName },
     createdAt: createdAt
   });
 
   invest.forEach(({ userId, amount }, index) => {
-    if (userId === foundationData.manager) {
+    if (userId === creator) {
       amount -= Meteor.settings.public.founderEarnestMoney;
     }
 
@@ -30,7 +30,7 @@ export function doOnFoundationFailure(foundationData) {
       logType: '創立退款',
       userId: [userId],
       data: {
-        companyName: foundationData.companyName,
+        companyName,
         refund: amount
       },
       createdAt: new Date(createdAt.getTime() + index + 1)

--- a/server/functions/foundation/doOnFoundationSuccess.js
+++ b/server/functions/foundation/doOnFoundationSuccess.js
@@ -101,6 +101,7 @@ export function doOnFoundationSuccess(foundationData) {
   const companySchema = dbCompanies.simpleSchema();
   const newCompanyData = companySchema.clean({
     companyName: foundationData.companyName,
+    creator: foundationData.creator,
     manager: foundationData.manager,
     chairman: '!none',
     chairmanTitle: '董事長',

--- a/server/functions/foundation/doOnFoundationSuccess.js
+++ b/server/functions/foundation/doOnFoundationSuccess.js
@@ -101,7 +101,7 @@ export function doOnFoundationSuccess(foundationData) {
   const companySchema = dbCompanies.simpleSchema();
   const newCompanyData = companySchema.clean({
     companyName: foundationData.companyName,
-    creator: foundationData.creator,
+    founder: foundationData.founder,
     manager: foundationData.manager,
     chairman: '!none',
     chairmanTitle: '董事長',

--- a/server/imports/migrations/037-add-company-creator.js
+++ b/server/imports/migrations/037-add-company-creator.js
@@ -1,0 +1,23 @@
+import { defineMigration } from '/server/imports/utils/defineMigration';
+import { executeBulksSync } from '/server/imports/utils/executeBulksSync';
+import { dbCompanies } from '/db/dbCompanies';
+import { dbLog } from '/db/dbLog';
+import { dbFoundations } from '/db/dbFoundations';
+
+defineMigration({
+  version: 37,
+  name: 'add company creator',
+  up() {
+    const companyBulk = dbCompanies.rawCollection().initializeUnorderedBulkOp();
+    const foundationBulk = dbFoundations.rawCollection().initializeUnorderedBulkOp();
+
+    dbLog.find({ logType: '創立公司' }).forEach(({ companyId, userId }) => {
+      const creator = userId[0];
+
+      companyBulk.find({ _id: companyId }).updateOne({ $set: { creator } });
+      foundationBulk.find({ _id: companyId }).updateOne({ $set: { creator } });
+    });
+
+    executeBulksSync(companyBulk, foundationBulk);
+  }
+});

--- a/server/imports/migrations/037-add-company-founder.js
+++ b/server/imports/migrations/037-add-company-founder.js
@@ -6,16 +6,16 @@ import { dbFoundations } from '/db/dbFoundations';
 
 defineMigration({
   version: 37,
-  name: 'add company creator',
+  name: 'add company founder',
   up() {
     const companyBulk = dbCompanies.rawCollection().initializeUnorderedBulkOp();
     const foundationBulk = dbFoundations.rawCollection().initializeUnorderedBulkOp();
 
     dbLog.find({ logType: '創立公司' }).forEach(({ companyId, userId }) => {
-      const creator = userId[0];
+      const founder = userId[0];
 
-      companyBulk.find({ _id: companyId }).updateOne({ $set: { creator } });
-      foundationBulk.find({ _id: companyId }).updateOne({ $set: { creator } });
+      companyBulk.find({ _id: companyId }).updateOne({ $set: { founder } });
+      foundationBulk.find({ _id: companyId }).updateOne({ $set: { founder } });
     });
 
     executeBulksSync(companyBulk, foundationBulk);

--- a/server/imports/migrations/index.js
+++ b/server/imports/migrations/index.js
@@ -34,4 +34,4 @@ import './033-announcement-voiding';
 import './034-add-ordinal-to-season';
 import './035-product-rating';
 import './036-fix-dbDirectors-have-two-same-user-director-data-in-one-company';
-import './037-add-company-creator';
+import './037-add-company-founder';

--- a/server/imports/migrations/index.js
+++ b/server/imports/migrations/index.js
@@ -34,3 +34,4 @@ import './033-announcement-voiding';
 import './034-add-ordinal-to-season';
 import './035-product-rating';
 import './036-fix-dbDirectors-have-two-same-user-director-data-in-one-company';
+import './037-add-company-creator';

--- a/server/methods/foundation/foundCompany.js
+++ b/server/methods/foundation/foundCompany.js
@@ -47,7 +47,7 @@ export function foundCompany(user, foundCompanyData) {
     throw new Meteor.Error(401, '您的現金不足，不足以支付投資保證金！');
   }
   const userId = user._id;
-  if (dbFoundations.find({ creator: userId }).count() > 0) {
+  if (dbFoundations.find({ founder: userId }).count() > 0) {
     throw new Meteor.Error(403, '您現在已經有一家新創公司正在申請中，無法同時發起第二家新創公司！');
   }
 
@@ -87,7 +87,7 @@ export function foundCompany(user, foundCompanyData) {
     if (user.profile.money < founderEarnestMoney) {
       throw new Meteor.Error(401, '您的現金不足，不足以支付投資保證金！');
     }
-    if (dbFoundations.find({ creator: userId }).count() > 0) {
+    if (dbFoundations.find({ founder: userId }).count() > 0) {
       throw new Meteor.Error(403, '您現在已經有一家新創公司正在籌備中，無法同時發起第二家新創公司！');
     }
     // 存放進archive中並取得_id
@@ -99,7 +99,7 @@ export function foundCompany(user, foundCompanyData) {
       pictureBig: foundCompanyData.pictureBig,
       description: foundCompanyData.description
     });
-    foundCompanyData.creator = userId;
+    foundCompanyData.founder = userId;
     foundCompanyData.manager = userId;
     const createdAt = new Date();
     foundCompanyData.createdAt = createdAt;

--- a/server/methods/foundation/foundCompany.js
+++ b/server/methods/foundation/foundCompany.js
@@ -47,7 +47,7 @@ export function foundCompany(user, foundCompanyData) {
     throw new Meteor.Error(401, '您的現金不足，不足以支付投資保證金！');
   }
   const userId = user._id;
-  if (dbFoundations.find({ manager: userId }).count() > 0) {
+  if (dbFoundations.find({ creator: userId }).count() > 0) {
     throw new Meteor.Error(403, '您現在已經有一家新創公司正在申請中，無法同時發起第二家新創公司！');
   }
 
@@ -87,7 +87,7 @@ export function foundCompany(user, foundCompanyData) {
     if (user.profile.money < founderEarnestMoney) {
       throw new Meteor.Error(401, '您的現金不足，不足以支付投資保證金！');
     }
-    if (dbFoundations.find({ manager: userId }).count() > 0) {
+    if (dbFoundations.find({ creator: userId }).count() > 0) {
       throw new Meteor.Error(403, '您現在已經有一家新創公司正在籌備中，無法同時發起第二家新創公司！');
     }
     // 存放進archive中並取得_id
@@ -99,6 +99,7 @@ export function foundCompany(user, foundCompanyData) {
       pictureBig: foundCompanyData.pictureBig,
       description: foundCompanyData.description
     });
+    foundCompanyData.creator = userId;
     foundCompanyData.manager = userId;
     const createdAt = new Date();
     foundCompanyData.createdAt = createdAt;

--- a/server/publications/accounts/accountCreatorTitle.js
+++ b/server/publications/accounts/accountCreatorTitle.js
@@ -6,26 +6,27 @@ import { limitSubscription } from '/server/imports/utils/rateLimit';
 import { debug } from '/server/imports/utils/debug';
 import { publishTotalCount } from '/server/imports/utils/publishTotalCount';
 
-Meteor.publish('accountChairmanTitle', function(userId, offset) {
-  debug.log('publish accountChairmanTitle', { userId, offset });
+Meteor.publish('accountCreatorTitle', function(userId, offset) {
+  debug.log('publish accountCreatorTitle', { userId, offset });
   check(userId, String);
   check(offset, Match.Integer);
 
-  const filter = { chairman: userId, isSeal: false };
+  const filter = { creator: userId, isSeal: false };
 
-  publishTotalCount('totalCountOfChairmanTitle', dbCompanies.find(filter), this);
+  publishTotalCount('totalCountOfCreatorTitle', dbCompanies.find(filter), this);
 
   return dbCompanies
     .find(filter, {
       fields: {
         isSeal: 1,
-        chairman: 1,
-        chairmanTitle: 1
+        creator: 1,
+        createdAt: 1
       },
+      sort: { createdAt: -1 },
       skip: offset,
       limit: 10,
       disableOplog: true
     });
 });
 // 一分鐘最多20次
-limitSubscription('accountChairmanTitle');
+limitSubscription('accountCreatorTitle');

--- a/server/publications/accounts/accountEmployeeTitle.js
+++ b/server/publications/accounts/accountEmployeeTitle.js
@@ -15,10 +15,14 @@ Meteor.publish('accounEmployeeTitle', function(userId) {
   return [
     dbEmployees.find(filter),
     dbCompanies.find({
-      '_id': {
-        '$in': dbEmployees.find(filter).map((companyData) => {
+      _id: {
+        $in: dbEmployees.find(filter).map((companyData) => {
           return companyData.companyId;
         })
+      }
+    }, {
+      fields: {
+        isSeal: 1
       }
     })
   ];

--- a/server/publications/accounts/accountFounderTitle.js
+++ b/server/publications/accounts/accountFounderTitle.js
@@ -6,20 +6,20 @@ import { limitSubscription } from '/server/imports/utils/rateLimit';
 import { debug } from '/server/imports/utils/debug';
 import { publishTotalCount } from '/server/imports/utils/publishTotalCount';
 
-Meteor.publish('accountCreatorTitle', function(userId, offset) {
-  debug.log('publish accountCreatorTitle', { userId, offset });
+Meteor.publish('accountFounderTitle', function(userId, offset) {
+  debug.log('publish accountFounderTitle', { userId, offset });
   check(userId, String);
   check(offset, Match.Integer);
 
-  const filter = { creator: userId, isSeal: false };
+  const filter = { founder: userId, isSeal: false };
 
-  publishTotalCount('totalCountOfCreatorTitle', dbCompanies.find(filter), this);
+  publishTotalCount('totalCountOfFounderTitle', dbCompanies.find(filter), this);
 
   return dbCompanies
     .find(filter, {
       fields: {
         isSeal: 1,
-        creator: 1,
+        founder: 1,
         createdAt: 1
       },
       sort: { createdAt: -1 },
@@ -29,4 +29,4 @@ Meteor.publish('accountCreatorTitle', function(userId, offset) {
     });
 });
 // 一分鐘最多20次
-limitSubscription('accountCreatorTitle');
+limitSubscription('accountFounderTitle');

--- a/server/publications/accounts/accountManagerTitle.js
+++ b/server/publications/accounts/accountManagerTitle.js
@@ -17,6 +17,10 @@ Meteor.publish('accountManagerTitle', function(userId, offset) {
 
   return dbCompanies
     .find(filter, {
+      fields: {
+        isSeal: 1,
+        manager: 1
+      },
       skip: offset,
       limit: 10,
       disableOplog: true
@@ -24,4 +28,3 @@ Meteor.publish('accountManagerTitle', function(userId, offset) {
 });
 // 一分鐘最多20次
 limitSubscription('accountManagerTitle');
-

--- a/server/publications/company/companyList.js
+++ b/server/publications/company/companyList.js
@@ -89,6 +89,7 @@ Meteor.publish('companyList', function({ keyword, matchType, onlyShow, sortBy, o
   const fields = {
     _id: 1,
     companyName: 1,
+    creator: 1,
     manager: 1,
     chairmanTitle: 1,
     chairman: 1,

--- a/server/publications/company/companyList.js
+++ b/server/publications/company/companyList.js
@@ -89,7 +89,7 @@ Meteor.publish('companyList', function({ keyword, matchType, onlyShow, sortBy, o
   const fields = {
     _id: 1,
     companyName: 1,
-    creator: 1,
+    founder: 1,
     manager: 1,
     chairmanTitle: 1,
     chairman: 1,


### PR DESCRIPTION
1. 新創計劃與公司加入 creator 欄位，以發起該公司新創計劃的人為創立者
2. 修正在新創階段若創立者被解職經理時，在新創失敗時，保證金會因該玩家當下不為經理而不正常歸還的問題
3. 限制頭銜查詢相關訂閱的回傳欄位，以避免不必要的資料傳輸或情報洩漏
4. 調整公司資訊排版，將公司識別碼移至數據資訊區，同時新增創立者顯示
5. 帳號資訊頭銜區新增該玩家的創立公司列表
6. 新創計劃與公司列表卡面新增創立者專屬顏色，其顯示優先度在董事長與經理之下
7. 限制同時進行的新創間數判斷不再以經理為基準，而以創立人為基準，避免解職馬上又復職的操作造成限制無法生效