### PR TITLE
SEO -  加入 robots.txt, sitemap, prerender 讓搜尋引擎可以獲取網頁資訊

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ A stock system simulator game which use acgn characters as company.
 3. type `meteor npm install` in project folder
 4. type `meteor run --settings config.json` in project folder
 
+### Turn to Production mode
+
+Production mode requires `Headless Chrome`, so you need to install Chrome first.
+
+Set `"production": true` in [config.json](config.json).
+
 ## Contributors
 
 This project exists thanks to all the people who contribute. [[Contribute]](CONTRIBUTING.md).

--- a/client/layout/layout.html
+++ b/client/layout/layout.html
@@ -25,6 +25,7 @@
   <script src="https://code.highcharts.com/stock/highstock.js"></script>
 </head>
 <body>
+  <script>window.prerenderReady = false</script>
   {{> layout}}
   {{> loading}}
 </body>

--- a/client/layout/loading.js
+++ b/client/layout/loading.js
@@ -6,11 +6,13 @@ let taskCount = 0;
 export function addTask() {
   taskCount += 1;
   isLoading.set(true);
+  window.prerenderReady = false;
 }
 export function resolveTask() {
   taskCount -= 1;
   if (taskCount <= 0) {
     isLoading.set(false);
+    window.prerenderReady = true;
   }
 }
 export function inheritedShowLoadingOnSubscribing(template) {

--- a/config.js
+++ b/config.js
@@ -1,6 +1,7 @@
 // 真正的設定檔請寫在config.json，這邊只是註解用。
 export const config = {
   debugMode: false, // 是否為debug mode(紀錄一分鐘內的所有方法與訂閱動作，以備crash查看)
+  production: false, // 是否在 production mode (production設定下需要安裝chrome以啟用所有功能)
   websiteInfo: { // 網站資訊
     websiteName: 'ACGN股票交易市場', // 網站名稱
     description: '｜ 尋找你的老婆！ \n｜ 喜歡嗎？那麼就入股吧！',

--- a/config.js
+++ b/config.js
@@ -9,7 +9,7 @@ export const config = {
     timezone: 8 // 主要客群所在的時區 (可能與server的時區不同)
   },
   prerenderServer: {
-    'url': 'https://127.0.0.1', // prerender的server位置
+    'url': 'http://127.0.0.1', // prerender的server位置
     'port': '3900'
   },
   intervalTimer: 60000, // 每隔多少毫秒進行一次工作檢查

--- a/config.js
+++ b/config.js
@@ -8,6 +8,10 @@ export const config = {
     image: 'https://acgn-stock.com/ms-icon-310x310.png',
     timezone: 8 // 主要客群所在的時區 (可能與server的時區不同)
   },
+  prerenderServer: {
+    'url': 'https://127.0.0.1', // prerender的server位置
+    'port': '3900'
+  },
   intervalTimer: 60000, // 每隔多少毫秒進行一次工作檢查
   releaseStocksForHighPriceInterval: { // 高價釋股的排程時間範圍 (ms)
     min: 10800000,

--- a/config.json
+++ b/config.json
@@ -1,6 +1,7 @@
 {
   "public": {
     "debugMode": false,
+    "production": false,
     "websiteInfo": {
       "websiteName": "ACGN股票交易市場",
       "description": "｜ 尋找你的老婆！ \n｜ 喜歡嗎？那麼就入股吧！",

--- a/config.json
+++ b/config.json
@@ -9,7 +9,7 @@
       "timezone": 8
     },
     "prerenderServer": {
-      "url": "https://127.0.0.1",
+      "url": "http://127.0.0.1",
       "port": "3900"
     },
     "intervalTimer": 60000,

--- a/config.json
+++ b/config.json
@@ -8,6 +8,10 @@
       "image": "https://acgn-stock.com/ms-icon-310x310.png",
       "timezone": 8
     },
+    "prerenderServer": {
+      "url": "https://127.0.0.1",
+      "port": "3900"
+    },
     "intervalTimer": 60000,
     "releaseStocksForHighPriceInterval": {
       "min": 10800000,

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,30 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
+    "accepts": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+      "requires": {
+        "mime-types": "2.1.22",
+        "negotiator": "0.6.1"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.38.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+          "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg=="
+        },
+        "mime-types": {
+          "version": "2.1.22",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
+          "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+          "requires": {
+            "mime-db": "1.38.0"
+          }
+        }
+      }
+    },
     "acorn": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
@@ -173,6 +197,11 @@
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true
     },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
     "array-includes": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
@@ -237,6 +266,11 @@
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
       "dev": true
+    },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -970,6 +1004,38 @@
         "inherits": "2.0.3"
       }
     },
