### PR TITLE
實作待上架產品編輯功能

### DIFF
--- a/client/company/companyProductEditForm.html
+++ b/client/company/companyProductEditForm.html
@@ -1,5 +1,4 @@
 <template name="companyProductEditForm">
-
   {{> companyProductEditFormInner product}}
 </template>
 
@@ -25,7 +24,7 @@
       <label for="type" data-required>產品類別</label>
       <select class="form-control" name="type">
         {{#each type in productTypeList}}
-          <option value="{{type}}">{{type}}</option>
+          <option value="{{type}}" {{selectedAttr type (valueOf 'type')}}>{{type}}</option>
         {{/each}}
       </select>
       {{{errorHtmlOf 'type'}}}
@@ -34,7 +33,7 @@
       <label for="rating" data-required>產品分級</label>
       <select class="form-control" name="rating">
         {{#each rating in productRatingList}}
-          <option value="{{rating}}">{{rating}}</option>
+          <option value="{{rating}}" {{selectedAttr rating (valueOf 'rating')}}>{{rating}}</option>
         {{/each}}
       </select>
       {{{errorHtmlOf 'rating'}}}
@@ -81,7 +80,7 @@
         value="{{valueOf 'totalAmount'}}"
         min="1" />
       {{{errorHtmlOf 'totalAmount'}}}
-      <div class="mr-auto">需要生產資金：${{currencyFormat requiredProductionFund}}</div>
+      <div class="mr-auto">花費生產資金：${{currencyFormat requiredProductionFund}}</div>
     </div>
 
     <div class="d-flex flex-wrap justify-content-end">

--- a/client/company/editCompanySwitchContentManageProducts.html
+++ b/client/company/editCompanySwitchContentManageProducts.html
@@ -3,7 +3,7 @@
     <h4 class="mb-0 mr-2">
       待上架產品
     </h4>
-    <button class="btn btn-sm btn-primary" type="button" data-action="addProduct">
+    <button class="btn btn-sm btn-primary {{disabledOnFormVisibleClass}}" type="button" data-action="addProduct">
       <i class="fa fa-plus" aria-hidden="true"></i>
       新增
     </button>
@@ -19,7 +19,7 @@
     <div class="mr-auto">產品價格上限：${{currencyFormat company.productPriceLimit}}</div>
   </div>
 
-  {{#if inAddMode}}
+  {{#if isFormVisible}}
     <div class="my-3">
       {{> companyProductEditForm formArgs}}
     </div>
@@ -41,13 +41,24 @@
         <tr>
           <td class="text-left " data-title="產品">
             <div class="product-name">
+              {{#if isEditingProduct product._id}}
+                <span class="product-editing-badge badge badge-sm badge-danger badge-pill">編輯中</span>
+              {{/if}}
               <a href="{{product.url}}" title="{{product.productName}}" target="_blank">
                 {{product.productName}}
               </a>
             </div>
-            <div class="small mt-2 product-description">
+            <div class="small my-2 product-description">
               {{product.description}}
             </div>
+            <div class="small text-info">
+              由 {{> userLink product.creator}} 於 {{formatDateTimeText product.createdAt}} 建立
+            </div>
+            {{#if product.updatedAt}}
+              <div class="small text-info">
+                由 {{> userLink product.updatedBy}} 於 {{formatDateTimeText product.updatedAt}} 進行最後更新
+              </div>
+            {{/if}}
           </td>
           {{#if isUntyped product.type}}
             <td class="text-center text-truncate text-nowrap align-middle text-warning" data-title="類別">
@@ -74,7 +85,11 @@
             {{product.totalAmount}}
           </td>
           <td class="text-center text-truncate text-nowrap align-middle" data-title="管理">
-            <button class="btn btn-danger btn-sm" type="button" data-remove-product="{{product._id}}">
+            <button class="btn btn-info btn-sm {{disabledOnFormVisibleClass}}" type="button" data-action="editProduct" data-product-id="{{product._id}}">
+              <i class="fa fa-edit" aria-hidden="true"></i>
+              編輯
+            </button>
+            <button class="btn btn-danger btn-sm" type="button" data-action="removeProduct" data-product-id="{{product._id}}">
               <i class="fa fa-trash" aria-hidden="true"></i>
               刪除
             </button>

--- a/client/layout/tutorial.js
+++ b/client/layout/tutorial.js
@@ -3,12 +3,6 @@ import { _ } from 'meteor/underscore';
 import { Meteor } from 'meteor/meteor';
 import { Template } from 'meteor/templating';
 
-import { gradeNameList, gradeProportionMap } from '/db/dbCompanies';
-import { dbVariables } from '/db/dbVariables';
-import { VIP_LEVEL5_MAX_COUNT } from '/db/dbVips';
-import { importantFscLogTypeList } from '/db/dbLog';
-import { stonePowerTable } from '/db/dbCompanyStones';
-
 Template.tutorial.onCreated(function() {
   this.subscribe('fscMembers');
 });
@@ -22,92 +16,6 @@ Template.tutorial.events({
 });
 
 Template.tutorial.helpers({
-  importantFscLogTypeList() {
-    return importantFscLogTypeList;
-  },
-  fscRuleURL() {
-    return dbVariables.get('fscRuleURL');
-  },
-  newUserBirthStoneCount() {
-    return Meteor.settings.public.newUserBirthStones;
-  },
-  stonePower(stoneType) {
-    return stonePowerTable[stoneType];
-  },
-  stonePrice(stoneType) {
-    return Meteor.settings.public.stonePrice[stoneType];
-  },
-  miningMachineOperationHours() {
-    return Math.floor(Meteor.settings.public.miningMachineOperationTime / 1000 / 60 / 60);
-  },
-  productFinalSaleHours() {
-    return Math.floor(Meteor.settings.public.productFinalSaleTime / 1000 / 60 / 60);
-  },
-  systemProductVotingReward() {
-    return Meteor.settings.public.systemProductVotingReward;
-  },
-  employeeProductVotingRewardPercentage() {
-    return Meteor.settings.public.employeeProductVotingRewardFactor * 100;
-  },
-  productVoucherAmount() {
-    return Meteor.settings.public.productVoucherAmount;
-  },
-  productRebateDivisorAmount() {
-    return Meteor.settings.public.productRebates.divisorAmount;
-  },
-  productRebateDeliverAmount() {
-    return Meteor.settings.public.productRebates.deliverAmount;
-  },
-  vipPreviousSeasonScoreWeightPercent() {
-    return Math.round(Meteor.settings.public.vipPreviousSeasonScoreWeight * 100);
-  },
-  vipLevel5MaxCount() {
-    return VIP_LEVEL5_MAX_COUNT;
-  },
-  vipParameters() {
-    return Object.entries(Meteor.settings.public.vipParameters).map(([level, parameters]) => {
-      return {
-        level,
-        productProfitFactorPercent: Math.round(parameters.productProfitFactor * 100),
-        stockBonusFactorPercent: Math.round(parameters.stockBonusFactor * 100)
-      };
-    });
-  },
-  companyGradeList() {
-    return gradeNameList;
-  },
-  getCompanyGradeProportionPercentage(grade) {
-    return Math.round(gradeProportionMap[grade] * 100);
-  },
-  incomeTaxRatePercent() {
-    return Meteor.settings.public.companyProfitDistribution.incomeTaxRatePercent;
-  },
-  employeeProductVotingRewardRatePercent() {
-    return Meteor.settings.public.companyProfitDistribution.employeeProductVotingRewardRatePercent;
-  },
-  minCapitalIncreaseRatePercent() {
-    return Meteor.settings.public.companyProfitDistribution.capitalIncreaseRatePercent.min;
-  },
-  capitalIncreaseRatePercentLimit() {
-    return Meteor.settings.public.companyProfitDistribution.capitalIncreaseRatePercent.limit;
-  },
-  minManagerBonusRatePercent() {
-    return Meteor.settings.public.companyProfitDistribution.managerBonusRatePercent.min;
-  },
-  maxManagerBonusRatePercent() {
-    return Meteor.settings.public.companyProfitDistribution.managerBonusRatePercent.max;
-  },
-  minEmployeeBonusRatePercent() {
-    return Meteor.settings.public.companyProfitDistribution.employeeBonusRatePercent.min;
-  },
-  maxEmployeeBonusRatePercent() {
-    return Meteor.settings.public.companyProfitDistribution.employeeBonusRatePercent.max;
-  },
-  profitDistributionLockTimeHours() {
-    const { lockTime } = Meteor.settings.public.companyProfitDistribution;
-
-    return Math.floor(lockTime / 1000 / 60 / 60);
-  },
   fscMembers() {
     return _.pluck(Meteor.users.find({ 'profile.roles': 'fscMember' }, { sort: { createdAt: 1 } }).fetch(), '_id');
   }

--- a/client/product/productCard.html
+++ b/client/product/productCard.html
@@ -32,6 +32,12 @@
       </h5>
       <div class="card-subtitle product-description">{{product.description}}</div>
       <div class="text-right"><small>識別碼：{{product._id}}</small></div>
+      {{#if currentUserHasRole 'fscMember'}}
+        <div class="text-right text-info"><small>由 {{> userLink product.creator }} 於 {{formatDateTimeText product.createdAt}} 建立</small></div>
+        {{#if product.updatedAt}}
+          <div class="text-right text-info"><small>由 {{> userLink product.updatedBy }} 於 {{formatDateTimeText product.updatedAt}} 最後更新</small></div>
+        {{/if}}
+      {{/if}}
     </div>
     <div class="card-footer d-flex flex-wrap px-3">
       <div class="mr-auto my-1">

--- a/client/productCenter/productCenterByCompany.html
+++ b/client/productCenter/productCenterByCompany.html
@@ -30,7 +30,7 @@
   <table class="table-bordered custom-responsive-table-md product-list-by-company w-100" style="table-layout: fixed;">
     <thead>
       <tr>
-        <th class="text-center text-truncate" title="產品名稱">產品名稱</th>
+        <th class="text-center text-truncate" title="產品">產品</th>
         <th class="text-center text-truncate" style="width: 120px; cursor: pointer;" title="類別" data-sort="type">
           類別
           {{{getSortIcon 'type'}}}
@@ -56,17 +56,28 @@
           <td class="text-left px-md-1" data-title="產品名稱">
             <div class="product-name">{{>productLink product._id}}</div>
             <div class="small product-description">{{product.description}}</div>
+            {{#if currentUserHasRole 'fscMember'}}
+              <div class="small text-info mt-2">
+                識別碼：{{product._id}}
+              </div>
+              <div class="small text-info">
+                由 {{> userLink product.creator}} 於 {{formatDateTimeText product.createdAt}} 建立
+              </div>
+              <div class="small text-info">
+                {{#if product.updatedAt}}
+                  由 {{> userLink product.updatedBy }} 於 {{formatDateTimeText product.createdAt}} 最後編輯
+                {{/if}}
+              </div>
+            {{/if}}
           </td>
           <td class="text-center text-truncate" data-title="類別">
             {{product.type}}
           </td>
-          {{#if isRestrictedRating product.rating}}
-            <td class="text-center text-truncate text-nowrap text-danger" data-title="分級">
-              {{product.rating}}
+            <td class="text-center text-truncate text-nowrap" data-title="分級">
+              {{#if isRestrictedRating product.rating}}
+                <span class="text-danger">{{product.rating}}</span>
+              {{/if}}
             </td>
-          {{else}}
-            <td class="text-center text-truncate text-nowrap" data-title="分級"></td>
-          {{/if}}
           <td class="text-center text-truncate" data-title="得票數">
             <button
               class="btn btn-primary btn-sm"

--- a/client/productCenter/productCenterBySeason.html
+++ b/client/productCenter/productCenterBySeason.html
@@ -46,19 +46,19 @@
   <table class="table-bordered custom-responsive-table-md product-list-by-season w-100" style="table-layout: fixed;">
     <thead>
       <tr>
-        <th class="text-center text-truncate">產品</th>
-        <th class="text-center text-truncate" title="公司名稱">
+        <th class="text-center text-truncate" style="width: 40%">產品</th>
+        <th class="text-center text-truncate" style="width: 20%" title="公司名稱">
           公司名稱
         </th>
-        <th class="text-center text-truncate" style="width: 120px; cursor: pointer;" title="類別" data-sort="type">
+        <th class="text-center text-truncate" style="width: 100px; cursor: pointer;" title="類別" data-sort="type">
           類別
           {{{getSortIcon 'type'}}}
         </th>
-        <th class="text-center text-truncate" style="width: 120px; cursor: pointer;" title="分級" data-sort="rating">
+        <th class="text-center text-truncate" style="width: 100px; cursor: pointer;" title="分級" data-sort="rating">
           分級
           {{{getSortIcon 'rating'}}}
         </th>
-        <th class="text-center text-truncate" style="width: 120px; cursor: pointer;" title="得票數" data-sort="voteCount">
+        <th class="text-center text-truncate" style="width: 100px; cursor: pointer;" title="得票數" data-sort="voteCount">
           得票數
           {{{getSortIcon 'voteCount'}}}
         </th>
@@ -93,6 +93,19 @@
     <td class="text-left px-md-1" data-title="產品">
       <div class="product-name">{{>productLink this._id}}</div>
       <div class="small product-description">{{this.description}}</div>
+      {{#if currentUserHasRole 'fscMember'}}
+        <div class="small text-info mt-2">
+          識別碼：{{this._id}}
+        </div>
+        <div class="small text-info">
+          由 {{> userLink this.creator}} 於 {{formatDateTimeText this.createdAt}} 建立
+        </div>
+        <div class="small text-info">
+          {{#if this.updatedAt}}
+            由 {{> userLink this.updatedBy }} 於 {{formatDateTimeText this.createdAt}} 最後編輯
+          {{/if}}
+        </div>
+      {{/if}}
     </td>
     <td class="text-left text-truncate text-nowrap px-md-1" data-title="公司名稱">
       {{>companyLink this.companyId}}

--- a/client/utils/styles.css
+++ b/client/utils/styles.css
@@ -488,6 +488,16 @@ table.company-next-season-product .product-description {
   max-height: 3.5rem;
 }
 
+table.company-next-season-product .product-editing-badge {
+  animation: fade-loop 2s linear infinite
+}
+
+@keyframes fade-loop {
+  0% { opacity: 1; }
+  50% { opacity: 0; }
+  100% { opacity: 1; }
+}
+
 /* 產品卡 */
 .product-card .product-description {
   word-break: break-all;

--- a/db/dbProducts.js
+++ b/db/dbProducts.js
@@ -4,7 +4,6 @@ import SimpleSchema from 'simpl-schema';
 
 // 公司產品資料集
 export const dbProducts = new Mongo.Collection('products');
-export default dbProducts;
 
 export const productTypeList = [
   '未分類',
@@ -114,9 +113,23 @@ const schema = new SimpleSchema({
     type: SimpleSchema.Integer,
     defaultValue: 0
   },
+  // 建立人 userId
+  creator: {
+    type: String
+  },
   // 建立日期
   createdAt: {
     type: Date
+  },
+  // 最後更新產品的人 userId（金管會造成的修改除外）
+  updatedBy: {
+    type: String,
+    optional: true
+  },
+  // 更新日期（金管會造成的修改除外）
+  updatedAt: {
+    type: Date,
+    optional: true
   }
 });
 dbProducts.attachSchema(schema);

--- a/server/imports/migrations/038-add-creator-to-products.js
+++ b/server/imports/migrations/038-add-creator-to-products.js
@@ -1,0 +1,37 @@
+import { defineMigration } from '/server/imports/utils/defineMigration';
+import { executeBulksSync } from '/server/imports/utils/executeBulksSync';
+import { dbProducts } from '/db/dbProducts';
+import { dbLog } from '/db/dbLog';
+
+defineMigration({
+  version: 38,
+  name: 'add creator to products',
+  up() {
+    const productBulk = dbProducts.rawCollection().initializeUnorderedBulkOp();
+
+    dbProducts.find({}, { fields: { companyId: 1, createdAt: 1 } })
+      .forEach(({ _id: productId, companyId, createdAt }) => {
+        /*
+         * 以產品建立時間為準，往前找出負責上架該產品的人
+         * 產品建立當下公司有經理 -> 以當下的經理為建立者
+         * 產品建立當下公司無經理 -> 金管會代為上架，以金管會（!FSC）為建立者
+         */
+
+        const log = dbLog.findOne({
+          logType: { $in: ['創立公司', '就任經理', '辭職紀錄', '撤職紀錄'] },
+          companyId,
+          createdAt: { $lte: createdAt }
+        }, {
+          sort: { createdAt: -1 },
+          fields: { userId: 1 }
+        });
+
+        const noManager = ['辭職紀錄', '撤職紀錄'].includes(log.logType);
+        const creator = noManager ? '!FSC' : log.userId[0];
+
+        productBulk.find({ _id: productId }).updateOne({ $set: { creator } });
+      });
+
+    executeBulksSync(productBulk);
+  }
+});

--- a/server/imports/migrations/index.js
+++ b/server/imports/migrations/index.js
@@ -35,3 +35,4 @@ import './034-add-ordinal-to-season';
 import './035-product-rating';
 import './036-fix-dbDirectors-have-two-same-user-director-data-in-one-company';
 import './037-add-company-founder';
+import './038-add-creator-to-products';


### PR DESCRIPTION
1. products 新增 creator, updatedBy 與 updatedAt 欄位，
   分別代表產品的建立者、由誰最後更新以及最後更新時間。
   若是公司無經理而由金管會代為上架 / 編輯，則以金管會名義記錄
2. migration 時由產品的建立時間 (createdAt) 為準，
   找尋在當下時間最近就職的公司經理，以其為該產品之建立者
   若當下無經理，表示由金管會代為上架，以金管會為該產品之建立者
3. 微調產品管理頁面，加入建立者、最後更新的顯示，以及已建立的待上架產品編輯支援
4. client 端 tutorial.js 移除不必要的 helpers
5. 調整產品中心的顯示，金管會成員將會看到產品識別碼、建立者與時間、編輯者與時間的情報