### PR TITLE
在遇到HeadlessChrome時自動開啟所有tag

### DIFF
--- a/client/company/companyDetailNormalContent.js
+++ b/client/company/companyDetailNormalContent.js
@@ -8,13 +8,14 @@ import { dbEmployees } from '/db/dbEmployees';
 import { getCurrentSeason } from '/db/dbSeason';
 import { changeChairmanTitle, confiscateCompanyProfit, markCompanyIllegal, returnCompanyProfit, toggleFavorite, unmarkCompanyIllegal } from '/client/utils/methods';
 import { currencyFormat } from '/client/utils/helpers';
+import { isHeadlessChrome } from '/client/utils/isHeadlessChrome';
 import { alertDialog } from '/client/layout/alertDialog';
 import { paramCompany, paramCompanyId } from './helpers';
 
 const TAGS_LIMIT = 3;
 
 Template.companyDetailNormalContent.onCreated(function() {
-  this.showAllTags = new ReactiveVar(false);
+  this.showAllTags = new ReactiveVar(isHeadlessChrome());
   this.autorunWithIdleSupport(() => {
     const companyId = paramCompanyId();
     if (companyId) {

--- a/client/utils/isHeadlessChrome.js
+++ b/client/utils/isHeadlessChrome.js
@@ -1,0 +1,3 @@
+export function isHeadlessChrome() {
+  return /HeadlessChrome/.test(window.navigator.userAgent);
+}


### PR DESCRIPTION
~~由於沒有`dev` branch，推送到`master`~~
~~`dev`出現了我再修正~~
已修正為推送至`dev`

---

讓BOT可以抓到完整的tag，而非只有前3個

---

~~讓 `綾地寧寧 股票` 關鍵字可以在Google正常運作，而不用特地搜尋 `綾地寧々 股票`~~