+    "body-parser": {
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+      "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
+      "requires": {
+        "bytes": "3.0.0",
+        "content-type": "1.0.4",
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.23",
+        "on-finished": "2.3.0",
+        "qs": "6.5.2",
+        "raw-body": "2.3.3",
+        "type-is": "1.6.16"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.23",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+          "requires": {
+            "safer-buffer": "2.1.2"
+          }
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        }
+      }
+    },
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -1096,6 +1162,11 @@
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
+    "bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+    },
     "caller-id": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-id/-/caller-id-0.1.0.tgz",
@@ -1181,6 +1252,22 @@
         "is-glob": "2.0.1",
         "path-is-absolute": "1.0.1",
         "readdirp": "2.1.0"
+      }
+    },
+    "chrome-remote-interface": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.25.7.tgz",
+      "integrity": "sha512-6zI6LbR2IiGmduFZededaerEr9hHXabxT/L+fRrdq65a0CfyLMzpq0BKuZiqN0Upqcacsb6q2POj7fmobwBsEA==",
+      "requires": {
+        "commander": "2.11.0",
+        "ws": "3.3.3"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+        }
       }
     },
     "circular-json": {
@@ -1298,6 +1385,42 @@
         "babel-runtime": "6.26.0"
       }
     },
+    "compressible": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.16.tgz",
+      "integrity": "sha512-JQfEOdnI7dASwCuSPWIeVYwc/zMsu/+tRhoUvEfXz2gxOA2DNjmG5vhtFdBlhWPPGo+RdT9S3tgc/uH5qgDiiA==",
+      "requires": {
+        "mime-db": "1.38.0"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.38.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+          "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg=="
+        }
+      }
+    },
+    "compression": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz",
+      "integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
+      "requires": {
+        "accepts": "1.3.5",
+        "bytes": "3.0.0",
+        "compressible": "2.0.16",
+        "debug": "2.6.9",
+        "on-headers": "1.0.2",
+        "safe-buffer": "5.1.2",
+        "vary": "1.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1339,11 +1462,31 @@
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
+    "content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
     "convert-source-map": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
       "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
       "dev": true
+    },
+    "cookie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "core-js": {
       "version": "2.5.1",
@@ -1518,6 +1661,16 @@
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
     "detect-indent": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
@@ -1611,6 +1764,11 @@
         "jsbn": "0.1.1"
       }
     },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
     "egal": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/egal/-/egal-1.3.0.tgz",
@@ -1631,6 +1789,11 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.5.1.tgz",
       "integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ==",
       "dev": true
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "encoding": {
       "version": "0.1.12",
@@ -1753,6 +1916,11 @@
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -2125,6 +2293,11 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
     "event-emitter": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
@@ -2180,6 +2353,65 @@
       "dev": true,
       "requires": {
         "fill-range": "2.2.3"
+      }
+    },
+    "express": {
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
+      "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
+      "requires": {
+        "accepts": "1.3.5",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.18.3",
+        "content-disposition": "0.5.2",
+        "content-type": "1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "finalhandler": "1.1.1",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "2.0.4",
+        "qs": "6.5.2",
+        "range-parser": "1.2.0",
+        "safe-buffer": "5.1.2",
+        "send": "0.16.2",
+        "serve-static": "1.13.2",
+        "setprototypeof": "1.1.0",
+        "statuses": "1.4.0",
+        "type-is": "1.6.16",
+        "utils-merge": "1.0.1",
+        "vary": "1.1.2"
+      },
+      "dependencies": {
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "statuses": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+        }
       }
     },
     "extend": {
@@ -2297,6 +2529,27 @@
         "repeat-string": "1.6.1"
       }
     },
