### PR TITLE
 長時間休市的DB時間修復工具

### DIFF
--- a/dev-utils/imports/mongo-scripts/fixDbTimeTool.js
+++ b/dev-utils/imports/mongo-scripts/fixDbTimeTool.js
@@ -1,0 +1,88 @@
+function fixEventSchedule(eventScheduleId, fixDateFunc) {
+  const oldEventSchedule = db.eventSchedules.findOne({ _id: eventScheduleId });
+  if (! oldEventSchedule) {
+    return;
+  }
+
+  db.eventSchedules.update(
+    { _id: eventScheduleId },
+    { $set: { scheduledAt: fixDateFunc(oldEventSchedule.scheduledAt) } }
+  );
+}
+
+function fixVariable(variableId, fixDateFunc) {
+  const oldVariable = db.variables.findOne({ _id: variableId });
+  db.variables.update(
+    { _id: variableId },
+    { $set: { value: fixDateFunc(new Date(oldVariable.value)).getTime() } }
+  );
+}
+
+function fixUsersLastLogin(fixDateFunc) {
+  db.users.find().forEach((oldUserData) => {
+    if (! oldUserData.status) {
+      // 只登入一次的使用者
+      // TODO 修正 Accounts.createUser 不會自帶 status 的問題後 刪除此判斷
+      return;
+    }
+    db.users.update(
+      { _id: oldUserData._id },
+      { $set: { 'status.lastLogin.date': fixDateFunc(oldUserData.status.lastLogin.date) } }
+    );
+  });
+}
+
+function fixTaxesExpireDate(fixDateFunc) {
+  db.taxes.find().forEach((oldTaxData) => {
+    db.taxes.update(
+      { _id: oldTaxData._id },
+      { $set: { expireDate: fixDateFunc(oldTaxData.expireDate) } }
+    );
+  });
+}
+
+
+const lastLog = db.log.find().sort({ createdAt: -1 }).limit(1)[0];
+const addTime = Date.now() - lastLog.createdAt.getTime();
+const fixDateToNow = (oldDate) => {
+  return new Date(oldDate.getTime() + addTime);
+};
+
+fixEventSchedule('company.releaseStocksForHighPrice', fixDateToNow);
+fixVariable('releaseStocksForHighPriceBegin', fixDateToNow);
+fixVariable('releaseStocksForHighPriceEnd', fixDateToNow);
+
+fixEventSchedule('company.releaseStocksForNoDeal', fixDateToNow);
+fixVariable('releaseStocksForNoDealBegin', fixDateToNow);
+fixVariable('releaseStocksForNoDealEnd', fixDateToNow);
+
+fixEventSchedule('company.recordListPrice', fixDateToNow);
+fixEventSchedule('company.checkChairman', fixDateToNow);
+fixEventSchedule('vip.checkVipLevels', fixDateToNow);
+fixUsersLastLogin(fixDateToNow);
+fixTaxesExpireDate(fixDateToNow);
+
+
+const lastSeason = db.season.find().sort({ endDate: -1 }).limit(1)[0];
+const lostWeekTime = Math.ceil((Date.now() - lastSeason.beginDate.getTime()) / 604800000) * 604800000;
+const fixDateToNextWeek = (oldDate) => {
+  return new Date(oldDate.getTime() + lostWeekTime);
+};
+
+fixEventSchedule('season.electManager', fixDateToNextWeek);
+fixEventSchedule('arena.joinEnded', fixDateToNextWeek);
+fixEventSchedule('product.finalSale', fixDateToNextWeek);
+db.season.update({ _id: lastSeason._id }, { $set: { endDate: fixDateToNextWeek(lastSeason.endDate) } });
+const lastArena = db.arena.find().sort({ endDate: -1 }).limit(1)[0];
+db.arena.update(
+  { _id: lastArena._id },
+  { $set: {
+    endDate: fixDateToNextWeek(lastArena.endDate),
+    joinEndDate: fixDateToNextWeek(lastArena.joinEndDate)
+  } }
+);
+
+
+fixEventSchedule('global.daily', () => {
+  return new Date(new Date(Date.now() + 24 * 60 * 60 * 1000).setUTCHours(0, 0, 0, 0));
+});

--- a/dev-utils/imports/mongo-scripts/fixDbTimeTool.js
+++ b/dev-utils/imports/mongo-scripts/fixDbTimeTool.js
@@ -41,6 +41,15 @@ function fixTaxesExpireDate(fixDateFunc) {
   });
 }
 
+function fixFoundations(fixDateFunc) {
+  db.foundations.find().forEach((oldFoundation) => {
+    db.foundations.update(
+      { _id: oldFoundation._id },
+      { $set: { createdAt: fixDateFunc(oldFoundation.createdAt) } }
+    );
+  });
+}
+
 
 const lastLog = db.log.find().sort({ createdAt: -1 }).limit(1)[0];
 const addTime = Date.now() - lastLog.createdAt.getTime();
@@ -61,6 +70,7 @@ fixEventSchedule('company.checkChairman', fixDateToNow);
 fixEventSchedule('vip.checkVipLevels', fixDateToNow);
 fixUsersLastLogin(fixDateToNow);
 fixTaxesExpireDate(fixDateToNow);
+fixFoundations(fixDateToNow);
 
 
 const lastSeason = db.season.find().sort({ endDate: -1 }).limit(1)[0];


### PR DESCRIPTION
伺服器長時間斷線後，可以用此工具修復DB時間

修正包含
* db.eventSchedules
 a. 經理選舉 (season.electManager)
 b. 萌戰報名封關 (arena.joinEnded)
 c. 產品最後出清時間 (product.finalSale)
 d. 每日事件（發薪） (global.daily)
 e. 高釋 (company.releaseStocksForHighPrice)
 f. 低量 (company.releaseStocksForNoDeal)
 g. 價更時間 (company.recordListPrice)
 h. 換董事長時間 (company.checkChairman)
 i. VIP等級更新時間 (vip.checkVipLevels)

* db.variables 的
  releaseStocksForNoDealBegin
  releaseStocksForNoDealEnd
  releaseStocksForHighPriceBegin
  releaseStocksForHighPriceEnd

* db.arena 最後一項的
  endDate
  joinEndDate

* db.season 的 endDate

* 所有人的登入時間 (db.users 的 status.lastLogin.date 欄位)

* 所有稅單的過期時間 (db.taxes 的 exprireDate 欄位)

* 所有新創公司的開始時間 (db.foundations 的 createdAt 欄位)

---

上次長時間斷線時，也修正了 `arenaCounter` ，但我不太確定這是否必要?
看起來 `arenaCounter` 是跟著換季時跑的，在換季時間已經有調整的情況下，需要動此數值嗎?