### PR TITLE
只針對搜尋引擎的BOT提供prerender & 讓prerender會等到title變更完成

### DIFF
--- a/client/accountInfo/accountInfo.js
+++ b/client/accountInfo/accountInfo.js
@@ -11,6 +11,8 @@ import { dbCompanies } from '/db/dbCompanies';
 import { dbEmployees } from '/db/dbEmployees';
 import { dbVips } from '/db/dbVips';
 import { roleDisplayName, getManageableRoles } from '/db/users';
+import { setPrerenderTitleReady } from '/client/utils/prerenderReady';
+
 import { inheritedShowLoadingOnSubscribing } from '../layout/loading';
 import { alertDialog } from '../layout/alertDialog';
 import { shouldStopSubscribe } from '../utils/idle';
@@ -40,6 +42,10 @@ Template.accountInfo.onCreated(function() {
     const user = paramUser();
     if (user) {
       DocHead.setTitle(getCurrentPageFullTitle(user.profile.name));
+      setPrerenderTitleReady(true);
+    }
+    else {
+      setPrerenderTitleReady(false);
     }
   });
 });

--- a/client/company/companyDetail.js
+++ b/client/company/companyDetail.js
@@ -2,6 +2,8 @@ import { DocHead } from 'meteor/kadira:dochead';
 import { Template } from 'meteor/templating';
 
 import { getCurrentPageFullTitle } from '/routes';
+import { setPrerenderTitleReady } from '/client/utils/prerenderReady';
+
 import { inheritedShowLoadingOnSubscribing } from '../layout/loading';
 import { paramCompany, paramCompanyId } from './helpers';
 
@@ -12,6 +14,10 @@ Template.companyDetail.onCreated(function() {
     const company = paramCompany();
     if (company) {
       DocHead.setTitle(getCurrentPageFullTitle(company.companyName));
+      setPrerenderTitleReady(true);
+    }
+    else {
+      setPrerenderTitleReady(false);
     }
   });
 

--- a/client/foundation/foundationDetail.js
+++ b/client/foundation/foundationDetail.js
@@ -10,6 +10,8 @@ import { getCurrentPageFullTitle } from '/routes';
 import { dbLog } from '/db/dbLog';
 import { dbVariables } from '/db/dbVariables';
 import { formatShortDateTimeText } from '/common/imports/utils/formatTimeUtils';
+import { setPrerenderTitleReady } from '/client/utils/prerenderReady';
+
 import { inheritedShowLoadingOnSubscribing } from '../layout/loading';
 import { shouldStopSubscribe } from '../utils/idle';
 import { investFoundCompany, markCompanyIllegal, unmarkCompanyIllegal, changeCompanyName } from '../utils/methods';
@@ -25,6 +27,10 @@ Template.foundationDetail.onCreated(function() {
     const foundationData = paramFoundation();
     if (foundationData) {
       DocHead.setTitle(getCurrentPageFullTitle(foundationData.companyName));
+      setPrerenderTitleReady(true);
+    }
+    else {
+      setPrerenderTitleReady(false);
     }
   });
 

--- a/client/layout/loading.js
+++ b/client/layout/loading.js
@@ -1,18 +1,19 @@
 import { ReactiveVar } from 'meteor/reactive-var';
 import { Template } from 'meteor/templating';
+import { setPrerenderDataReady } from '/client/utils/prerenderReady';
 
 const isLoading = new ReactiveVar(false);
 let taskCount = 0;
 export function addTask() {
   taskCount += 1;
   isLoading.set(true);
-  window.prerenderReady = false;
+  setPrerenderDataReady(false);
 }
 export function resolveTask() {
   taskCount -= 1;
   if (taskCount <= 0) {
     isLoading.set(false);
-    window.prerenderReady = true;
+    setPrerenderDataReady(true);
   }
 }
 export function inheritedShowLoadingOnSubscribing(template) {

--- a/client/ruleDiscuss/ruleAgendaDetail.js
+++ b/client/ruleDiscuss/ruleAgendaDetail.js
@@ -10,6 +10,8 @@ import { dbRound } from '/db/dbRound';
 import { dbRuleAgendas } from '/db/dbRuleAgendas';
 import { dbRuleIssues } from '/db/dbRuleIssues';
 import { dbRuleIssueOptions } from '/db/dbRuleIssueOptions';
+import { setPrerenderTitleReady } from '/client/utils/prerenderReady';
+
 import { inheritedShowLoadingOnSubscribing } from '../layout/loading';
 import { alertDialog } from '../layout/alertDialog';
 import { shouldStopSubscribe } from '../utils/idle';
@@ -25,6 +27,10 @@ Template.ruleAgendaDetail.onCreated(function() {
       const agendaData = dbRuleAgendas.findOne(agendaId);
       if (agendaData) {
         DocHead.setTitle(getCurrentPageFullTitle(agendaData.title));
+        setPrerenderTitleReady(true);
+      }
+      else {
+        setPrerenderTitleReady(false);
       }
     }
   });