+    "finalhandler": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.4.0",
+        "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "statuses": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+        }
+      }
+    },
     "find-babel-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.1.0.tgz",
@@ -2390,6 +2643,16 @@
       "requires": {
         "samsam": "1.3.0"
       }
+    },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "from": {
       "version": "0.1.7",
@@ -2606,6 +2869,11 @@
         "sntp": "2.1.0"
       }
     },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+    },
     "hoek": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
@@ -2638,6 +2906,17 @@
         "entities": "1.1.1",
         "inherits": "2.0.3",
         "readable-stream": "2.3.3"
+      }
+    },
+    "http-errors": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+      "requires": {
+        "depd": "1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": "1.5.0"
       }
     },
     "http-signature": {
@@ -2775,6 +3054,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+    },
+    "ipaddr.js": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
+      "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -3565,6 +3849,11 @@
       "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.0.tgz",
       "integrity": "sha512-3Zs9P/0zzwTob2pdgT0CHZuMbnSUSp8MB1bddfm+HDmnFWHGT4jvEZRf+2RuPoa+cjdn/z25SEt5gFTqdhvJAg=="
     },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
     "mem": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
@@ -3572,6 +3861,11 @@
       "requires": {
         "mimic-fn": "1.1.0"
       }
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
     "meteor-node-stubs": {
       "version": "0.2.11",
@@ -4175,6 +4469,11 @@
         }
       }
     },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
     "micromatch": {
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
@@ -4195,6 +4494,11 @@
         "parse-glob": "3.0.4",
         "regex-cache": "0.4.4"
       }
+    },
+    "mime": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
     },
     "mime-db": {
       "version": "1.30.0",
@@ -4286,6 +4590,11 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "negotiator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
     "nise": {
       "version": "1.2.0",
@@ -4455,6 +4764,19 @@
         "is-extendable": "0.1.1"
       }
     },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -4614,6 +4936,11 @@
         "@types/node": "8.0.51"
       }
     },
+    "parseurl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+    },
     "path-exists": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
@@ -4756,6 +5083,27 @@
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "dev": true
     },
+    "prerender": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/prerender/-/prerender-5.5.1.tgz",
+      "integrity": "sha512-F3ZF4vdz5zaqoCkO2Fa0+3zUXu4RD7L6ht4GPG8NQ5g/hF+oK549Q6ggFRP15r6KQNfGqThalpsO6J4gBDmp/g==",
+      "requires": {
+        "body-parser": "1.18.3",
+        "chrome-remote-interface": "0.25.7",
+        "compression": "1.7.3",
+        "express": "4.16.4",
+        "he": "1.1.1",
+        "valid-url": "1.0.9"
+      }
+    },
+    "prerender-node": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/prerender-node/-/prerender-node-3.2.1.tgz",
+      "integrity": "sha512-SSXFTzm/xGmAM+jNALCXFbdzzzgNN4y9ZaCfZ5cNgA/WYNWpIwUGX/zXweR/Xdco9um3unGCF2LXef+GAovf7w==",
+      "requires": {
+        "request": "2.83.0"
+      }
+    },
     "preserve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
@@ -4816,6 +5164,15 @@
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1"
+      }
+    },
+    "proxy-addr": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
+      "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
+      "requires": {
+        "forwarded": "0.1.2",
+        "ipaddr.js": "1.8.0"
       }
     },
     "ps-tree": {
@@ -4879,6 +5236,32 @@
           "dev": true,
           "requires": {
             "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+    },
+    "raw-body": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+      "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+      "requires": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.23",
+        "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.23",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+          "requires": {
+            "safer-buffer": "2.1.2"
           }
         }
       }
@@ -5199,6 +5582,11 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
     "samsam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
@@ -5219,6 +5607,44 @@
         "semver": "5.4.1"
       }
     },
