### PR TITLE
調整金管會相關紀錄的未讀訊息文字

### DIFF
--- a/client/layout/footer.html
+++ b/client/layout/footer.html
@@ -29,7 +29,7 @@
     <div class="media bg-danger text-white px-2 py-1 my-2 rounded footer-message-container">
       <div class="media-body footer-message">
         <strong style="color: yellow">【注意】</strong>
-        您有未讀的重要金管會相關訊息！請至您的<a style="color: yellow" href="{{accountInfoLink currentUserId}}">帳號資訊</a>頁面查看。
+        您有未讀的重要金管會相關訊息！請至您的<a style="color: yellow" href="{{accountInfoLink currentUserId}}">帳號資訊</a>頁面之玩家紀錄區塊查看。
       </div>
       <div class="footer-message-close-button">
         <a class="btn btn-danger btn-sm" href="#">


### PR DESCRIPTION
已有多次玩家反應不知道去哪裡消除該未讀通知，因此在訊息中加註該去頁面中的哪個區塊檢視，希望能降低此類困擾。