--- a/client/ruleDiscuss/ruleAgendaVote.js
+++ b/client/ruleDiscuss/ruleAgendaVote.js
@@ -9,6 +9,8 @@ import { dbRound } from '/db/dbRound';
 import { dbRuleAgendas } from '/db/dbRuleAgendas';
 import { dbRuleIssues } from '/db/dbRuleIssues';
 import { dbRuleIssueOptions } from '/db/dbRuleIssueOptions';
+import { setPrerenderTitleReady } from '/client/utils/prerenderReady';
+
 import { inheritedShowLoadingOnSubscribing } from '../layout/loading';
 import { alertDialog } from '../layout/alertDialog';
 import { shouldStopSubscribe } from '../utils/idle';
@@ -24,6 +26,10 @@ Template.ruleAgendaVote.onCreated(function() {
       const agendaData = dbRuleAgendas.findOne(agendaId);
       if (agendaData) {
         DocHead.setTitle(getCurrentPageFullTitle(agendaData.title));
+        setPrerenderTitleReady(true);
+      }
+      else {
+        setPrerenderTitleReady(false);
       }
     }
   });

--- a/client/utils/prerenderReady.js
+++ b/client/utils/prerenderReady.js
@@ -1,0 +1,41 @@
+import { getCurrentPage } from '/routes';
+
+let prerenderDataReady = false;
+let prerenderTitleReady = false;
+
+export function setPrerenderDataReady(ready) {
+  prerenderDataReady = ready;
+  setPrerenderReady();
+}
+
+export function setPrerenderTitleReady(ready) {
+  prerenderTitleReady = ready;
+  setPrerenderReady();
+}
+
+
+function setPrerenderReady() {
+  window.prerenderReady = isPrerenderReady();
+}
+
+function isPrerenderReady() {
+  if (! prerenderDataReady) {
+    return false;
+  }
+
+  if (isNeedResetTitlePage() && (! prerenderTitleReady)) {
+    return false;
+  }
+
+  return true;
+}
+
+const resetTitlePageList = ['companyDetail', 'accountInfo', 'foundationDetail', 'ruleAgendaDetail', 'ruleAgendaVote'];
+function isNeedResetTitlePage() {
+  if (resetTitlePageList.includes(getCurrentPage())) {
+    return true;
+  }
+  else {
+    return false;
+  }
+}

--- a/server/startup/prerender.js
+++ b/server/startup/prerender.js
@@ -5,6 +5,15 @@ import { WebApp } from 'meteor/webapp';
 Meteor.startup(() => {
   prerenderNode.set('protocol', 'https');
   prerenderNode.set('prerenderServiceUrl', getPrerenderServer());
+  prerenderNode.set('crawlerUserAgents', [
+    'googlebot',
+    'Yahoo! Slurp',
+    'bingbot',
+    'yandex',
+    'baiduspider',
+    'developers.google.com/+/web/snippet',
+    'Applebot'
+  ]);
   WebApp.rawConnectHandlers.use(prerenderNode);
 });
 


### PR DESCRIPTION
1. 將prerender的對象改為只針對搜尋引擎的BOT
社群網站的BOT使用head中的meta tag便足以顯示資訊，且prerender的等待時間太久，可能被社群網站判斷為無法連線

2. 由於一些不確定因素，google拿到網頁時title可能還沒更換完成，但title是搜尋結果顯示的重要依據，因此讓prerender等到title完成更換後才設置ready