+    "send": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "1.6.3",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.4.0"
+      },
+      "dependencies": {
+        "statuses": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+      "requires": {
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
+        "send": "0.16.2"
+      }
+    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -5235,6 +5661,11 @@
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
       "dev": true
+    },
+    "setprototypeof": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -5451,6 +5882,11 @@
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
       "dev": true
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "stream-combiner": {
       "version": "0.0.4",
@@ -5851,6 +6287,30 @@
       "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ==",
       "dev": true
     },
+    "type-is": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "2.1.22"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.38.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+          "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg=="
+        },
+        "mime-types": {
+          "version": "2.1.22",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
+          "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+          "requires": {
+            "mime-db": "1.38.0"
+          }
+        }
+      }
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -5868,6 +6328,11 @@
       "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
       "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
     },
+    "ultron": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+    },
     "undefsafe": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-0.0.3.tgz",
@@ -5882,6 +6347,11 @@
       "requires": {
         "crypto-random-string": "1.0.0"
       }
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "unzip-response": {
       "version": "2.0.1",
@@ -5951,10 +6421,20 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
     "uuid": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
       "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+    },
+    "valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA="
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
@@ -5965,6 +6445,11 @@
         "spdx-correct": "1.0.2",
         "spdx-expression-parse": "1.0.4"
       }
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "verror": {
       "version": "1.10.0",
@@ -6050,6 +6535,16 @@
         "graceful-fs": "4.1.11",
         "imurmurhash": "0.1.4",
         "signal-exit": "3.0.2"
+      }
+    },
+    "ws": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+      "requires": {
+        "async-limiter": "1.0.0",
+        "safe-buffer": "5.1.1",
+        "ultron": "1.1.1"
       }
     },
     "xdg-basedir": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "mathml-tag-names": "^2.1.0",
     "meteor-node-stubs": "0.2.11",
     "opencollective": "^1.0.3",
+    "prerender": "^5.5.1",
+    "prerender-node": "^3.2.1",
     "probability-distributions": "^0.9.1",
     "remove-markdown": "^0.3.0",
     "rosie": "^1.6.0",

