### PR TITLE
讓公司的log與違規案件不會顯示到上一賽季的

### DIFF
--- a/server/publications/company/companyLog.js
+++ b/server/publications/company/companyLog.js
@@ -2,6 +2,7 @@ import { check, Match } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 
 import { dbLog } from '/db/dbLog';
+import { getCurrentRound } from '/db/dbRound';
 import { limitSubscription } from '/server/imports/utils/rateLimit';
 import { debug } from '/server/imports/utils/debug';
 import { publishTotalCount } from '/server/imports/utils/publishTotalCount';
@@ -12,7 +13,7 @@ Meteor.publish('companyLog', function(companyId, onlyShowMine, offset) {
   check(onlyShowMine, Boolean);
   check(offset, Match.Integer);
 
-  const filter = { companyId };
+  const filter = { companyId, createdAt: { $gt: getCurrentRound().beginDate } };
   const userId = Meteor.userId();
   if (onlyShowMine && userId) {
     filter.userId = {

--- a/server/publications/violation/violationCaseListSimple.js
+++ b/server/publications/violation/violationCaseListSimple.js
@@ -4,6 +4,7 @@ import { Meteor } from 'meteor/meteor';
 import { Counts } from 'meteor/tmeasday:publish-counts';
 
 import { hasRole } from '/db/users';
+import { getCurrentRound } from '/db/dbRound';
 import { dbViolationCases, categoryMap, stateMap } from '/db/dbViolationCases';
 import { limitSubscription } from '/server/imports/utils/rateLimit';
 import { publishWithTransformation } from '/server/imports/utils/publishWithTransformation';
@@ -45,7 +46,11 @@ Meteor.publish('violationCaseListSimple', function({ listType, userId, companyId
       Object.assign(filter, { 'violators.violatorType': 'user', 'violators.violatorId': userId });
       break;
     case 'companyViolated':
-      Object.assign(filter, { 'violators.violatorType': 'company', 'violators.violatorId': companyId });
+      Object.assign(filter, {
+        'violators.violatorType': 'company',
+        'violators.violatorId': companyId,
+        createdAt: { $gt: getCurrentRound().beginDate }
+      });
       break;
     case 'userReported':
       Object.assign(filter, { informer: userId });


### PR DESCRIPTION
讓公司的log與違規案件不會顯示到上一賽季的

---

本來想在log加roundId的，後來發現 `createdAt: { $gt: ... }` 好像沒有拖累很多效能，就直接用 createdAt 來過濾了
加 `createdAt: { $gt: ... }` 後 `executionTimeMillis` 從 16 增加到 17 (7461筆log)
有指定 userId 的話則是從 33 增加到 47 (343筆log)