### PR TITLE
 實作待上架產品編輯功能 & 補貨方案擴增 & 其他修正

### DIFF
--- a/client/company/companyProductEditForm.html
+++ b/client/company/companyProductEditForm.html
@@ -1,5 +1,4 @@
 <template name="companyProductEditForm">
-
   {{> companyProductEditFormInner product}}
 </template>
 
@@ -25,7 +24,7 @@
       <label for="type" data-required>產品類別</label>
       <select class="form-control" name="type">
         {{#each type in productTypeList}}
-          <option value="{{type}}">{{type}}</option>
+          <option value="{{type}}" {{selectedAttr type (valueOf 'type')}}>{{type}}</option>
         {{/each}}
       </select>
       {{{errorHtmlOf 'type'}}}
@@ -34,7 +33,7 @@
       <label for="rating" data-required>產品分級</label>
       <select class="form-control" name="rating">
         {{#each rating in productRatingList}}
-          <option value="{{rating}}">{{rating}}</option>
+          <option value="{{rating}}" {{selectedAttr rating (valueOf 'rating')}}>{{rating}}</option>
         {{/each}}
       </select>
       {{{errorHtmlOf 'rating'}}}
@@ -81,7 +80,7 @@
         value="{{valueOf 'totalAmount'}}"
         min="1" />
       {{{errorHtmlOf 'totalAmount'}}}
-      <div class="mr-auto">需要生產資金：${{currencyFormat requiredProductionFund}}</div>
+      <div class="mr-auto">花費生產資金：${{currencyFormat requiredProductionFund}}</div>
     </div>
 
     <div class="d-flex flex-wrap justify-content-end">

--- a/client/company/companyProductEditForm.html
+++ b/client/company/companyProductEditForm.html
@@ -72,7 +72,7 @@
       {{{errorHtmlOf 'price'}}}
     </div>
     <div class="form-group">
-      <label for="totalAmount" data-required>產品數量</label>
+      <label for="totalAmount" data-required>產品總數</label>
       <input
         class="form-control"
         type="number"
@@ -80,7 +80,37 @@
         value="{{valueOf 'totalAmount'}}"
         min="1" />
       {{{errorHtmlOf 'totalAmount'}}}
-      <div class="mr-auto">花費生產資金：${{currencyFormat requiredProductionFund}}</div>
+    </div>
+    <div class="form-group">
+      <label for="replenishBaseAmountType" data-required>產品補貨基準</label>
+      <select class="form-control" name="replenishBaseAmountType">
+        {{#each replenishBaseAmountType in productReplenishBaseAmountTypeList}}
+          <option value="{{replenishBaseAmountType}}"
+              {{selectedAttr replenishBaseAmountType (valueOf 'replenishBaseAmountType')}}>
+            {{productReplenishBaseAmountTypeDisplayName replenishBaseAmountType}}
+          </option>
+        {{/each}}
+      </select>
+      {{{errorHtmlOf 'replenishBaseAmountType'}}}
+    </div>
+    <div class="form-group">
+      <label for="replenishBatchSizeType" data-required>產品補貨量</label>
+      <select class="form-control" name="replenishBatchSizeType">
+        {{#each replenishBatchSizeType in productReplenishBatchSizeTypeList}}
+          <option value="{{replenishBatchSizeType}}"
+              {{selectedAttr replenishBatchSizeType (valueOf 'replenishBatchSizeType')}}>
+            {{productReplenishBatchSizeTypeDisplayName replenishBatchSizeType}}
+          </option>
+        {{/each}}
+      </select>
+      {{{errorHtmlOf 'replenishBatchSizeType'}}}
+    </div>
+
+    <div class="form-group">
+      <div name="productionFund">
+        花費生產資金：${{currencyFormat requiredProductionFund}}
+      </div>
+      {{{errorHtmlOf 'productionFund'}}}
     </div>
 
     <div class="d-flex flex-wrap justify-content-end">

--- a/client/company/editCompanySwitchContentManageProducts.html
+++ b/client/company/editCompanySwitchContentManageProducts.html
@@ -3,7 +3,7 @@
     <h4 class="mb-0 mr-2">
       待上架產品
     </h4>
-    <button class="btn btn-sm btn-primary" type="button" data-action="addProduct">
+    <button class="btn btn-sm btn-primary {{disabledOnFormVisibleClass}}" type="button" data-action="addProduct">
       <i class="fa fa-plus" aria-hidden="true"></i>
       新增
     </button>
@@ -19,7 +19,7 @@
     <div class="mr-auto">產品價格上限：${{currencyFormat company.productPriceLimit}}</div>
   </div>
 
-  {{#if inAddMode}}
+  {{#if isFormVisible}}
     <div class="my-3">
       {{> companyProductEditForm formArgs}}
     </div>
@@ -41,13 +41,24 @@
         <tr>
           <td class="text-left " data-title="產品">
             <div class="product-name">
+              {{#if isEditingProduct product._id}}
+                <span class="product-editing-badge badge badge-sm badge-danger badge-pill">編輯中</span>
+              {{/if}}
               <a href="{{product.url}}" title="{{product.productName}}" target="_blank">
                 {{product.productName}}
               </a>
             </div>
-            <div class="small mt-2 product-description">
+            <div class="small my-2 product-description">
               {{product.description}}
             </div>
+            <div class="small text-info">
+              由 {{> userLink product.creator}} 於 {{formatDateTimeText product.createdAt}} 建立
+            </div>
+            {{#if product.updatedAt}}
+              <div class="small text-info">
+                由 {{> userLink product.updatedBy}} 於 {{formatDateTimeText product.updatedAt}} 進行最後更新
+              </div>
+            {{/if}}
           </td>
           {{#if isUntyped product.type}}
             <td class="text-center text-truncate text-nowrap align-middle text-warning" data-title="類別">
@@ -74,7 +85,11 @@
             {{product.totalAmount}}
           </td>
           <td class="text-center text-truncate text-nowrap align-middle" data-title="管理">
-            <button class="btn btn-danger btn-sm" type="button" data-remove-product="{{product._id}}">
+            <button class="btn btn-info btn-sm {{disabledOnFormVisibleClass}}" type="button" data-action="editProduct" data-product-id="{{product._id}}">
+              <i class="fa fa-edit" aria-hidden="true"></i>
+              編輯
+            </button>
+            <button class="btn btn-danger btn-sm" type="button" data-action="removeProduct" data-product-id="{{product._id}}">
               <i class="fa fa-trash" aria-hidden="true"></i>
               刪除
             </button>

--- a/client/company/editCompanySwitchContentManageProducts.html
+++ b/client/company/editCompanySwitchContentManageProducts.html
@@ -33,13 +33,15 @@
         <th class="text-center text-truncate" style="width: 60px;" title="分級">分級</th>
         <th class="text-center text-truncate" style="width: 60px;" title="價格">價格</th>
         <th class="text-center text-truncate" style="width: 60px;" title="數量">數量</th>
+        <th class="text-center text-truncate" style="width: 60px;" title="補貨基準">補貨基準</th>
+        <th class="text-center text-truncate" style="width: 60px;" title="補貨量">補貨量</th>
         <th class="text-center text-truncate" style="width: 60px;" title="管理">管理</th>
       </tr>
     </thead>
     <tbody>
       {{#each product in productList}}
         <tr>
-          <td class="text-left " data-title="產品">
+          <td class="text-left" data-title="產品">
             <div class="product-name">
               {{#if isEditingProduct product._id}}
                 <span class="product-editing-badge badge badge-sm badge-danger badge-pill">編輯中</span>
@@ -84,6 +86,12 @@
           <td class="text-center text-truncate text-nowrap align-middle" data-title="數量">
             {{product.totalAmount}}
           </td>
+          <td class="text-center text-truncate text-nowrap align-middle" data-title="補貨基準">
+            {{productReplenishBaseAmountTypeDisplayName product.replenishBaseAmountType}}
+          </td>
+          <td class="text-center text-truncate text-nowrap align-middle" data-title="補貨量">
+            {{productReplenishBatchSizeTypeDisplayName product.replenishBatchSizeType}}
+          </td>
           <td class="text-center text-truncate text-nowrap align-middle" data-title="管理">
             <button class="btn btn-info btn-sm {{disabledOnFormVisibleClass}}" type="button" data-action="editProduct" data-product-id="{{product._id}}">
               <i class="fa fa-edit" aria-hidden="true"></i>
@@ -97,7 +105,7 @@
         </tr>
       {{else}}
         <tr class="default-content">
-          <td class="text-center text-truncate p-1" colspan="6">目前沒有預定產品！</td>
+          <td class="text-center text-truncate p-1" colspan="8">目前沒有預定產品！</td>
         </tr>
       {{/each}}
     </tbody>

--- a/client/company/editCompanySwitchContentManageProducts.js
+++ b/client/company/editCompanySwitchContentManageProducts.js
@@ -5,7 +5,11 @@ import { Template } from 'meteor/templating';
 import { ReactiveVar } from 'meteor/reactive-var';
 
 import { getTotalProductionFund, getUsedProductionFund, getPlanningProducts } from '/db/dbCompanies';
-import { dbProducts, productTypeList, productRatingList } from '/db/dbProducts';
+import {
+  dbProducts, productTypeList, productRatingList,
+  productReplenishBaseAmountTypeDisplayName, productReplenishBatchSizeTypeDisplayName,
+  productReplenishBatchSizeTypeList, productReplenishBaseAmountTypeList
+} from '/db/dbProducts';
 import { alertDialog } from '../layout/alertDialog';
 import { paramCompany, paramCompanyId } from './helpers';
 
@@ -15,6 +19,8 @@ Template.editCompanySwitchContentManageProducts.onCreated(function() {
 });
 
 Template.editCompanySwitchContentManageProducts.helpers({
+  productReplenishBatchSizeTypeDisplayName,
+  productReplenishBaseAmountTypeDisplayName,
   isFormVisible() {
     return Template.instance().productEditFormVisible.get();
   },
@@ -25,11 +31,11 @@ Template.editCompanySwitchContentManageProducts.helpers({
     const templateInstance = Template.instance();
 
     const emptyProductData = {
-      productName: '',
       companyId: paramCompanyId(),
       type: productTypeList[0],
       rating: productRatingList[0],
-      url: ''
+      replenishBaseAmountType: productReplenishBaseAmountTypeList[0],
+      replenishBatchSizeType: productReplenishBatchSizeTypeList[0]
     };
 
     const productId = templateInstance.editingProductId.get();

--- a/client/layout/tutorial.js
+++ b/client/layout/tutorial.js
@@ -3,12 +3,6 @@ import { _ } from 'meteor/underscore';
 import { Meteor } from 'meteor/meteor';
 import { Template } from 'meteor/templating';
 
-import { gradeNameList, gradeProportionMap } from '/db/dbCompanies';
-import { dbVariables } from '/db/dbVariables';
-import { VIP_LEVEL5_MAX_COUNT } from '/db/dbVips';
-import { importantFscLogTypeList } from '/db/dbLog';
-import { stonePowerTable } from '/db/dbCompanyStones';
-
 Template.tutorial.onCreated(function() {
   this.subscribe('fscMembers');
 });
@@ -22,92 +16,6 @@ Template.tutorial.events({
 });
 
 Template.tutorial.helpers({
-  importantFscLogTypeList() {
-    return importantFscLogTypeList;
-  },
-  fscRuleURL() {
-    return dbVariables.get('fscRuleURL');
-  },
-  newUserBirthStoneCount() {
-    return Meteor.settings.public.newUserBirthStones;
-  },
-  stonePower(stoneType) {
-    return stonePowerTable[stoneType];
-  },
-  stonePrice(stoneType) {
-    return Meteor.settings.public.stonePrice[stoneType];
-  },
-  miningMachineOperationHours() {
-    return Math.floor(Meteor.settings.public.miningMachineOperationTime / 1000 / 60 / 60);
-  },
-  productFinalSaleHours() {
-    return Math.floor(Meteor.settings.public.productFinalSaleTime / 1000 / 60 / 60);
-  },
-  systemProductVotingReward() {
-    return Meteor.settings.public.systemProductVotingReward;
-  },
-  employeeProductVotingRewardPercentage() {
-    return Meteor.settings.public.employeeProductVotingRewardFactor * 100;
-  },
-  productVoucherAmount() {
-    return Meteor.settings.public.productVoucherAmount;
-  },
-  productRebateDivisorAmount() {
-    return Meteor.settings.public.productRebates.divisorAmount;
-  },
-  productRebateDeliverAmount() {
-    return Meteor.settings.public.productRebates.deliverAmount;
-  },
-  vipPreviousSeasonScoreWeightPercent() {
-    return Math.round(Meteor.settings.public.vipPreviousSeasonScoreWeight * 100);
-  },
-  vipLevel5MaxCount() {
-    return VIP_LEVEL5_MAX_COUNT;
-  },
-  vipParameters() {
-    return Object.entries(Meteor.settings.public.vipParameters).map(([level, parameters]) => {
-      return {
-        level,
-        productProfitFactorPercent: Math.round(parameters.productProfitFactor * 100),
-        stockBonusFactorPercent: Math.round(parameters.stockBonusFactor * 100)
-      };
-    });
-  },
-  companyGradeList() {
-    return gradeNameList;
-  },
-  getCompanyGradeProportionPercentage(grade) {
-    return Math.round(gradeProportionMap[grade] * 100);
-  },
-  incomeTaxRatePercent() {
-    return Meteor.settings.public.companyProfitDistribution.incomeTaxRatePercent;
-  },
-  employeeProductVotingRewardRatePercent() {
-    return Meteor.settings.public.companyProfitDistribution.employeeProductVotingRewardRatePercent;
-  },
-  minCapitalIncreaseRatePercent() {
-    return Meteor.settings.public.companyProfitDistribution.capitalIncreaseRatePercent.min;
-  },
-  capitalIncreaseRatePercentLimit() {
-    return Meteor.settings.public.companyProfitDistribution.capitalIncreaseRatePercent.limit;
-  },
-  minManagerBonusRatePercent() {
-    return Meteor.settings.public.companyProfitDistribution.managerBonusRatePercent.min;
-  },
-  maxManagerBonusRatePercent() {
-    return Meteor.settings.public.companyProfitDistribution.managerBonusRatePercent.max;
-  },
-  minEmployeeBonusRatePercent() {
-    return Meteor.settings.public.companyProfitDistribution.employeeBonusRatePercent.min;
-  },
-  maxEmployeeBonusRatePercent() {
-    return Meteor.settings.public.companyProfitDistribution.employeeBonusRatePercent.max;
-  },
-  profitDistributionLockTimeHours() {
-    const { lockTime } = Meteor.settings.public.companyProfitDistribution;
-
-    return Math.floor(lockTime / 1000 / 60 / 60);
-  },
   fscMembers() {
     return _.pluck(Meteor.users.find({ 'profile.roles': 'fscMember' }, { sort: { createdAt: 1 } }).fetch(), '_id');
   }

--- a/client/product/productCard.html
+++ b/client/product/productCard.html
@@ -1,24 +1,31 @@
 <template name="productCard">
   <div class="card my-2 product-card">
-    <div class="card-header d-flex flex-wrap py-2 px-3">
-      <div class="mr-3">價格：${{currencyFormat product.price}}</div>
-      <div class="mr-auto">
-        {{#if product.availableAmount}}
-          尚餘：{{product.availableAmount}}
-        {{else}}
-          {{#if product.hasStockAmount}}
-            <span class="text-warning">補貨中</span>
+    <div class="card-header py-2 px-3">
+      <div class="d-flex flex-wrap mr-auto">
+        <div class="mr-3">價格：${{currencyFormat product.price}}</div>
+        <div>
+          {{#if product.availableAmount}}
+            尚餘：{{product.availableAmount}}
           {{else}}
-            <span class="text-danger">已完售</span>
+            {{#if product.hasStockAmount}}
+              <span class="text-warning">補貨中</span>
+            {{else}}
+              <span class="text-danger">已完售</span>
+            {{/if}}
           {{/if}}
-        {{/if}}
+        </div>
       </div>
       {{#if isCompanyManager company=product.companyId user=currentUser}}
-        <div class="mr-3 text-info">
-          庫存：{{product.stockAmount}}
-        </div>
-        <div class="mr-3 text-info">
-          賣出：{{soldAmount}}
+        <div class="d-flex flex-wrap align-items-baseline mr-auto">
+          <div class="mr-3 text-info">
+            庫存：{{product.stockAmount}}
+          </div>
+          <div class="mr-auto text-info">
+            賣出：{{soldAmount}}
+          </div>
+          <div class="text-info small">
+            方案：{{replenishPolicyDescription}}
+          </div>
         </div>
       {{/if}}
     </div>

--- a/client/product/productCard.html
+++ b/client/product/productCard.html
@@ -32,6 +32,12 @@
       </h5>
       <div class="card-subtitle product-description">{{product.description}}</div>
       <div class="text-right"><small>識別碼：{{product._id}}</small></div>
+      {{#if currentUserHasRole 'fscMember'}}
+        <div class="text-right text-info"><small>由 {{> userLink product.creator }} 於 {{formatDateTimeText product.createdAt}} 建立</small></div>
+        {{#if product.updatedAt}}
+          <div class="text-right text-info"><small>由 {{> userLink product.updatedBy }} 於 {{formatDateTimeText product.updatedAt}} 最後更新</small></div>
+        {{/if}}
+      {{/if}}
     </div>
     <div class="card-footer d-flex flex-wrap px-3">
       <div class="mr-auto my-1">

--- a/client/product/productCard.js
+++ b/client/product/productCard.js
@@ -3,7 +3,7 @@ import { Template } from 'meteor/templating';
 import { $ } from 'meteor/jquery';
 import { FlowRouter } from 'meteor/kadira:flow-router';
 
-import { dbProducts } from '/db/dbProducts';
+import { dbProducts, productReplenishBatchSizeTypeDisplayName, productReplenishBaseAmountTypeDisplayName } from '/db/dbProducts';
 import { getAvailableProductTradeQuota } from '/db/dbUserOwnedProducts';
 import { voteProduct, adminEditProduct, banProduct } from '../utils/methods';
 import { currencyFormat } from '../utils/helpers';
@@ -20,6 +20,13 @@ Template.productCard.helpers({
     const { product } = Template.currentData();
 
     return FlowRouter.path('reportViolation', null, { type: 'product', id: product._id });
+  },
+  replenishPolicyDescription() {
+    const { product } = Template.currentData();
+    const baseAmountType = productReplenishBaseAmountTypeDisplayName(product.replenishBaseAmountType);
+    const batchSizeType = productReplenishBatchSizeTypeDisplayName(product.replenishBatchSizeType);
+
+    return `依${baseAmountType}補${batchSizeType}`;
   }
 });
 

--- a/client/productCenter/productCenterByCompany.html
+++ b/client/productCenter/productCenterByCompany.html
@@ -30,7 +30,7 @@
   <table class="table-bordered custom-responsive-table-md product-list-by-company w-100" style="table-layout: fixed;">
     <thead>
       <tr>
-        <th class="text-center text-truncate" title="產品名稱">產品名稱</th>
+        <th class="text-center text-truncate" title="產品">產品</th>
         <th class="text-center text-truncate" style="width: 120px; cursor: pointer;" title="類別" data-sort="type">
           類別
           {{{getSortIcon 'type'}}}
@@ -56,17 +56,28 @@
           <td class="text-left px-md-1" data-title="產品名稱">
             <div class="product-name">{{>productLink product._id}}</div>
             <div class="small product-description">{{product.description}}</div>
+            {{#if currentUserHasRole 'fscMember'}}
+              <div class="small text-info mt-2">
+                識別碼：{{product._id}}
+              </div>
+              <div class="small text-info">
+                由 {{> userLink product.creator}} 於 {{formatDateTimeText product.createdAt}} 建立
+              </div>
+              <div class="small text-info">
+                {{#if product.updatedAt}}
+                  由 {{> userLink product.updatedBy }} 於 {{formatDateTimeText product.createdAt}} 最後編輯
+                {{/if}}
+              </div>
+            {{/if}}
           </td>
           <td class="text-center text-truncate" data-title="類別">
             {{product.type}}
           </td>
-          {{#if isRestrictedRating product.rating}}
-            <td class="text-center text-truncate text-nowrap text-danger" data-title="分級">
-              {{product.rating}}
+            <td class="text-center text-truncate text-nowrap" data-title="分級">
+              {{#if isRestrictedRating product.rating}}
+                <span class="text-danger">{{product.rating}}</span>
+              {{/if}}
             </td>
-          {{else}}
-            <td class="text-center text-truncate text-nowrap" data-title="分級"></td>
-          {{/if}}
           <td class="text-center text-truncate" data-title="得票數">
             <button
               class="btn btn-primary btn-sm"

--- a/client/productCenter/productCenterBySeason.html
+++ b/client/productCenter/productCenterBySeason.html
@@ -46,19 +46,19 @@
   <table class="table-bordered custom-responsive-table-md product-list-by-season w-100" style="table-layout: fixed;">
     <thead>
       <tr>
-        <th class="text-center text-truncate">產品</th>
-        <th class="text-center text-truncate" title="公司名稱">
+        <th class="text-center text-truncate" style="width: 40%">產品</th>
+        <th class="text-center text-truncate" style="width: 20%" title="公司名稱">
           公司名稱
         </th>
-        <th class="text-center text-truncate" style="width: 120px; cursor: pointer;" title="類別" data-sort="type">
+        <th class="text-center text-truncate" style="width: 100px; cursor: pointer;" title="類別" data-sort="type">
           類別
           {{{getSortIcon 'type'}}}
         </th>
-        <th class="text-center text-truncate" style="width: 120px; cursor: pointer;" title="分級" data-sort="rating">
+        <th class="text-center text-truncate" style="width: 100px; cursor: pointer;" title="分級" data-sort="rating">
           分級
           {{{getSortIcon 'rating'}}}
         </th>
-        <th class="text-center text-truncate" style="width: 120px; cursor: pointer;" title="得票數" data-sort="voteCount">
+        <th class="text-center text-truncate" style="width: 100px; cursor: pointer;" title="得票數" data-sort="voteCount">
           得票數
           {{{getSortIcon 'voteCount'}}}
         </th>
@@ -93,6 +93,19 @@
     <td class="text-left px-md-1" data-title="產品">
       <div class="product-name">{{>productLink this._id}}</div>
       <div class="small product-description">{{this.description}}</div>
+      {{#if currentUserHasRole 'fscMember'}}
+        <div class="small text-info mt-2">
+          識別碼：{{this._id}}
+        </div>
+        <div class="small text-info">
+          由 {{> userLink this.creator}} 於 {{formatDateTimeText this.createdAt}} 建立
+        </div>
+        <div class="small text-info">
+          {{#if this.updatedAt}}
+            由 {{> userLink this.updatedBy }} 於 {{formatDateTimeText this.createdAt}} 最後編輯
+          {{/if}}
+        </div>
+      {{/if}}
     </td>
     <td class="text-left text-truncate text-nowrap px-md-1" data-title="公司名稱">
       {{>companyLink this.companyId}}

--- a/client/utils/styles.css
+++ b/client/utils/styles.css
@@ -488,6 +488,16 @@ table.company-next-season-product .product-description {
   max-height: 3.5rem;
 }
 
+table.company-next-season-product .product-editing-badge {
+  animation: fade-loop 2s linear infinite
+}
+
+@keyframes fade-loop {
+  0% { opacity: 1; }
+  50% { opacity: 0; }
+  100% { opacity: 1; }
+}
+
 /* 產品卡 */
 .product-card .product-description {
   word-break: break-all;

--- a/common/imports/utils/schemaHelpers.js
+++ b/common/imports/utils/schemaHelpers.js
@@ -8,6 +8,7 @@ export const translatedMessages = {
     minCount: '{{label}}總數量不得少於 {{minCount}} 個！',
     maxCount: '{{label}}總數量不得超過 {{maxCount}} 個！',
     noDecimal: '{{label}}必須為整數！',
-    notAllowed: '{{value}}並非被允許的值！'
+    notAllowed: '{{value}}並非被允許的值！',
+    regEx: '{{label}}格式不符！'
   }
 };

--- a/db/dbProducts.js
+++ b/db/dbProducts.js
@@ -4,7 +4,6 @@ import SimpleSchema from 'simpl-schema';
 
 // 公司產品資料集
 export const dbProducts = new Mongo.Collection('products');
-export default dbProducts;
 
 export const productTypeList = [
   '未分類',
@@ -114,9 +113,23 @@ const schema = new SimpleSchema({
     type: SimpleSchema.Integer,
     defaultValue: 0
   },
+  // 建立人 userId
+  creator: {
+    type: String
+  },
   // 建立日期
   createdAt: {
     type: Date
+  },
+  // 最後更新產品的人 userId（金管會造成的修改除外）
+  updatedBy: {
+    type: String,
+    optional: true
+  },
+  // 更新日期（金管會造成的修改除外）
+  updatedAt: {
+    type: Date,
+    optional: true
   }
 });
 dbProducts.attachSchema(schema);

--- a/db/dbProducts.js
+++ b/db/dbProducts.js
@@ -1,6 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 import { Mongo } from 'meteor/mongo';
 import SimpleSchema from 'simpl-schema';
+import { translatedMessages } from '/common/imports/utils/schemaHelpers';
 
 // 公司產品資料集
 export const dbProducts = new Mongo.Collection('products');
@@ -38,6 +39,49 @@ export function productStateDescription(state) {
   }
 }
 
+// 產品補貨的基準值方案
+export const productReplenishBaseAmountTypeList = [
+  'stockAmount',
+  'totalAmount'
+];
+
+export function productReplenishBaseAmountTypeDisplayName(value) {
+  switch (value) {
+    case 'stockAmount':
+      return '庫存數';
+    case 'totalAmount':
+      return '總數';
+    default:
+      return value;
+  }
+}
+
+// 產品補貨的速度方案
+export const productReplenishBatchSizeTypeList = [
+  'verySmall',
+  'small',
+  'medium',
+  'large',
+  'veryLarge'
+];
+
+export function productReplenishBatchSizeTypeDisplayName(value) {
+  switch (value) {
+    case 'verySmall':
+      return '極少量';
+    case 'small':
+      return '少量';
+    case 'medium':
+      return '中量';
+    case 'large':
+      return '大量';
+    case 'veryLarge':
+      return '極大量';
+    default:
+      return value;
+  }
+}
+
 const schema = new SimpleSchema({
   // 公司Id
   companyId: {
@@ -55,38 +99,45 @@ const schema = new SimpleSchema({
   },
   // 產品名稱
   productName: {
+    label: '產品名稱',
     type: String,
     min: 4,
     max: 255
   },
   // 產品類別
   type: {
+    label: '產品類別',
     type: String,
     allowedValues: productTypeList
   },
   // 產品分級
   rating: {
+    label: '產品分級',
     type: String,
     allowedValues: productRatingList
   },
   // 產品url
   url: {
+    label: '產品連結',
     type: String,
     regEx: SimpleSchema.RegEx.Url
   },
   // 產品描述
   description: {
+    label: '產品描述',
     type: String,
     max: 500,
     optional: true
   },
   // 產品售價
   price: {
+    label: '產品價格',
     type: SimpleSchema.Integer,
     min: 1
   },
   // 產品發行總數
   totalAmount: {
+    label: '產品總數',
     type: SimpleSchema.Integer,
     min: 1
   },
@@ -101,6 +152,18 @@ const schema = new SimpleSchema({
     type: SimpleSchema.Integer,
     min: 0,
     defaultValue: 0
+  },
+  // 產品補貨的基準值設定
+  replenishBaseAmountType: {
+    label: '產品補貨基準',
+    type: String,
+    allowedValues: productReplenishBaseAmountTypeList
+  },
+  // 產品補貨的批次量大小設定
+  replenishBatchSizeType: {
+    label: '產品補貨量',
+    type: String,
+    allowedValues: productReplenishBatchSizeTypeList
   },
   // 產品所貢獻的營利
   profit: {
@@ -132,6 +195,9 @@ const schema = new SimpleSchema({
     optional: true
   }
 });
+schema.messageBox.setLanguage('zh-tw');
+schema.messageBox.messages(translatedMessages);
+
 dbProducts.attachSchema(schema);
 
 dbProducts.findByIdOrThrow = function(id, options) {

--- a/dev-utils/factories.js
+++ b/dev-utils/factories.js
@@ -2,7 +2,7 @@ import { Meteor } from 'meteor/meteor';
 import { Factory } from 'rosie';
 import faker from 'faker';
 
-import { productTypeList, productRatingList } from '/db/dbProducts';
+import { productTypeList, productRatingList, productReplenishBaseAmountTypeList, productReplenishBatchSizeTypeList } from '/db/dbProducts';
 import { orderTypeList } from '/db/dbOrders';
 
 export const pttUserFactory = new Factory()
@@ -88,6 +88,12 @@ export const productFactory = new Factory()
     },
     description() {
       return faker.lorem.sentence(20);
+    },
+    replenishBaseAmountType() {
+      return faker.random.arrayElement(productReplenishBaseAmountTypeList);
+    },
+    replenishBatchSizeType() {
+      return faker.random.arrayElement(productReplenishBatchSizeTypeList);
     },
     price: 1,
     totalAmount: 1,

--- a/server/functions/product/replenishProducts.js
+++ b/server/functions/product/replenishProducts.js
@@ -1,31 +1,63 @@
-import { Meteor } from 'meteor/meteor';
-import { _ } from 'meteor/underscore';
-import PD from 'probability-distributions';
-
 import { dbProducts } from '/db/dbProducts';
+import { executeBulksSync } from '/server/imports/utils/executeBulksSync';
+import PD from 'probability-distributions';
+import { MathUtil } from '/common/imports/utils/MathUtil';
+
+// 計算產品補貨的基準值
+function getBaseAmount(product) {
+  return product[product.replenishBaseAmountType];
+}
+
+// 計算產品補貨的隨機乘數
+function getAmountFactor(product) {
+  switch (product.replenishBatchSizeType) {
+    case 'verySmall': {
+      // 0% ~ 10%，Beta(3,7) 分佈（期望值 3%）
+      return PD.rbeta(1, 3, 7)[0] * 0.1;
+    }
+    case 'small': {
+      // 5% ~ 7%
+      return 0.05 + Math.random() * 0.02;
+    }
+    case 'medium': {
+      // 7% ~ 30%
+      return 0.07 + Math.random() * 0.23;
+    }
+    case 'large': {
+      // 30% ~ 50%
+      return 0.3 + Math.random() * 0.2;
+    }
+    case 'veryLarge': {
+      // 50% ~ 100%
+      return 0.5 + Math.random() * 0.5;
+    }
+  }
+}
+
+// 計算產品補貨的隨機數量
+function getReplenishAmount(product) {
+  const baseAmount = getBaseAmount(product);
+  const factor = getAmountFactor(product);
+
+  // 最少釋出 1 個、最多全部釋出
+  return MathUtil.clamp(Math.round(baseAmount * factor), 1, product.stockAmount);
+}
 
 // 對全部上市產品進行補貨
 export function replenishProducts({ finalSale } = { finalSale: false }) {
-  const productUpdateModifierMap = {};
+  const productBulk = dbProducts.rawCollection().initializeUnorderedBulkOp();
 
-  dbProducts.find({ state: 'marketing', stockAmount: { $gt: 0 } }).forEach(({ _id: productId, stockAmount }) => {
-    // 以 Beta(alpha=3, beta=7) 分佈的亂數計算上架的數量
-    const [sample] = PD.rbeta(1, 3, 7);
-    const replenishAmount = finalSale ? stockAmount : Math.max(1, Math.ceil(stockAmount * sample * 0.1));
-
-    productUpdateModifierMap[productId] = {
-      $inc: {
-        availableAmount: replenishAmount,
-        stockAmount: -replenishAmount
-      }
-    };
-  });
-
-  if (! _.isEmpty(productUpdateModifierMap)) {
-    const productBulk = dbProducts.rawCollection().initializeUnorderedBulkOp();
-    Object.entries(productUpdateModifierMap).forEach(([productId, modifier]) => {
-      productBulk.find({ _id: productId }).updateOne(modifier);
+  dbProducts
+    .find({ state: 'marketing', stockAmount: { $gt: 0 } })
+    .forEach((product) => {
+      const replenishAmount = finalSale ? product.stockAmount : getReplenishAmount(product);
+      productBulk.find({ _id: product._id }).updateOne({
+        $inc: {
+          availableAmount: replenishAmount,
+          stockAmount: -replenishAmount
+        }
+      });
     });
-    Meteor.wrapAsync(productBulk.execute).call(productBulk);
-  }
+
+  executeBulksSync(productBulk);
 }

--- a/server/imports/migrations/038-add-creator-to-products.js
+++ b/server/imports/migrations/038-add-creator-to-products.js
@@ -1,0 +1,37 @@
+import { defineMigration } from '/server/imports/utils/defineMigration';
+import { executeBulksSync } from '/server/imports/utils/executeBulksSync';
+import { dbProducts } from '/db/dbProducts';
+import { dbLog } from '/db/dbLog';
+
+defineMigration({
+  version: 38,
+  name: 'add creator to products',
+  up() {
+    const productBulk = dbProducts.rawCollection().initializeUnorderedBulkOp();
+
+    dbProducts.find({}, { fields: { companyId: 1, createdAt: 1 } })
+      .forEach(({ _id: productId, companyId, createdAt }) => {
+        /*
+         * 以產品建立時間為準，往前找出負責上架該產品的人
+         * 產品建立當下公司有經理 -> 以當下的經理為建立者
+         * 產品建立當下公司無經理 -> 金管會代為上架，以金管會（!FSC）為建立者
+         */
+
+        const log = dbLog.findOne({
+          logType: { $in: ['創立公司', '就任經理', '辭職紀錄', '撤職紀錄'] },
+          companyId,
+          createdAt: { $lte: createdAt }
+        }, {
+          sort: { createdAt: -1 },
+          fields: { userId: 1 }
+        });
+
+        const noManager = ['辭職紀錄', '撤職紀錄'].includes(log.logType);
+        const creator = noManager ? '!FSC' : log.userId[0];
+
+        productBulk.find({ _id: productId }).updateOne({ $set: { creator } });
+      });
+
+    executeBulksSync(productBulk);
+  }
+});

--- a/server/imports/migrations/039-default-product-replenish-options.js
+++ b/server/imports/migrations/039-default-product-replenish-options.js
@@ -1,0 +1,15 @@
+import { defineMigration } from '/server/imports/utils/defineMigration';
+import { dbProducts } from '/db/dbProducts';
+
+defineMigration({
+  version: 39,
+  name: 'default product replenish options',
+  up() {
+    dbProducts.update({}, {
+      $set: {
+        replenishBaseAmountType: 'stockAmount',
+        replenishBatchSizeType: 'verySmall'
+      }
+    }, { multi: true });
+  }
+});

--- a/server/imports/migrations/index.js
+++ b/server/imports/migrations/index.js
@@ -35,3 +35,4 @@ import './034-add-ordinal-to-season';
 import './035-product-rating';
 import './036-fix-dbDirectors-have-two-same-user-director-data-in-one-company';
 import './037-add-company-founder';
+import './038-add-creator-to-products';

--- a/server/imports/migrations/index.js
+++ b/server/imports/migrations/index.js
@@ -36,3 +36,4 @@ import './035-product-rating';
 import './036-fix-dbDirectors-have-two-same-user-director-data-in-one-company';
 import './037-add-company-founder';
 import './038-add-creator-to-products';
+import './039-default-product-replenish-options';

--- a/server/publications/product/companyMarketingProducts.js
+++ b/server/publications/product/companyMarketingProducts.js
@@ -8,6 +8,21 @@ import { limitSubscription } from '/server/imports/utils/rateLimit';
 import { publishTotalCount } from '/server/imports/utils/publishTotalCount';
 import { debug } from '/server/imports/utils/debug';
 import { publishWithTransformation } from '/server/imports/utils/publishWithTransformation';
+import { hasRole } from '/db/users';
+
+const MANAGER_ONLY_FIELDS = [
+  'stockAmount',
+  'totalAmount',
+  'replenishBatchSizeType',
+  'replenishBaseAmountType'
+];
+
+const ADMIN_ONLY_FIELDS = [
+  'createdAt',
+  'creator',
+  'updatedAt',
+  'updatedBy'
+];
 
 Meteor.publish('companyMarketingProducts', function({ companyId, offset }) {
   debug.log('publish companyMarketingProducts', { companyId, offset });
@@ -22,9 +37,37 @@ Meteor.publish('companyMarketingProducts', function({ companyId, offset }) {
 
   const { companyMarketingProducts: dataNumberPerPage } = Meteor.settings.public.dataNumberPerPage;
 
+  const fields = {
+    companyId: 1,
+    seasonId: 1,
+    state: 1,
+    productName: 1,
+    type: 1,
+    rating: 1,
+    description: 1,
+    url: 1,
+    voteCount: 1,
+    price: 1,
+    availableAmount: 1
+  };
+
+  MANAGER_ONLY_FIELDS.forEach((fieldName) => { // will be omitted later if necessary
+    fields[fieldName] = 1;
+  });
+
+  const isCurrentUserFscMember = this.userId && hasRole(Meteor.users.findOne(this.userId), 'fscMember');
+  const isCurrentUserManager = this.userId && this.userId === company.manager;
+
+  if (isCurrentUserFscMember) {
+    ADMIN_ONLY_FIELDS.forEach((fieldName) => {
+      fields[fieldName] = 1;
+    });
+  }
+
   publishWithTransformation(this, {
     collection: 'products',
     cursor: dbProducts.find(filter, {
+      fields,
       sort: { voteCount: -1 },
       skip: offset,
       limit: dataNumberPerPage
@@ -36,8 +79,8 @@ Meteor.publish('companyMarketingProducts', function({ companyId, offset }) {
         result.hasStockAmount = fields.stockAmount > 0;
       }
 
-      if (! this.userId || this.userId !== company.manager) {
-        return _.omit(result, 'stockAmount', 'totalAmount');
+      if (! isCurrentUserManager) {
+        return _.omit(result, ...MANAGER_ONLY_FIELDS);
       }
 
       return result;

--- a/server/publications/product/productListByCompany.js
+++ b/server/publications/product/productListByCompany.js
@@ -5,6 +5,14 @@ import { dbProducts } from '/db/dbProducts';
 import { limitSubscription } from '/server/imports/utils/rateLimit';
 import { debug } from '/server/imports/utils/debug';
 import { publishTotalCount } from '/server/imports/utils/publishTotalCount';
+import { hasRole } from '/db/users';
+
+const ADMIN_ONLY_FIELDS = [
+  'createdAt',
+  'creator',
+  'updatedAt',
+  'updatedBy'
+];
 
 Meteor.publish('productListByCompany', function({ companyId, sortBy, sortDir, offset }) {
   debug.log('publish productListByCompany', { companyId, sortBy, sortDir, offset });
@@ -17,35 +25,30 @@ Meteor.publish('productListByCompany', function({ companyId, sortBy, sortDir, of
 
   publishTotalCount('totalCountOfProductList', dbProducts.find(filter), this);
 
-  const pageObserver = dbProducts
-    .find(filter, {
-      fields: {
-        profit: 0,
-        price: 0,
-        stockAmount: 0,
-        totalAmount: 0,
-        availableAmount: 0
-      },
-      sort: { [sortBy]: sortDir },
-      skip: offset,
-      limit: 30,
-      disableOplog: true
-    })
-    .observeChanges({
-      added: (id, fields) => {
-        this.added('products', id, fields);
-      },
-      changed: (id, fields) => {
-        this.changed('products', id, fields);
-      },
-      removed: (id) => {
-        this.removed('products', id);
-      }
-    });
+  const fields = {
+    companyId: 1,
+    seasonId: 1,
+    state: 1,
+    productName: 1,
+    type: 1,
+    rating: 1,
+    description: 1,
+    url: 1,
+    voteCount: 1
+  };
 
-  this.ready();
-  this.onStop(() => {
-    pageObserver.stop();
+  if (this.userId && hasRole(Meteor.users.findOne(this.userId), 'fscMember')) {
+    ADMIN_ONLY_FIELDS.forEach((fieldName) => {
+      fields[fieldName] = 1;
+    });
+  }
+
+  return dbProducts.find(filter, {
+    fields,
+    sort: { [sortBy]: sortDir },
+    skip: offset,
+    limit: 30,
+    disableOplog: true
   });
 });
 // 一分鐘最多20次

--- a/server/publications/product/productListBySeasonId.js
+++ b/server/publications/product/productListBySeasonId.js
@@ -5,6 +5,14 @@ import { dbProducts } from '/db/dbProducts';
 import { limitSubscription } from '/server/imports/utils/rateLimit';
 import { debug } from '/server/imports/utils/debug';
 import { publishTotalCount } from '/server/imports/utils/publishTotalCount';
+import { hasRole } from '/db/users';
+
+const ADMIN_ONLY_FIELDS = [
+  'createdAt',
+  'creator',
+  'updatedAt',
+  'updatedBy'
+];
 
 Meteor.publish('productListBySeasonId', function({ seasonId, sortBy, sortDir, offset }) {
   debug.log('publish productListBySeasonId', { seasonId, sortBy, sortDir, offset });
@@ -17,35 +25,30 @@ Meteor.publish('productListBySeasonId', function({ seasonId, sortBy, sortDir, of
 
   publishTotalCount('totalCountOfProductList', dbProducts.find(filter), this);
 
-  const pageObserver = dbProducts
-    .find(filter, {
-      fields: {
-        profit: 0,
-        price: 0,
-        stockAmount: 0,
-        totalAmount: 0,
-        availableAmount: 0
-      },
-      sort: { [sortBy]: sortDir },
-      skip: offset,
-      limit: 30,
-      disableOplog: true
-    })
-    .observeChanges({
-      added: (id, fields) => {
-        this.added('products', id, fields);
-      },
-      changed: (id, fields) => {
-        this.changed('products', id, fields);
-      },
-      removed: (id) => {
-        this.removed('products', id);
-      }
-    });
+  const fields = {
+    companyId: 1,
+    seasonId: 1,
+    state: 1,
+    productName: 1,
+    type: 1,
+    rating: 1,
+    description: 1,
+    url: 1,
+    voteCount: 1
+  };
 
-  this.ready();
-  this.onStop(() => {
-    pageObserver.stop();
+  if (this.userId && hasRole(Meteor.users.findOne(this.userId), 'fscMember')) {
+    ADMIN_ONLY_FIELDS.forEach((fieldName) => {
+      fields[fieldName] = 1;
+    });
+  }
+
+  return dbProducts.find(filter, {
+    fields,
+    sort: { [sortBy]: sortDir },
+    skip: offset,
+    limit: 30,
+    disableOplog: true
   });
 });
 // 一分鐘最多重複訂閱10次


### PR DESCRIPTION
待上架產品編輯功能（原 #571）：

1. products 新增 creator, updatedBy 與 updatedAt 欄位，
   分別代表產品的建立者、由誰最後更新以及最後更新時間。
   若是公司無經理而由金管會代為上架 / 編輯，則以金管會名義記錄
2. migration 時由產品的建立時間 (createdAt) 為準，
   找尋在當下時間最近就職的公司經理，以其為該產品之建立者
   若當下無經理，表示由金管會代為上架，以金管會為該產品之建立者
3. 微調產品管理頁面，加入建立者、最後更新的顯示，以及已建立的待上架產品編輯支援
4. client 端 tutorial.js 移除不必要的 helpers
5. 調整產品中心的顯示，金管會成員將會看到產品識別碼、建立者與時間、編輯者與時間的情報


實作產品補貨方案擴增：

依照 https://acgn-stock.com/announcement/view/hN4AmgFKsGj3X7rGt 之規劃實作

經理在產品規劃上架時，可選擇「產品補貨基準」與「產品補貨量」兩項設定
在正式開賣後，此設定會影響每次補貨時的數量多寡
產品補貨基準有依照**庫存數**和**總數**兩種
產品補貨量有**極少量**、**少量**、**中量**、**大量**、**極大量**五種
（分別對應原公告的打點滴、細水長流、要射不射、小爆射、大爆射五個方案）
更新前的舊有產品將預設成「極少量」、「庫存數」的設定
其他詳細設定見公告內容

其他更動：

1. 配合本次更動，調整公司當季產品的排版，只有經理人將能看到當初設定的補貨方案
2. 利用 SimpleSchema 內建的驗證機制簡化產品表單驗證輸入部分的邏輯，並微調排版
3. 調整 createProduct 與 editProduct 兩個 method 參數形式
   產品資料不再帶 companyId 而是另外帶入
4. 產品相關的幾個訂閱查詢 fields 改用 whitelisting 寫法取代 blacklisting
   以期望能避免後續加入新欄位時無意又洩漏資料