--- a/server/http/robots.js
+++ b/server/http/robots.js
@@ -12,7 +12,7 @@ WebApp.connectHandlers.use('/robots.txt', (req, res) => {
   robotsTxt += `Disallow: /violation/view/* \n`;
   robotsTxt += `Disallow: /violation/report* \n`;
   robotsTxt += `Disallow: /fscLogs* \n`;
-  robotsTxt += `Crawl-deslay: 4 \n`;
+  robotsTxt += `Crawl-delay: 4 \n`;
 
   robotsTxt += `\n`;
   robotsTxt += `sitemap: https://${Meteor.settings.public.websiteInfo.domainName}/sitemap/sitemap-index.xml \n`;

--- a/server/http/robots.js
+++ b/server/http/robots.js
@@ -1,0 +1,16 @@
+import { WebApp } from 'meteor/webapp';
+import { Meteor } from 'meteor/meteor';
+
+WebApp.connectHandlers.use('/robots.txt', (req, res) => {
+  let robotsTxt = `User-agent: * \n`;
+  robotsTxt += `Crawl-deslay: 4 \n`;
+  robotsTxt += `Disallow: /companyInfo* \n`;
+  robotsTxt += `Disallow: /productInfo* \n`;
+  robotsTxt += `Disallow: /userInfo* \n`;
+
+  robotsTxt += `\n`;
+  robotsTxt += `sitemap: https://${Meteor.settings.public.websiteInfo.domainName}/sitemap/sitemap-index.xml \n`;
+
+  res.setHeader('Cache-Control', 'public, max-age=604800');
+  res.end(robotsTxt);
+});

--- a/server/http/robots.js
+++ b/server/http/robots.js
@@ -3,10 +3,16 @@ import { Meteor } from 'meteor/meteor';
 
 WebApp.connectHandlers.use('/robots.txt', (req, res) => {
   let robotsTxt = `User-agent: * \n`;
-  robotsTxt += `Crawl-deslay: 4 \n`;
   robotsTxt += `Disallow: /companyInfo* \n`;
   robotsTxt += `Disallow: /productInfo* \n`;
   robotsTxt += `Disallow: /userInfo* \n`;
+  robotsTxt += `Disallow: /company/edit/* \n`;
+  robotsTxt += `Disallow: /foundation/view/* \n`;
+  robotsTxt += `Disallow: /violation?offset=* \n`;
+  robotsTxt += `Disallow: /violation/view/* \n`;
+  robotsTxt += `Disallow: /violation/report* \n`;
+  robotsTxt += `Disallow: /fscLogs* \n`;
+  robotsTxt += `Crawl-deslay: 4 \n`;
 
   robotsTxt += `\n`;
   robotsTxt += `sitemap: https://${Meteor.settings.public.websiteInfo.domainName}/sitemap/sitemap-index.xml \n`;

--- a/server/http/sitemap/sitemapCompanies.js
+++ b/server/http/sitemap/sitemapCompanies.js
@@ -1,0 +1,50 @@
+import { WebApp } from 'meteor/webapp';
+import { Meteor } from 'meteor/meteor';
+
+import { dbCompanies } from '/db/dbCompanies';
+
+WebApp.connectHandlers.use('/sitemap/sitemap-companies.xml', (req, res) => {
+  let xmlData = `<?xml version="1.0" encoding="UTF-8"?>`;
+  xmlData += `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`;
+  dbCompanies.find({}, { fields: { _id: 1, grade: 1 } })
+    .forEach((companyData) => {
+      xmlData += createCompanyUrlTag(companyData);
+    });
+  xmlData += `</urlset>`;
+
+  res.setHeader('Content-Type', 'application/xml');
+  res.setHeader('Cache-Control', 'public, max-age=86400');
+  res.end(xmlData);
+});
+
+
+function createCompanyUrlTag(companyData) {
+  return `<url>${createLocTag(companyData)}${createPriorityTag(companyData)}</url>`;
+}
+
+function createLocTag({ _id }) {
+  return `<loc>https://${Meteor.settings.public.websiteInfo.domainName}/company/detail/${_id}</loc>`;
+}
+
+function createPriorityTag({ grade }) {
+  let priority = '';
+  switch (grade) {
+    case 'S':
+      priority = '0.9';
+      break;
+    case 'A':
+      priority = '0.8';
+      break;
+    case 'B':
+      priority = '0.7';
+      break;
+    case 'C':
+      priority = '0.6';
+      break;
+    default:
+      priority = '0.5';
+      break;
+  }
+
+  return `<priority>${priority}</priority>`;
+}

--- a/server/http/sitemap/sitemapIndex.js
+++ b/server/http/sitemap/sitemapIndex.js
@@ -1,0 +1,18 @@
+import { WebApp } from 'meteor/webapp';
+import { Meteor } from 'meteor/meteor';
+
+WebApp.connectHandlers.use('/sitemap/sitemap-index.xml', (req, res) => {
+  let xmlData = `<?xml version="1.0" encoding="UTF-8"?>`;
+  xmlData += `<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`;
+  xmlData += createSitemapTag('/sitemap/sitemap-main.xml');
+  xmlData += createSitemapTag('/sitemap/sitemap-companies.xml');
+  xmlData += `</sitemapindex>`;
+
+  res.setHeader('Content-Type', 'application/xml');
+  res.setHeader('Cache-Control', 'public, max-age=86400');
+  res.end(xmlData);
+});
+
+function createSitemapTag(path) {
+  return `<sitemap><loc>https://${Meteor.settings.public.websiteInfo.domainName}${path}</loc></sitemap>`;
+}

--- a/server/http/sitemap/sitemapMain.js
+++ b/server/http/sitemap/sitemapMain.js
@@ -1,0 +1,22 @@
+import { WebApp } from 'meteor/webapp';
+import { Meteor } from 'meteor/meteor';
+
+WebApp.connectHandlers.use('/sitemap/sitemap-main.xml', (req, res) => {
+  let xmlData = `<?xml version="1.0" encoding="UTF-8"?>`;
+  xmlData += `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`;
+  xmlData += createUrlTag('/');
+  xmlData += createUrlTag('/company/1');
+  xmlData += createUrlTag('/foundation/1');
+  xmlData += createUrlTag('/announcement');
+  xmlData += createUrlTag('/ruleDiscuss');
+  xmlData += createUrlTag('/violation');
+  xmlData += `</urlset>`;
+
+  res.setHeader('Content-Type', 'application/xml');
+  res.setHeader('Cache-Control', 'public, max-age=86400');
+  res.end(xmlData);
+});
+
+function createUrlTag(path) {
+  return `<url><loc>https://${Meteor.settings.public.websiteInfo.domainName}${path}</loc><priority>1.0</priority></url>`;
+}

--- a/server/startup/prerender.js
+++ b/server/startup/prerender.js
@@ -1,0 +1,15 @@
+import prerenderNode from 'prerender-node';
+import { Meteor } from 'meteor/meteor';
+import { WebApp } from 'meteor/webapp';
+
+Meteor.startup(() => {
+  prerenderNode.set('protocol', 'https');
+  prerenderNode.set('prerenderServiceUrl', getPrerenderServer());
+  WebApp.rawConnectHandlers.use(prerenderNode);
+});
+
+function getPrerenderServer() {
+  const { url, port } = Meteor.settings.public.prerenderServer;
+
+  return `${url}${port ? `:${port}` : ''}/`;
+}

--- a/server/startup/prerenderServer.js
+++ b/server/startup/prerenderServer.js
@@ -1,0 +1,8 @@
+import prerender from 'prerender';
+import { Meteor } from 'meteor/meteor';
+
+Meteor.startup(() => {
+  const prerenderServer = prerender({ port: Meteor.settings.public.prerenderServer.port });
+  prerenderServer.start();
+  process.env.DISABLE_LOGGING = true;
+});

--- a/server/startup/prerenderServer.js
+++ b/server/startup/prerenderServer.js
@@ -2,6 +2,10 @@ import prerender from 'prerender';
 import { Meteor } from 'meteor/meteor';
 
 Meteor.startup(() => {
+  if (! Meteor.settings.public.production) {
+    return;
+  }
+
   const prerenderServer = prerender({
     port: Meteor.settings.public.prerenderServer.port,
     waitAfterLastRequest: 3000

--- a/server/startup/prerenderServer.js
+++ b/server/startup/prerenderServer.js
@@ -2,7 +2,10 @@ import prerender from 'prerender';
 import { Meteor } from 'meteor/meteor';
 
 Meteor.startup(() => {
-  const prerenderServer = prerender({ port: Meteor.settings.public.prerenderServer.port });
+  const prerenderServer = prerender({
+    port: Meteor.settings.public.prerenderServer.port,
+    waitAfterLastRequest: 3000
+  });
   prerenderServer.start();
   process.env.DISABLE_LOGGING = true;
 });


### PR DESCRIPTION
- 加入新的package，更新時需要執行 `meteor npm install`
- 有更動config檔
- **需要安裝 `Google Chrome`**

---

加入 `robots.txt` ，讓bot可以讀取，以得知哪些網址我們不建議掃描，還有建議掃描的`sitemap`在哪

加入 `sitemap` ，提供公司網址
網址會依照公司評級指定優先度，評級高的公司會有較高的優先度推薦搜尋引擎抓取 (抓取順序不影響搜尋結果排序)

使用 `prerender` 來讓搜尋引擎的BOT可以抓到完整的頁面
當收到BOT的訪問請求時，會轉由 `prerender server` 代為訪問網站，並將完整的結果傳回去
`prerender server` 監聽的port可以在config中修改，目前port設定為 `3900`

---

由於會開 `prerender server` ，需要在伺服器安裝 `Google Chrome`

可以用這條指令直接安裝
```sh
wget -qO- https://raw.githubusercontent.com/SoftwareSing/linux-install/master/install-chrome.sh | bash
```
安裝後建議重新啟動
