### PR TITLE
 [需於賽季更換前更新] 讓同名公司可以繼承ID

### DIFF
--- a/client/layout/nav.js
+++ b/client/layout/nav.js
@@ -241,7 +241,7 @@ Template.navCompanyLink.onRendered(function() {
         const path = FlowRouter.path('companyDetail', { companyId });
         $link
           .attr('href', path)
-          .text(companyData.name);
+          .text(companyData.companyName);
       },
       error: () => {
         $link.text('???');

--- a/client/layout/nav.js
+++ b/client/layout/nav.js
@@ -241,7 +241,7 @@ Template.navCompanyLink.onRendered(function() {
         const path = FlowRouter.path('companyDetail', { companyId });
         $link
           .attr('href', path)
-          .text(companyData.companyName);
+          .text(companyData.companyName || companyData.name);
       },
       error: () => {
         $link.text('???');

--- a/client/seasonalReport/seasonalReport.js
+++ b/client/seasonalReport/seasonalReport.js
@@ -307,7 +307,7 @@ function drawCompanyPriceRankTable(templateInstance) {
       },
       dataType: 'json',
       success: (companyData) => {
-        const companyName = companyData.name;
+        const { companyName } = companyData;
         if (companyName.length > 8) {
           companyNameHash[rankData.companyId] = companyName.slice(0, 7) + '...';
         }
@@ -417,7 +417,7 @@ function drawCompanyProfitRankTable(templateInstance) {
       },
       dataType: 'json',
       success: (companyData) => {
-        const companyName = companyData.name;
+        const { companyName } = companyData;
         if (companyName.length > 8) {
           companyNameHash[rankData.companyId] = companyName.slice(0, 7) + '...';
         }
@@ -547,7 +547,7 @@ function drawCompanyValueRankTable(templateInstance) {
       },
       dataType: 'json',
       success: (companyData) => {
-        const companyName = companyData.name;
+        const { companyName } = companyData;
         if (companyName.length > 8) {
           companyNameHash[rankData.companyId] = companyName.slice(0, 7) + '...';
         }
@@ -708,7 +708,7 @@ function drawCompanyCapitalRankTable(templateInstance) {
       },
       dataType: 'json',
       success: (companyData) => {
-        const companyName = companyData.name;
+        const { companyName } = companyData;
         if (companyName.length > 8) {
           companyNameHash[rankData.companyId] = companyName.slice(0, 7) + '...';
         }

--- a/client/seasonalReport/seasonalReport.js
+++ b/client/seasonalReport/seasonalReport.js
@@ -307,7 +307,7 @@ function drawCompanyPriceRankTable(templateInstance) {
       },
       dataType: 'json',
       success: (companyData) => {
-        const { companyName } = companyData;
+        const companyName = companyData.companyName || companyData.name;
         if (companyName.length > 8) {
           companyNameHash[rankData.companyId] = companyName.slice(0, 7) + '...';
         }
@@ -417,7 +417,7 @@ function drawCompanyProfitRankTable(templateInstance) {
       },
       dataType: 'json',
       success: (companyData) => {
-        const { companyName } = companyData;
+        const companyName = companyData.companyName || companyData.name;
         if (companyName.length > 8) {
           companyNameHash[rankData.companyId] = companyName.slice(0, 7) + '...';
         }
@@ -547,7 +547,7 @@ function drawCompanyValueRankTable(templateInstance) {
       },
       dataType: 'json',
       success: (companyData) => {
-        const { companyName } = companyData;
+        const companyName = companyData.companyName || companyData.name;
         if (companyName.length > 8) {
           companyNameHash[rankData.companyId] = companyName.slice(0, 7) + '...';
         }
@@ -708,7 +708,7 @@ function drawCompanyCapitalRankTable(templateInstance) {
       },
       dataType: 'json',
       success: (companyData) => {
-        const { companyName } = companyData;
+        const companyName = companyData.companyName || companyData.name;
         if (companyName.length > 8) {
           companyNameHash[rankData.companyId] = companyName.slice(0, 7) + '...';
         }

--- a/client/utils/displayLink.js
+++ b/client/utils/displayLink.js
@@ -28,7 +28,7 @@ Template.companyLink.onRendered(function() {
       },
       dataType: 'json',
       success: (companyData) => {
-        const companyName = companyData.name;
+        const { companyName } = companyData;
         let path;
         switch (companyData.status) {
           case 'foundation': {

--- a/client/utils/displayLink.js
+++ b/client/utils/displayLink.js
@@ -28,7 +28,7 @@ Template.companyLink.onRendered(function() {
       },
       dataType: 'json',
       success: (companyData) => {
-        const { companyName } = companyData;
+        const companyName = companyData.companyName || companyData.name;
         let path;
         switch (companyData.status) {
           case 'foundation': {

--- a/client/utils/displayLog.js
+++ b/client/utils/displayLog.js
@@ -22,7 +22,7 @@ Template.displayLog.onRendered(function() {
       url: '/companyInfo',
       data: { id: companyId },
       dataType: 'json',
-      success: ({ name: companyName, status }) => {
+      success: ({ companyName, status }) => {
         let path;
         // TODO write a helper
         switch (status) {

--- a/client/utils/displayLog.js
+++ b/client/utils/displayLog.js
@@ -22,7 +22,9 @@ Template.displayLog.onRendered(function() {
       url: '/companyInfo',
       data: { id: companyId },
       dataType: 'json',
-      success: ({ companyName, status }) => {
+      success: (companyData) => {
+        const { status } = companyData;
+        const companyName = companyData.companyName || companyData.name;
         let path;
         // TODO write a helper
         switch (status) {

--- a/db/dbCompanyArchive.js
+++ b/db/dbCompanyArchive.js
@@ -13,7 +13,7 @@ const schema = new SimpleSchema({
     allowedValues: ['archived', 'foundation', 'market']
   },
   // 公司名稱
-  name: {
+  companyName: {
     type: String
   },
   // 相關搜索用Tag

--- a/db/dbCompanyArchive.js
+++ b/db/dbCompanyArchive.js
@@ -45,14 +45,6 @@ const schema = new SimpleSchema({
     type: String,
     min: 10,
     max: 3000
-  },
-  // 投資人列表
-  invest: {
-    type: Array,
-    defaultValue: []
-  },
-  'invest.$': {
-    type: String
   }
 });
 dbCompanyArchive.attachSchema(schema);

--- a/dev-utils/createSeedData.js
+++ b/dev-utils/createSeedData.js
@@ -82,7 +82,7 @@ if (Meteor.isServer && Meteor.isDevelopment) {
         companyArchiveBulk.insert({
           _id: companyData._id,
           status: 'market',
-          name: companyData.companyName,
+          companyName: companyData.companyName,
           tags: companyData.tags,
           pictureSmall: companyData.pictureSmall,
           pictureBig: companyData.pictureSmall,

--- a/integration-test/server/functions/foundation/doOnFoundationFailure.test.js
+++ b/integration-test/server/functions/foundation/doOnFoundationFailure.test.js
@@ -49,8 +49,10 @@ describe('function doOnFoundationFailure', function() {
     const foundationData = dbFoundations.findOne(companyId);
     doOnFoundationFailure(foundationData);
 
+    const companyArchiveData = dbCompanyArchive.findOne(companyId);
+    expect(companyArchiveData).to.exist();
+    expect(companyArchiveData.status).to.equal('archived');
     expect(dbFoundations.findOne(companyId)).to.not.exist();
-    expect(dbCompanyArchive.findOne(companyId)).to.not.exist();
     expect(dbLog.findOne({ companyId })).to.not.exist();
   });
 

--- a/integration-test/server/methods/foundation/foundCompany.test.js
+++ b/integration-test/server/methods/foundation/foundCompany.test.js
@@ -1,0 +1,161 @@
+import { Meteor } from 'meteor/meteor';
+import { resetDatabase } from 'meteor/xolvio:cleaner';
+import { Accounts } from 'meteor/accounts-base';
+import expect from 'must';
+import faker from 'faker';
+
+import { foundCompany } from '/server/methods/foundation/foundCompany';
+import { foundationFactory, pttUserFactory, seasonFactory } from '/dev-utils/factories';
+import { dbRound } from '/db/dbRound';
+import { dbFoundations } from '/db/dbFoundations';
+import { dbSeason } from '/db/dbSeason';
+import { dbCompanyArchive } from '/db/dbCompanyArchive';
+import { dbLog } from '/db/dbLog';
+
+describe('method foundCompany', function() {
+  this.timeout(10000);
+
+  let user;
+  let foundCompanyData;
+  let roundId;
+  let seasonId;
+
+  beforeEach(function() {
+    resetDatabase();
+    const { founderEarnestMoney, newRoundFoundationRestrictionTime, seasonTime, seasonNumberInRound } = Meteor.settings.public;
+
+    const userId = Accounts.createUser(pttUserFactory.build());
+    const money = faker.random.number({ min: founderEarnestMoney });
+    Meteor.users.update(userId, { $set: { 'profile.money': money } });
+    user = Meteor.users.findOne(userId);
+
+    foundCompanyData = foundationFactory.build();
+    delete foundCompanyData.createdAt;
+
+    roundId = dbRound.insert({
+      beginDate: new Date(Date.now() - newRoundFoundationRestrictionTime - 1000),
+      endDate: new Date(Date.now() + seasonTime * seasonNumberInRound)
+    });
+    seasonId = dbSeason.insert(seasonFactory.build());
+  });
+
+  it('should fail if the user is in vacation', function() {
+    user.profile.isInVacation = true;
+    foundCompany.bind(null, user, foundCompanyData)
+      .must.throw(Meteor.Error, '您現在正在渡假中，請好好放鬆！ [403]');
+  });
+
+  it('should fail if the user is not pay tax', function() {
+    user.profile.notPayTax = true;
+    foundCompany.bind(null, user, foundCompanyData)
+      .must.throw(Meteor.Error, '您現在有稅單逾期未繳！ [403]');
+  });
+
+  it('should fail if the user is been ban manager', function() {
+    user.profile.ban.push('manager');
+    foundCompany.bind(null, user, foundCompanyData)
+      .must.throw(Meteor.Error, '您現在被金融管理會禁止了擔任經理人的資格！ [403]');
+  });
+
+  it('should fail if the user is been ban deal', function() {
+    user.profile.ban.push('deal');
+    foundCompany.bind(null, user, foundCompanyData)
+      .must.throw(Meteor.Error, '您現在被金融管理會禁止了所有投資下單行為！ [403]');
+  });
+
+  it('should fail if the user does not have enough money', function() {
+    const { founderEarnestMoney } = Meteor.settings.public;
+    user.profile.money = founderEarnestMoney - 1;
+    foundCompany.bind(null, user, foundCompanyData)
+      .must.throw(Meteor.Error, '您的現金不足，不足以支付投資保證金！ [401]');
+  });
+
+  it('should fail if the user has another company is been founding', function() {
+    const userId = user._id;
+    dbFoundations.insert(foundationFactory.build({ founder: userId }));
+    foundCompany.bind(null, user, foundCompanyData)
+      .must.throw(Meteor.Error, '您現在已經有一家新創公司正在申請中，無法同時發起第二家新創公司！ [403]');
+  });
+
+
+  it('should fail if is in new round foundation restriction time', function() {
+    const { newRoundFoundationRestrictionTime } = Meteor.settings.public;
+    dbRound.update(roundId, { $set: { beginDate: new Date(Date.now() - faker.random.number({ max: newRoundFoundationRestrictionTime - 600000 })) } });
+    foundCompany.bind(null, user, foundCompanyData)
+      .must.throw(Meteor.Error, '目前尚未開放新創計劃！ [403]');
+  });
+
+  it('should fail if is in last season of current round', function() {
+    const { seasonTime } = Meteor.settings.public;
+    dbRound.update(roundId, { $set: { endDate: new Date(Date.now() + faker.random.number({ max: seasonTime })) } });
+    foundCompany.bind(null, user, foundCompanyData)
+      .must.throw(Meteor.Error, '賽季度結束前的最後一個商業季度，禁止新創計劃！ [403]');
+  });
+
+  it('should fail if do not have enough time to found a company before current season end', function() {
+    const { foundExpireTime } = Meteor.settings.public;
+    const hours = Math.ceil(foundExpireTime / 3600000);
+    dbSeason.update(seasonId, { $set: { endDate: new Date(Date.now() + faker.random.number({ max: foundExpireTime })) } });
+    foundCompany.bind(null, user, foundCompanyData)
+      .must.throw(Meteor.Error, `商業季度即將結束前${hours}小時，禁止新創計劃！ [403]`);
+  });
+
+
+  it('should fail if have the same name company is in foundation', function() {
+    dbCompanyArchive.insert({
+      status: 'foundation',
+      name: foundCompanyData.companyName,
+      tags: [],
+      description: faker.random.words(10)
+    });
+    foundCompany.bind(null, user, foundCompanyData)
+      .must.throw(Meteor.Error, '已有相同名稱的公司上市或創立中，無法創立同名公司！ [403]');
+  });
+
+  it('should fail if have the same name company is in market', function() {
+    dbCompanyArchive.insert({
+      status: 'market',
+      name: foundCompanyData.companyName,
+      tags: [],
+      description: faker.random.words()
+    });
+    foundCompany.bind(null, user, foundCompanyData)
+      .must.throw(Meteor.Error, '已有相同名稱的公司上市或創立中，無法創立同名公司！ [403]');
+  });
+
+
+  it('should success found company', function() {
+    foundCompany.bind(null, user, foundCompanyData).must.not.throw();
+
+    const companyArchiveData = dbCompanyArchive.findOne({ name: foundCompanyData.companyName });
+    expect(companyArchiveData).to.exist();
+    const expectCompanyArchiveData = {
+      _id: companyArchiveData._id,
+      status: 'foundation',
+      name: foundCompanyData.companyName,
+      tags: foundCompanyData.tags,
+      description: foundCompanyData.description,
+      invest: []
+    };
+    if (foundCompanyData.pictureSmall) {
+      expectCompanyArchiveData.pictureSmall = foundCompanyData.pictureSmall;
+    }
+    if (foundCompanyData.pictureBig) {
+      expectCompanyArchiveData.pictureBig = foundCompanyData.pictureBig;
+    }
+    expect(companyArchiveData).to.eql(expectCompanyArchiveData);
+
+    const foundationData = dbFoundations.findOne(companyArchiveData._id);
+    expect(foundationData).to.exist();
+
+    const foundLog = dbLog.findOne({ logType: '創立公司' });
+    expect(foundLog).to.exist();
+
+    const investLog = dbLog.findOne({ logType: '參與投資' });
+    expect(investLog).to.exist();
+
+    const { founderEarnestMoney } = Meteor.settings.public;
+    const userData = Meteor.users.findOne(user._id, { fields: { 'profile.money': 1 } });
+    expect(userData.profile.money).to.equal(user.profile.money - founderEarnestMoney);
+  });
+});

--- a/integration-test/server/methods/foundation/foundCompany.test.js
+++ b/integration-test/server/methods/foundation/foundCompany.test.js
@@ -104,7 +104,7 @@ describe('method foundCompany', function() {
   it('should fail if have the same name company is in foundation', function() {
     dbCompanyArchive.insert({
       status: 'foundation',
-      name: foundCompanyData.companyName,
+      companyName: foundCompanyData.companyName,
       tags: [],
       description: faker.random.words(10)
     });
@@ -115,7 +115,7 @@ describe('method foundCompany', function() {
   it('should fail if have the same name company is in market', function() {
     dbCompanyArchive.insert({
       status: 'market',
-      name: foundCompanyData.companyName,
+      companyName: foundCompanyData.companyName,
       tags: [],
       description: faker.random.words(10)
     });
@@ -127,7 +127,7 @@ describe('method foundCompany', function() {
   it('should success found company', function() {
     foundCompany.bind(null, user, foundCompanyData).must.not.throw();
 
-    const companyArchiveData = dbCompanyArchive.findOne({ name: foundCompanyData.companyName });
+    const companyArchiveData = dbCompanyArchive.findOne({ companyName: foundCompanyData.companyName });
     expect(companyArchiveData).to.exist();
     const expectCompanyArchiveData = {
       _id: companyArchiveData._id,

--- a/integration-test/server/methods/foundation/foundCompany.test.js
+++ b/integration-test/server/methods/foundation/foundCompany.test.js
@@ -127,15 +127,14 @@ describe('method foundCompany', function() {
   it('should success found company', function() {
     foundCompany.bind(null, user, foundCompanyData).must.not.throw();
 
-    const companyArchiveData = dbCompanyArchive.findOne({ companyName: foundCompanyData.companyName });
+    const companyArchiveData = dbCompanyArchive.findOne({ companyName: foundCompanyData.companyName, status: 'foundation' });
     expect(companyArchiveData).to.exist();
     const expectCompanyArchiveData = {
       _id: companyArchiveData._id,
       status: 'foundation',
       companyName: foundCompanyData.companyName,
       tags: foundCompanyData.tags,
-      description: foundCompanyData.description,
-      invest: []
+      description: foundCompanyData.description
     };
     if (foundCompanyData.pictureSmall) {
       expectCompanyArchiveData.pictureSmall = foundCompanyData.pictureSmall;
@@ -157,5 +156,17 @@ describe('method foundCompany', function() {
     const { founderEarnestMoney } = Meteor.settings.public;
     const userData = Meteor.users.findOne(user._id, { fields: { 'profile.money': 1 } });
     expect(userData.profile.money).to.equal(user.profile.money - founderEarnestMoney);
+  });
+
+  it('should inherit id if same name company is in archived', function() {
+    const expectId = dbCompanyArchive.insert({
+      status: 'archived',
+      companyName: foundCompanyData.companyName,
+      tags: [],
+      description: faker.random.words(10)
+    });
+    foundCompany.bind(null, user, foundCompanyData).must.not.throw();
+    expect(dbCompanyArchive.findOne(expectId).status).to.equal('foundation');
+    expect(dbFoundations.findOne({ companyName: foundCompanyData.companyName })._id).to.equal(expectId);
   });
 });

--- a/integration-test/server/methods/foundation/foundCompany.test.js
+++ b/integration-test/server/methods/foundation/foundCompany.test.js
@@ -117,7 +117,7 @@ describe('method foundCompany', function() {
       status: 'market',
       name: foundCompanyData.companyName,
       tags: [],
-      description: faker.random.words()
+      description: faker.random.words(10)
     });
     foundCompany.bind(null, user, foundCompanyData)
       .must.throw(Meteor.Error, '已有相同名稱的公司上市或創立中，無法創立同名公司！ [403]');

--- a/integration-test/server/methods/foundation/foundCompany.test.js
+++ b/integration-test/server/methods/foundation/foundCompany.test.js
@@ -132,7 +132,7 @@ describe('method foundCompany', function() {
     const expectCompanyArchiveData = {
       _id: companyArchiveData._id,
       status: 'foundation',
-      name: foundCompanyData.companyName,
+      companyName: foundCompanyData.companyName,
       tags: foundCompanyData.tags,
       description: foundCompanyData.description,
       invest: []

--- a/server/functions/foundation/doOnFoundationFailure.js
+++ b/server/functions/foundation/doOnFoundationFailure.js
@@ -4,6 +4,7 @@ import { Meteor } from 'meteor/meteor';
 import { dbFoundations } from '/db/dbFoundations';
 import { dbLog } from '/db/dbLog';
 import { dbCompanyArchive } from '/db/dbCompanyArchive';
+import { executeBulksSync } from '/server/imports/utils/executeBulksSync';
 
 // 新創公司失敗之處理
 export function doOnFoundationFailure(foundationData) {
@@ -48,8 +49,5 @@ export function doOnFoundationFailure(foundationData) {
     .find({ companyId })
     .update({ $unset: { companyId: 1 } });
 
-  Meteor.wrapAsync(logBulk.execute).call(logBulk);
-  if (foundationData.invest.length > 0) {
-    Meteor.wrapAsync(usersBulk.execute).call(usersBulk);
-  }
+  executeBulksSync(logBulk, usersBulk);
 }

--- a/server/functions/foundation/doOnFoundationFailure.js
+++ b/server/functions/foundation/doOnFoundationFailure.js
@@ -43,7 +43,7 @@ export function doOnFoundationFailure(foundationData) {
   });
 
   dbFoundations.remove(companyId);
-  dbCompanyArchive.remove(companyId);
+  dbCompanyArchive.update(companyId, { $set: { status: 'archived' } });
 
   logBulk
     .find({ companyId })

--- a/server/functions/foundation/doOnFoundationSuccess.js
+++ b/server/functions/foundation/doOnFoundationSuccess.js
@@ -7,6 +7,7 @@ import { dbCompanies } from '/db/dbCompanies';
 import { dbCompanyArchive } from '/db/dbCompanyArchive';
 import { dbDirectors } from '/db/dbDirectors';
 import { dbPrice } from '/db/dbPrice';
+import { executeBulksSync } from '/server/imports/utils/executeBulksSync';
 
 const { minReleaseStock } = Meteor.settings.public;
 
@@ -133,9 +134,6 @@ export function doOnFoundationSuccess(foundationData) {
     createdAt: basicCreatedAt
   });
 
-  let needExecuteDirectorsBulk = false;
-  let needExecuteUserBulk = false;
-
   directors.forEach(({ userId, stocks, refund }, index) => {
     const createdAt = new Date(basicCreatedAt.getTime() + index + 1);
     if (stocks > 0) {
@@ -149,7 +147,6 @@ export function doOnFoundationSuccess(foundationData) {
         },
         createdAt: createdAt
       });
-      needExecuteDirectorsBulk = true;
       directorsBulk.insert({ companyId, userId, stocks, createdAt });
     }
     if (refund > 0) {
@@ -163,24 +160,13 @@ export function doOnFoundationSuccess(foundationData) {
         },
         createdAt: createdAt
       });
-      needExecuteUserBulk = true;
       usersBulk
         .find({ _id: userId })
         .updateOne({ $inc: { 'profile.money': refund } });
     }
   });
 
-  Meteor.wrapAsync(companiesBulk.execute).call(companiesBulk);
-  Meteor.wrapAsync(logBulk.execute).call(logBulk);
-
-  if (needExecuteDirectorsBulk) {
-    Meteor.wrapAsync(directorsBulk.execute).call(directorsBulk);
-  }
-
-  if (needExecuteUserBulk) {
-    Meteor.wrapAsync(usersBulk.execute).call(usersBulk);
-  }
-
+  executeBulksSync(companiesBulk, logBulk, directorsBulk, usersBulk);
   dbFoundations.remove(companyId);
   dbCompanyArchive.update(companyId, { $set: { status: 'market' } });
 }

--- a/server/http/companyInfo.js
+++ b/server/http/companyInfo.js
@@ -17,7 +17,7 @@ WebApp.connectHandlers.use('/companyInfo', (req, res) => {
 
   const companyData = dbCompanyArchive.findOne(companyId, {
     fields: {
-      name: 1,
+      companyName: 1,
       status: 1
     }
   });

--- a/server/imports/fixtures/variables.js
+++ b/server/imports/fixtures/variables.js
@@ -1,9 +1,9 @@
 import { dbVariables } from '/db/dbVariables';
 import { updateFoundationVariables } from '/server/functions/foundation/updateFoundationVariables';
 
-dbVariables.setIfNotFound('validateUserUrl', 'https://www.ptt.cc/bbs/C_Chat/M.1501484745.A.B15.html');
-dbVariables.setIfNotFound('validateUserBoardName', 'C_Chat');
-dbVariables.setIfNotFound('validateUserAID', '#1PVjR9iL');
+dbVariables.setIfNotFound('validateUserUrl', 'https://www.ptt.cc/bbs/ACGN_stock/M.1508993391.A.381.html');
+dbVariables.setIfNotFound('validateUserBoardName', 'ACGN_stock');
+dbVariables.setIfNotFound('validateUserAID', '#1PyMblE1');
 
 // 初始化新創相關變數
 if (! dbVariables.has('foundation.minInvestorCount') || ! dbVariables.has('foundation.minAmountPerInvestor')) {

--- a/server/imports/migrations/043-rename-name-to-companyName-in-companyArchive.js
+++ b/server/imports/migrations/043-rename-name-to-companyName-in-companyArchive.js
@@ -1,0 +1,14 @@
+import { defineMigration } from '/server/imports/utils/defineMigration';
+import { dbCompanyArchive } from '/db/dbCompanyArchive';
+
+defineMigration({
+  version: 43,
+  name: 'rename name to companyName in companyArchive',
+  async up() {
+    await dbCompanyArchive.rawCollection().dropIndex({ name: 1 });
+    await dbCompanyArchive.rawCollection().update({}, {
+      $rename: { name: 'companyName' }
+    }, { multi: true });
+    await dbCompanyArchive.rawCollection().createIndex({ companyName: 1 }, { unique: true });
+  }
+});

--- a/server/imports/migrations/044-remove-unnecessary-field-in-companyArchive.js
+++ b/server/imports/migrations/044-remove-unnecessary-field-in-companyArchive.js
@@ -1,0 +1,10 @@
+import { defineMigration } from '/server/imports/utils/defineMigration';
+import { dbCompanyArchive } from '/db/dbCompanyArchive';
+
+defineMigration({
+  version: 44,
+  name: 'remove unnecessary field in companyArchive',
+  up() {
+    dbCompanyArchive.update({}, { $unset: { invest: 1 } }, { multi: true });
+  }
+});

--- a/server/imports/migrations/index.js
+++ b/server/imports/migrations/index.js
@@ -41,3 +41,4 @@ import './040-arena-rewrite';
 import './041-add-voided-index-to-announcements';
 import './042-notification-system';
 import './043-rename-name-to-companyName-in-companyArchive';
+import './044-remove-unnecessary-field-in-companyArchive';

--- a/server/imports/migrations/index.js
+++ b/server/imports/migrations/index.js
@@ -40,3 +40,4 @@ import './039-default-product-replenish-options';
 import './040-arena-rewrite';
 import './041-add-voided-index-to-announcements';
 import './042-notification-system';
+import './043-rename-name-to-companyName-in-companyArchive';

--- a/server/intervalCheck.js
+++ b/server/intervalCheck.js
@@ -5,6 +5,7 @@ import { UserStatus } from 'meteor/mizzao:user-status';
 import { resourceManager } from '/server/imports/threading/resourceManager';
 import { debug } from '/server/imports/utils/debug';
 import { backupMongo } from '/server/imports/utils/backupMongo';
+import { executeBulksSync } from '/server/imports/utils/executeBulksSync';
 import { clearAllUserProductVouchers } from '/server/functions/product/vouchers/clearAllUserProductVouchers';
 import { deliverProductVouchers } from '/server/functions/product/vouchers/deliverProductVouchers';
 import { resetAllUserVoteTickets } from '/server/functions/product/voteTickets/resetAllUserVoteTickets';
@@ -140,12 +141,42 @@ export function doRoundWorks(lastRoundData, lastSeasonData) {
 
     backupMongo('-roundAfter');
 
+    // 保管所有未查封公司的狀態
+    const companyArchiveBulk = dbCompanyArchive.rawCollection().initializeUnorderedBulkOp();
+    dbCompanies
+      .find({}, {
+        fields: {
+          _id: 1,
+          tags: 1,
+          pictureSmall: 1,
+          pictureBig: 1,
+          description: 1,
+          isSeal: 1
+        }
+      })
+      .forEach(({ _id, tags, pictureSmall, pictureBig, description, isSeal }) => {
+        if (isSeal) {
+          companyArchiveBulk.find({ _id }).removeOne();
+        }
+        else {
+          companyArchiveBulk.find({ _id }).updateOne({
+            $set: {
+              status: 'archived',
+              tags,
+              pictureSmall,
+              pictureBig,
+              description
+            }
+          });
+        }
+      });
+    executeBulksSync(companyArchiveBulk);
+
     // 移除所有廣告
     dbAdvertising.remove({});
 
     // 移除所有公司資料
     dbCompanies.remove({});
-    dbCompanyArchive.remove({});
     dbCompanyStones.remove({});
     // 移除所有股份資料
     dbDirectors.remove({});

--- a/server/methods/company/changeCompanyName.js
+++ b/server/methods/company/changeCompanyName.js
@@ -31,7 +31,7 @@ function changeCompanyName(user, { companyId, newCompanyName, violationCaseId })
     dbViolationCases.findByIdOrThrow(violationCaseId, { fields: { _id: 1 } });
   }
 
-  const { name: oldCompanyName } = dbCompanyArchive.findByIdOrThrow(companyId, { fields: { name: 1 } });
+  const { companyName: oldCompanyName } = dbCompanyArchive.findByIdOrThrow(companyId, { fields: { companyName: 1 } });
 
   dbLog.insert({
     logType: '公司更名',
@@ -42,6 +42,6 @@ function changeCompanyName(user, { companyId, newCompanyName, violationCaseId })
   });
   dbCompanies.update(companyId, { $set: { companyName: newCompanyName } });
   dbFoundations.update(companyId, { $set: { companyName: newCompanyName } });
-  dbCompanyArchive.update(companyId, { $set: { name: newCompanyName } });
+  dbCompanyArchive.update(companyId, { $set: { companyName: newCompanyName } });
 }
 limitMethod('changeCompanyName');

--- a/server/methods/foundation/foundCompany.js
+++ b/server/methods/foundation/foundCompany.js
@@ -54,7 +54,7 @@ export function foundCompany(user, foundCompanyData) {
     // 存放進archive中並取得_id
     foundCompanyData._id = dbCompanyArchive.insert({
       status: 'foundation',
-      name: foundCompanyData.companyName,
+      companyName: foundCompanyData.companyName,
       tags: foundCompanyData.tags,
       pictureSmall: foundCompanyData.pictureSmall,
       pictureBig: foundCompanyData.pictureBig,
@@ -149,7 +149,7 @@ function checkTimeFoundLimitError() {
 }
 
 function checkSameNameCompanyError(companyName) {
-  if (dbCompanyArchive.find({ name: companyName }, { fields: { _id: 1 } }).count() > 0) {
+  if (dbCompanyArchive.find({ companyName }, { fields: { _id: 1 } }).count() > 0) {
     throw new Meteor.Error(403, '已有相同名稱的公司上市或創立中，無法創立同名公司！');
   }
 }

--- a/server/methods/foundation/foundCompany.js
+++ b/server/methods/foundation/foundCompany.js
@@ -28,54 +28,16 @@ Meteor.methods({
   }
 });
 export function foundCompany(user, foundCompanyData) {
-  const { foundExpireTime, founderEarnestMoney, seasonTime, newRoundFoundationRestrictionTime } = Meteor.settings.public;
-
   debug.log('foundCompany', { user, foundCompanyData });
-  if (user.profile.isInVacation) {
-    throw new Meteor.Error(403, '您現在正在渡假中，請好好放鬆！');
-  }
-  if (user.profile.notPayTax) {
-    throw new Meteor.Error(403, '您現在有稅單逾期未繳！');
-  }
-  if (_.contains(user.profile.ban, 'manager')) {
-    throw new Meteor.Error(403, '您現在被金融管理會禁止了擔任經理人的資格！');
-  }
-  if (_.contains(user.profile.ban, 'deal')) {
-    throw new Meteor.Error(403, '您現在被金融管理會禁止了所有投資下單行為！');
-  }
-  if (user.profile.money < founderEarnestMoney) {
-    throw new Meteor.Error(401, '您的現金不足，不足以支付投資保證金！');
-  }
+  const { founderEarnestMoney } = Meteor.settings.public;
   const userId = user._id;
-  if (dbFoundations.find({ founder: userId }).count() > 0) {
-    throw new Meteor.Error(403, '您現在已經有一家新創公司正在申請中，無法同時發起第二家新創公司！');
-  }
-
-  const currentRound = getCurrentRound();
-  if (Date.now() <= (currentRound.beginDate.getTime() + newRoundFoundationRestrictionTime)) {
-    throw new Meteor.Error(403, '目前尚未開放新創計劃！');
-  }
-  if (Date.now() >= (currentRound.endDate.getTime() - seasonTime)) {
-    throw new Meteor.Error(403, '賽季度結束前的最後一個商業季度，禁止新創計劃！');
-  }
-
-  const currentSeason = getCurrentSeason();
-  // 防止換季動作與新創集資期間重疊，並預留足夠時間（10分鐘）以確保換季前最後一批新創處理完成
-  if (Date.now() >= (currentSeason.endDate.getTime() - foundExpireTime - 600000)) {
-    const hours = Math.ceil(foundExpireTime / 3600000);
-    throw new Meteor.Error(403, '商業季度即將結束前' + hours + '小時，禁止新創計劃！');
-  }
-
   const companyName = foundCompanyData.companyName;
-  if (dbCompanyArchive.find({ name: companyName }).count() > 0) {
-    throw new Meteor.Error(403, '已有相同名稱的公司上市或創立中，無法創立同名公司！');
-  }
-  if (foundCompanyData.pictureBig) {
-    checkImageUrl(foundCompanyData.pictureBig);
-  }
-  if (foundCompanyData.pictureSmall) {
-    checkImageUrl(foundCompanyData.pictureSmall);
-  }
+  checkUserError(user);
+  checkUserFoundLimitError(userId);
+  checkTimeFoundLimitError();
+  checkSameNameCompanyError(companyName);
+  checkImageUrlError(foundCompanyData);
+
   // 先鎖定資源，再重新讀取一次資料進行運算
   resourceManager.throwErrorIsResourceIsLock(['user' + userId]);
   resourceManager.request('foundCompany', ['user' + userId], (release) => {
@@ -84,12 +46,11 @@ export function foundCompany(user, foundCompanyData) {
         'profile.money': 1
       }
     });
-    if (user.profile.money < founderEarnestMoney) {
-      throw new Meteor.Error(401, '您的現金不足，不足以支付投資保證金！');
-    }
-    if (dbFoundations.find({ founder: userId }).count() > 0) {
-      throw new Meteor.Error(403, '您現在已經有一家新創公司正在籌備中，無法同時發起第二家新創公司！');
-    }
+
+    checkUserMoneyError(user);
+    checkUserFoundLimitError(userId);
+    checkSameNameCompanyError(companyName);
+
     // 存放進archive中並取得_id
     foundCompanyData._id = dbCompanyArchive.insert({
       status: 'foundation',
@@ -137,3 +98,67 @@ export function foundCompany(user, foundCompanyData) {
 }
 // 二十秒鐘最多一次
 limitMethod('foundCompany', 1, 20000);
+
+
+function checkUserError(user) {
+  if (user.profile.isInVacation) {
+    throw new Meteor.Error(403, '您現在正在渡假中，請好好放鬆！');
+  }
+  if (user.profile.notPayTax) {
+    throw new Meteor.Error(403, '您現在有稅單逾期未繳！');
+  }
+  if (_.contains(user.profile.ban, 'manager')) {
+    throw new Meteor.Error(403, '您現在被金融管理會禁止了擔任經理人的資格！');
+  }
+  if (_.contains(user.profile.ban, 'deal')) {
+    throw new Meteor.Error(403, '您現在被金融管理會禁止了所有投資下單行為！');
+  }
+  checkUserMoneyError(user);
+}
+
+function checkUserMoneyError(user) {
+  const { founderEarnestMoney } = Meteor.settings.public;
+  if (user.profile.money < founderEarnestMoney) {
+    throw new Meteor.Error(401, '您的現金不足，不足以支付投資保證金！');
+  }
+}
+
+function checkUserFoundLimitError(userId) {
+  if (dbFoundations.find({ founder: userId }, { fields: { _id: 1 } }).count() > 0) {
+    throw new Meteor.Error(403, '您現在已經有一家新創公司正在申請中，無法同時發起第二家新創公司！');
+  }
+}
+
+function checkTimeFoundLimitError() {
+  const { seasonTime, newRoundFoundationRestrictionTime, foundExpireTime } = Meteor.settings.public;
+
+  const currentRound = getCurrentRound();
+  if (Date.now() <= (currentRound.beginDate.getTime() + newRoundFoundationRestrictionTime)) {
+    throw new Meteor.Error(403, '目前尚未開放新創計劃！');
+  }
+  if (Date.now() >= (currentRound.endDate.getTime() - seasonTime)) {
+    throw new Meteor.Error(403, '賽季度結束前的最後一個商業季度，禁止新創計劃！');
+  }
+
+  const currentSeason = getCurrentSeason();
+  // 防止換季動作與新創集資期間重疊，並預留足夠時間（10分鐘）以確保換季前最後一批新創處理完成
+  if (Date.now() >= (currentSeason.endDate.getTime() - foundExpireTime - 600000)) {
+    const hours = Math.ceil(foundExpireTime / 3600000);
+    throw new Meteor.Error(403, '商業季度即將結束前' + hours + '小時，禁止新創計劃！');
+  }
+}
+
+function checkSameNameCompanyError(companyName) {
+  if (dbCompanyArchive.find({ name: companyName }, { fields: { _id: 1 } }).count() > 0) {
+    throw new Meteor.Error(403, '已有相同名稱的公司上市或創立中，無法創立同名公司！');
+  }
+}
+
+function checkImageUrlError(foundCompanyData) {
+  if (foundCompanyData.pictureBig) {
+    checkImageUrl(foundCompanyData.pictureBig);
+  }
+  if (foundCompanyData.pictureSmall) {
+    checkImageUrl(foundCompanyData.pictureSmall);
+  }
+}


### PR DESCRIPTION
* 需於賽季更換前更新
* 可能的話建議用測試機測試

---

* 賽季結束時(`doRoundWorks`)，不清空`dbCompanyArchive`以保存公司資料
* 新創失敗時(`doOnFoundationFailure`)，不刪除`dbCompanyArchive`內的資料以保存公司資料
* 新創時(`foundCompany`)，如果有在`dbCompanyArchive`找到`archived`狀態的同名公司，會使用此公司的ID
* 修改公司名稱時(`changeCompanyName`)，如果新名稱有在`dbCompanyArchive`找到`archived`狀態的同名公司，會將其刪除以避免名稱重複，找到其餘狀態的同名公司則會拒絕請求


* `dbCompanyArchive`內的 `name` 改為 `companyName` ，避免與其他DB命名不一致
* 刪除`dbCompanyArchive`內的 `invest` 欄位

---

*測試時如果從`client`檢查結果的話，需注意[companyInfo](https://github.com/mrbigmouth/acgn-stock/blob/master/server/http/companyInfo.js#L36)的快取時間，會讓新創頁面顯示錯誤的連結(可能會連結到companyDetail)

---

commit 99a723e 為一個暫時的方案，因為 `companyInfo` 有一定的快取時間，為避免無法正常顯示網頁才做的，在快取到期後請 Revert 它
或是有什麼選項能直接清空快取?