### PR TITLE
修改page title的樣式

### DIFF
--- a/client/accountInfo/accountInfo.js
+++ b/client/accountInfo/accountInfo.js
@@ -6,6 +6,7 @@ import { Template } from 'meteor/templating';
 import { ReactiveVar } from 'meteor/reactive-var';
 import { FlowRouter } from 'meteor/kadira:flow-router';
 
+import { getCurrentPageFullTitle } from '/routes';
 import { dbCompanies } from '/db/dbCompanies';
 import { dbEmployees } from '/db/dbEmployees';
 import { dbVips } from '/db/dbVips';
@@ -38,7 +39,7 @@ Template.accountInfo.onCreated(function() {
   this.autorun(() => {
     const user = paramUser();
     if (user) {
-      DocHead.setTitle(`${Meteor.settings.public.websiteInfo.websiteName} - 「${user.profile.name}」帳號資訊`);
+      DocHead.setTitle(getCurrentPageFullTitle(user.profile.name));
     }
   });
 });

--- a/client/company/companyDetail.js
+++ b/client/company/companyDetail.js
@@ -1,7 +1,7 @@
-import { Meteor } from 'meteor/meteor';
 import { DocHead } from 'meteor/kadira:dochead';
 import { Template } from 'meteor/templating';
 
+import { getCurrentPageFullTitle } from '/routes';
 import { inheritedShowLoadingOnSubscribing } from '../layout/loading';
 import { paramCompany, paramCompanyId } from './helpers';
 
