### PR TITLE
修正公司經營管理的頁面 path

### DIFF
--- a/routes.js
+++ b/routes.js
@@ -151,7 +151,7 @@ companyRoute.route('/detail/:companyId', {
     }
   }
 });
-FlowRouter.route('/edit/:companyId', {
+companyRoute.route('/edit/:companyId', {
   name: 'editCompany',
   action() {
     DocHead.setTitle(Meteor.settings.public.websiteInfo.websiteName + ' - 經營管理');


### PR DESCRIPTION
將 editCompany 改成和 companyDetail 一致，掛在 companyRoute 底下（即 ``/company/edit/:companyId``）