@@ -11,7 +11,7 @@ Template.companyDetail.onCreated(function() {
   this.autorun(() => {
     const company = paramCompany();
     if (company) {
-      DocHead.setTitle(`${Meteor.settings.public.websiteInfo.websiteName} - 「${company.companyName}」公司資訊`);
+      DocHead.setTitle(getCurrentPageFullTitle(company.companyName));
     }
   });
 

--- a/client/foundation/foundationDetail.js
+++ b/client/foundation/foundationDetail.js
@@ -6,6 +6,7 @@ import { Template } from 'meteor/templating';
 import { ReactiveVar } from 'meteor/reactive-var';
 import { FlowRouter } from 'meteor/kadira:flow-router';
 
+import { getCurrentPageFullTitle } from '/routes';
 import { dbLog } from '/db/dbLog';
 import { dbVariables } from '/db/dbVariables';
 import { formatShortDateTimeText } from '/common/imports/utils/formatTimeUtils';
@@ -23,7 +24,7 @@ Template.foundationDetail.onCreated(function() {
   this.autorun(() => {
     const foundationData = paramFoundation();
     if (foundationData) {
-      DocHead.setTitle(`${Meteor.settings.public.websiteInfo.websiteName} - 「${foundationData.companyName}」公司資訊`);
+      DocHead.setTitle(getCurrentPageFullTitle(foundationData.companyName));
     }
   });
 

--- a/client/layout/layout.js
+++ b/client/layout/layout.js
@@ -4,15 +4,14 @@ import { FlowRouter } from 'meteor/kadira:flow-router';
 import { DocHead } from 'meteor/kadira:dochead';
 
 import { rMainTheme } from '/client/utils/styles';
-import { getCurrentPage, getCurrentPageTitle } from '/routes';
+import { getCurrentPage, getCurrentPageFullTitle } from '/routes';
 import { rAccountDialogMode } from './accountDialog';
 import { rShowAlertDialog, alertDialog } from './alertDialog';
 
 Template.layout.onRendered(function() {
   this.autorun(() => {
     FlowRouter.watchPathChange();
-    const title = getCurrentPageTitle();
-    DocHead.setTitle(`${Meteor.settings.public.websiteInfo.websiteName} - ${title}`);
+    DocHead.setTitle(getCurrentPageFullTitle());
   });
 });
 

--- a/client/ruleDiscuss/ruleAgendaDetail.js
+++ b/client/ruleDiscuss/ruleAgendaDetail.js
@@ -4,6 +4,8 @@ import { DocHead } from 'meteor/kadira:dochead';
 import { Template } from 'meteor/templating';
 import { ReactiveVar } from 'meteor/reactive-var';
 import { FlowRouter } from 'meteor/kadira:flow-router';
+
+import { getCurrentPageFullTitle } from '/routes';
 import { dbRound } from '/db/dbRound';
 import { dbRuleAgendas } from '/db/dbRuleAgendas';
 import { dbRuleIssues } from '/db/dbRuleIssues';
@@ -22,7 +24,7 @@ Template.ruleAgendaDetail.onCreated(function() {
     if (agendaId) {
       const agendaData = dbRuleAgendas.findOne(agendaId);
       if (agendaData) {
-        DocHead.setTitle(Meteor.settings.public.websiteInfo.websiteName + ' - 「' + agendaData.title + '」議程資訊');
+        DocHead.setTitle(getCurrentPageFullTitle(agendaData.title));
       }
     }
   });

--- a/client/ruleDiscuss/ruleAgendaVote.js
+++ b/client/ruleDiscuss/ruleAgendaVote.js
@@ -3,6 +3,8 @@ import { Meteor } from 'meteor/meteor';
 import { DocHead } from 'meteor/kadira:dochead';
 import { Template } from 'meteor/templating';
 import { FlowRouter } from 'meteor/kadira:flow-router';
+
+import { getCurrentPageFullTitle } from '/routes';
 import { dbRound } from '/db/dbRound';
 import { dbRuleAgendas } from '/db/dbRuleAgendas';
 import { dbRuleIssues } from '/db/dbRuleIssues';
@@ -21,7 +23,7 @@ Template.ruleAgendaVote.onCreated(function() {
     if (agendaId) {
       const agendaData = dbRuleAgendas.findOne(agendaId);
       if (agendaData) {
-        DocHead.setTitle(Meteor.settings.public.websiteInfo.websiteName + ' - 「' + agendaData.title + '」議程資訊');
+        DocHead.setTitle(getCurrentPageFullTitle(agendaData.title));
       }
     }
   });

--- a/routes.js
+++ b/routes.js
@@ -1,13 +1,21 @@
+import { Meteor } from 'meteor/meteor';
 import { FlowRouter } from 'meteor/kadira:flow-router';
 import { ReactiveVar } from 'meteor/reactive-var';
 
 const pageNameHash = {
   mainPage: '首頁',
   announcementList: '系統公告',
+  announcementDetail: '系統公告',
+  createAnnouncement: '建立新公告',
+  rejectAnnouncement: '否決公告',
   tutorial: '遊戲規則',
   instantMessage: '即時訊息',
   companyList: '股市總覽',
+  companyDetail: '公司資訊',
+  editCompany: '經營管理介面',
   foundationList: '新創計劃',
+  foundationDetail: '新創資訊',
+  editFoundationPlan: '編輯新創計劃',
   createFoundationPlan: '發起新創計創',
   advertising: '廣告宣傳',
   productCenterBySeason: '產品中心',
@@ -16,9 +24,15 @@ const pageNameHash = {
   seasonalReport: '季度報告',
   accountInfo: '帳號資訊',
   ruleAgendaList: '規則討論',
+  ruleAgendaDetail: '議程資訊',
+  createRuleAgenda: '建立新議程',
+  ruleAgendaVote: '議程投票',
+  reportViolation: '舉報違規',
   violationCaseList: '違規案件列表',
+  violationCaseDetail: '違規案件內容',
   fscLogs: '金管會執行紀錄',
-  fscStock: '金管會持股'
+  fscStock: '金管會持股',
+  controlCenterSendGift: '發送禮物'
 };
 
 /**
@@ -44,6 +58,15 @@ export function getPageTitle(pageName) {
 
 export function getCurrentPageTitle() {
   return getPageTitle(getCurrentPage());
+}
+
+export function getCurrentPageFullTitle(detailName) {
+  let title = `${getCurrentPageTitle()} - ${Meteor.settings.public.websiteInfo.websiteName}`;
+  if (detailName) {
+    title = `${detailName} - ${title}`;
+  }
+
+  return title;
 }
 
 FlowRouter.route('/', { name: 'mainPage' });

--- a/routes.js
+++ b/routes.js
@@ -61,6 +61,10 @@ export function getCurrentPageTitle() {
 }
 
 export function getCurrentPageFullTitle(detailName) {
+  if (getCurrentPage() === 'mainPage') {
+    return Meteor.settings.public.websiteInfo.websiteName;
+  }
+
   let title = `${getCurrentPageTitle()} - ${Meteor.settings.public.websiteInfo.websiteName}`;
   if (detailName) {
     title = `${detailName} - ${title}`;


### PR DESCRIPTION
1. 參考其他網站，將title的呈現方式改為詳細名稱在前，頁面名稱、網站名稱在後，使其可以先呈現較重要的資訊
範例: `中野三玖 - 公司資訊 - ACGN股票交易市場`

2. 重構title的產生方式，統一由 `routes` 的 `getCurrentPageFullTitle()` 產生

3. 補上缺漏的pageNameHash

4. 首頁的title不再特地標註首頁，改為只顯示網站名稱